### PR TITLE
Fix for issue 26 (concurrency in RabbitMqUnitOfWork)

### DIFF
--- a/src/NServiceBus.RabbitMQ.Tests/NServiceBus.RabbitMQ.Tests.csproj
+++ b/src/NServiceBus.RabbitMQ.Tests/NServiceBus.RabbitMQ.Tests.csproj
@@ -75,6 +75,7 @@
     <Compile Include="RabbitMqContext.cs" />
     <Compile Include="TestCategory.cs" />
     <Compile Include="When_consuming_messages.cs" />
+    <Compile Include="When_running_concurrent_units_of_work_and_distributed_tx.cs" />
     <Compile Include="When_sending_a_message_over_rabbitmq.cs" />
     <Compile Include="TransportMessageBuilder.cs" />
     <Compile Include="When_subscribed_to_a_event.cs" />

--- a/src/NServiceBus.RabbitMQ.Tests/When_running_concurrent_units_of_work_and_distributed_tx.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/When_running_concurrent_units_of_work_and_distributed_tx.cs
@@ -1,0 +1,84 @@
+﻿
+namespace NServiceBus.Transports.RabbitMQ.Tests
+{
+    using System;
+    using System.Diagnostics;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using System.Transactions;
+    using NUnit.Framework;
+
+    public class When_running_concurrent_units_of_work_and_distributed_tx : RabbitMqContext
+    {
+        /// <summary>
+        /// Reproduces https://github.com/Particular/NServiceBus.RabbitMQ/issues/26.
+        /// When there are several units of work running simultaneaously, hanling concurrent units of
+        /// work must not leak.
+        /// </summary>
+        [Test]
+        public void Should_launch_all_TransactionCompleted_events()
+        {
+            var rounds = 20; //majic number, this should be  enough to reproduce every time
+            var count = 0;
+            
+            Parallel.For(0, rounds, i =>
+            {
+                using (var scope = GetTransaction())
+                {
+                    MakeTransactionDistributed();
+                    unitOfWork.Add(model =>
+                    {
+                        Interlocked.Increment(ref count);
+                    });
+                    scope.Complete();
+                }
+            });
+
+            Assert.AreEqual(rounds, count);
+        }
+
+        /// <summary>
+        /// Turn on DTC by enlisting an extra durable transaction.
+        /// </summary>
+        static void MakeTransactionDistributed()
+        {
+            Transaction.Current.EnlistDurable(Guid.NewGuid(), new MockEnlistment(), EnlistmentOptions.None);
+        }
+
+        TransactionScope GetTransaction()
+        {
+            return new TransactionScope(TransactionScopeOption.RequiresNew, new TransactionOptions
+            {
+                IsolationLevel = IsolationLevel.ReadCommitted,
+                Timeout = TimeSpan.FromSeconds(15)
+            });
+        }
+
+        /// <summary>
+        /// Empty implementation of <see cref="IEnlistmentNotification"/>, can participate in transactions but
+        /// does nothing.
+        /// </summary>
+        class MockEnlistment : IEnlistmentNotification
+        {
+            public void Prepare(PreparingEnlistment preparingEnlistment)
+            {
+                preparingEnlistment.Prepared();
+            }
+
+            public void Commit(Enlistment enlistment)
+            {
+                enlistment.Done();
+            }
+
+            public void Rollback(Enlistment enlistment)
+            {
+                enlistment.Done();
+            }
+
+            public void InDoubt(Enlistment enlistment)
+            {
+                enlistment.Done();
+            }
+        }    
+    }
+}

--- a/src/NServiceBus.RabbitMQ/RabbitMqUnitOfWork.cs
+++ b/src/NServiceBus.RabbitMQ/RabbitMqUnitOfWork.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Transports.RabbitMQ
 {
     using System;
+    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Linq;
     using System.Text.RegularExpressions;
@@ -35,40 +36,32 @@
             }
 
             var transactionId = transaction.TransactionInformation.LocalIdentifier;
-
-            if (!OutstandingOperations.ContainsKey(transactionId))
+            OutstandingOperations.AddOrUpdate(transactionId, s =>
             {
                 transaction.TransactionCompleted += ExecuteActionsAgainstRabbitMq;
-                OutstandingOperations.Add(transactionId, new List<Action<IModel>> { action });
-                return;
-            }
-
-            OutstandingOperations[transactionId].Add(action);
+                return new List<Action<IModel>> { action };
+            }, (s, list) =>
+            {
+                list.Add(action);
+                return list;
+            });
         }
 
         void ExecuteActionsAgainstRabbitMq(object sender, TransactionEventArgs transactionEventArgs)
         {
             var transactionInfo = transactionEventArgs.Transaction.TransactionInformation;
-
-            if (transactionInfo.Status != TransactionStatus.Committed)
-            {
-                OutstandingOperations.Clear();
-                return;
-            }
-
             var transactionId = transactionInfo.LocalIdentifier;
 
-            if (!OutstandingOperations.ContainsKey(transactionId))
+            if (transactionInfo.Status != TransactionStatus.Committed)
                 return;
 
-            var actions = OutstandingOperations[transactionId];
+            IList<Action<IModel>> actions;
+            OutstandingOperations.TryRemove(transactionId, out actions);
 
             if (!actions.Any())
                 return;
 
             ExecuteRabbitMqActions(actions);
-
-            OutstandingOperations.Clear();
         }
 
         void ExecuteRabbitMqActions(IList<Action<IModel>> actions)
@@ -79,7 +72,6 @@
                 {
                     channel.ConfirmSelect();
                 }
-
 
                 foreach (var action in actions)
                 {
@@ -103,18 +95,6 @@
             }
         }
 
-
-        IDictionary<string, IList<Action<IModel>>> OutstandingOperations
-        {
-            get
-            {
-                return outstandingOperations ?? (outstandingOperations = new Dictionary<string, IList<Action<IModel>>>());
-            }
-        }
-
-
-        //we use a dictionary to make sure that actions from other tx doesn't spill over if threads are getting reused by the hosting infrastructure
-        [ThreadStatic]
-        static IDictionary<string, IList<Action<IModel>>> outstandingOperations;
+        private static ConcurrentDictionary<string, IList<Action<IModel>>> OutstandingOperations = new ConcurrentDictionary<string, IList<Action<IModel>>>();
     }
 }


### PR DESCRIPTION
RabbitMqUnitOfWork is fixed to support scenario where there are multiple concurrent, distributed transactions. Unit test 

```
When_running_concurrent_units_of_work_and_distributed_tx.Should_launch_all_TransactionCompleted_events() 
```

reproduces the issue.
