### PR TITLE
Update RabbitMQ to v3.2.1

### DIFF
--- a/ripple.config
+++ b/ripple.config
@@ -34,7 +34,7 @@
     <Dependency Name="NServiceBus.Interfaces" Version="4.1.0" Mode="Float" />
     <Dependency Name="NUnit" Version="2.6.2" Mode="Fixed" />
     <Dependency Name="Owin" Version="1.0.0.0" Mode="Fixed" />
-    <Dependency Name="RabbitMQ.Client" Version="3.1.1" Mode="Fixed" />
+    <Dependency Name="RabbitMQ.Client" Version="3.2.1" Mode="Fixed" />
   </Nugets>
   <Groups />
   <References>

--- a/src/NServiceBus.RabbitMQ.Tests/RabbitMqTransportMessageExtensionsTests.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/RabbitMqTransportMessageExtensionsTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Transports.RabbitMQ.Tests
 {
+    using System;
     using System.Collections;
     using System.Collections.Generic;
     using System.Text;
@@ -19,7 +20,7 @@
         [Test]
         public void TestCanHandleByteArrayHeader()
         {
-            var transportMessage = RabbitMqTransportMessageExtensions.ToTransportMessage(new BasicDeliverEventArgs { BasicProperties = new BasicProperties { MessageId = "Blah", Headers = new Hashtable
+            var transportMessage = RabbitMqTransportMessageExtensions.ToTransportMessage(new BasicDeliverEventArgs { BasicProperties = new BasicProperties { MessageId = "Blah", Headers = new Dictionary<string,object>()
                 {
                     {"Foo", Encoding.UTF8.GetBytes("blah")}
                 }} });
@@ -35,7 +36,7 @@
                 BasicProperties = new BasicProperties
                 {
                     MessageId = "Blah",
-                    Headers = new Hashtable
+                    Headers = new Dictionary<string, object>()
                 {
                     {"Foo", "ni"}
                 }
@@ -53,7 +54,7 @@
                 BasicProperties = new BasicProperties
                 {
                     MessageId = "Blah",
-                    Headers = new Hashtable
+                    Headers = new Dictionary<string,object>
                 {
                     {"Foo", new ArrayList{"Bing"}}
                 }
@@ -71,7 +72,7 @@
                 BasicProperties = new BasicProperties
                 {
                     MessageId = "Blah",
-                    Headers = new Hashtable
+                    Headers = new Dictionary<string, object>()
                 {
                     {"Foo", new List<object>{"Bing"}}
                 }
@@ -88,14 +89,14 @@
                 BasicProperties = new BasicProperties
                 {
                     MessageId = "Blah",
-                    Headers = new Hashtable
+                    Headers = new Dictionary<string, object>
                 {
                     {"Foo", new List<object>{new Dictionary<string, object>{{"key1", Encoding.UTF8.GetBytes("value1")}, {"key2", Encoding.UTF8.GetBytes("value2")}}}}
                 }
                 }
             });
             Assert.NotNull(transportMessage);
-            Assert.AreEqual("key1=value1,key2=value2", transportMessage.Headers["Foo"]);
+            Assert.AreEqual("key1=value1,key2=value2", Convert.ToString(transportMessage.Headers["Foo"]));
         }
     }
 }

--- a/src/NServiceBus.RabbitMQ.Tests/When_sending_a_message_over_rabbitmq.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/When_sending_a_message_over_rabbitmq.cs
@@ -186,12 +186,12 @@
 
                 channel.BasicConsume("testEndPoint", false, consumer);
 
-                object message;
+                BasicDeliverEventArgs message;
 
                 if (!consumer.Queue.Dequeue(1000, out message))
                     throw new InvalidOperationException("No message found in queue");
 
-                var e = (BasicDeliverEventArgs)message;
+                var e = message;
 
                 if (e.BasicProperties.MessageId != id)
                     throw new InvalidOperationException("Unexpected message found in queue");

--- a/src/NServiceBus.RabbitMQ/Config/ConnectionConfiguration.cs
+++ b/src/NServiceBus.RabbitMQ/Config/ConnectionConfiguration.cs
@@ -15,7 +15,7 @@
         public const ushort DefaultPrefetchCount = 1;
         public const ushort DefaultPort = 5672;
         public static TimeSpan DefaultWaitTimeForConfirms = TimeSpan.FromSeconds(30);
-        IDictionary<string, string> clientProperties = new Dictionary<string, string>();
+        IDictionary<string, object> clientProperties = new Dictionary<string, object>();
         IEnumerable<IHostConfiguration> hosts= new List<IHostConfiguration>();
 
         public ushort Port { get; set; }
@@ -28,7 +28,7 @@
         public bool UsePublisherConfirms { get; set; }
         public TimeSpan MaxWaitTimeForConfirms { get; set; }
         public TimeSpan RetryDelay { get; set; }
-        public IDictionary<string, string> ClientProperties {
+        public IDictionary<string, object> ClientProperties {
             get { return clientProperties; }
             private set { clientProperties = value; }
         }

--- a/src/NServiceBus.RabbitMQ/Config/IConnectionConfiguration.cs
+++ b/src/NServiceBus.RabbitMQ/Config/IConnectionConfiguration.cs
@@ -12,7 +12,7 @@
         string Password { get; }
         ushort RequestedHeartbeat { get; }
         ushort PrefetchCount { get; }
-        IDictionary<string, string> ClientProperties { get; } 
+        IDictionary<string, object> ClientProperties { get; } 
         IEnumerable<IHostConfiguration> Hosts { get; }
         TimeSpan RetryDelay { get; set; }
         bool UsePublisherConfirms { get; set; }

--- a/src/NServiceBus.RabbitMQ/EasyNetQ/ConnectionFactoryWrapper.cs
+++ b/src/NServiceBus.RabbitMQ/EasyNetQ/ConnectionFactoryWrapper.cs
@@ -41,9 +41,9 @@
             }
         }
 
-        private static IDictionary ConvertToHashtable(IDictionary<string, string> clientProperties)
+        private static IDictionary<string, object> ConvertToHashtable(IDictionary<string, object> clientProperties)
         {
-            var dictionary = new Hashtable();
+            var dictionary = new Dictionary<string, object>();
             foreach (var clientProperty in clientProperties)
             {
                 dictionary.Add(clientProperty.Key, clientProperty.Value);

--- a/src/NServiceBus.RabbitMQ/PersistentConnection.cs
+++ b/src/NServiceBus.RabbitMQ/PersistentConnection.cs
@@ -1,7 +1,7 @@
 namespace NServiceBus.Transports.RabbitMQ
 {
     using System;
-    using System.Collections;
+    using System.Collections.Generic;
     using System.Threading;
     using EasyNetQ;
     using global::RabbitMQ.Client;
@@ -194,12 +194,12 @@ namespace NServiceBus.Transports.RabbitMQ
             get { return connection.Heartbeat; }
         }
 
-        public IDictionary ClientProperties
+        public IDictionary<string, object> ClientProperties
         {
             get { return connection.ClientProperties; }
         }
 
-        public IDictionary ServerProperties
+        public IDictionary<string, object> ServerProperties
         {
             get { return connection.ServerProperties; }
         }
@@ -225,7 +225,7 @@ namespace NServiceBus.Transports.RabbitMQ
             set { connection.AutoClose = value; }
         }
 
-        public IList ShutdownReport
+        public IList<ShutdownReportEntry> ShutdownReport
         {
             get { return connection.ShutdownReport; }
         }
@@ -242,6 +242,19 @@ namespace NServiceBus.Transports.RabbitMQ
             remove { connection.CallbackException -= value; }
         }
 
+        public event ConnectionBlockedEventHandler ConnectionBlocked
+        {
+            add { connection.ConnectionBlocked += value; }
+            remove { connection.ConnectionBlocked -= value; }
+        }
+
+        public event ConnectionUnblockedEventHandler ConnectionUnblocked
+        {
+            add { connection.ConnectionUnblocked += value; }
+            remove { connection.ConnectionUnblocked -= value; }
+        }
+
+
         public void Close(ushort reasonCode, string reasonText, int timeout)
         {
             connection.Close(reasonCode, reasonText, timeout);
@@ -250,6 +263,16 @@ namespace NServiceBus.Transports.RabbitMQ
         public void Close(ushort reasonCode, string reasonText)
         {
             connection.Close(reasonCode, reasonText);
+        }
+
+        public void HandleConnectionBlocked(string reason)
+        {
+            connection.HandleConnectionBlocked(reason);
+        }
+        
+        public void HandleConnectionUnblocked()
+        {
+            connection.HandleConnectionUnblocked();
         }
 
         public void Dispose()

--- a/src/NServiceBus.RabbitMQ/RabbitMqDequeueStrategy.cs
+++ b/src/NServiceBus.RabbitMQ/RabbitMqDequeueStrategy.cs
@@ -164,14 +164,14 @@
         static BasicDeliverEventArgs DequeueMessage(QueueingBasicConsumer consumer)
         {
 
-            object rawMessage;
+            BasicDeliverEventArgs rawMessage;
 
             if (!consumer.Queue.Dequeue(1000, out rawMessage))
             {
                 return null;
             }
 
-            return (BasicDeliverEventArgs)rawMessage;
+            return rawMessage;
         }
 
         void Purge()

--- a/src/NServiceBus.RabbitMQ/RabbitMqTransportMessageExtensions.cs
+++ b/src/NServiceBus.RabbitMQ/RabbitMqTransportMessageExtensions.cs
@@ -26,7 +26,7 @@
 
             properties.SetPersistent(message.Recoverable);
 
-            properties.Headers = message.Headers;
+            properties.Headers = message.Headers.ToDictionary(p => p.Key, p => (object)p.Value);
 
             if (message.Headers.ContainsKey(Headers.EnclosedMessageTypes))
             {
@@ -96,9 +96,9 @@
                 return new Dictionary<string, string>();
             }
 
-            return message.BasicProperties.Headers.Cast<DictionaryEntry>()
+            return message.BasicProperties.Headers.Cast<KeyValuePair<string, object>>()
                 .ToDictionary(
-                    dictionaryEntry => (string) dictionaryEntry.Key,
+                    dictionaryEntry => dictionaryEntry.Key,
                     dictionaryEntry =>
                     {
                         var value = dictionaryEntry.Value;


### PR DESCRIPTION
There are breaking changes in the `IConnection` interface and `IBasicProperties` implementations in RabbitMQ.Client v3.2.1. This pull request applies those changes.
