### PR TITLE
Only open the admin connection when we need to use it

### DIFF
--- a/src/NServiceBus.RabbitMQ/RabbitMqConnectionManager.cs
+++ b/src/NServiceBus.RabbitMQ/RabbitMqConnectionManager.cs
@@ -36,7 +36,7 @@
             //note: The purpose is there so that we/users can add more advanced connection managers in the future
             lock (connectionFactory)
             {
-                return connectionAdministration ?? (connectionAdministration = new PersistentConnection(connectionFactory, connectionConfiguration.RetryDelay,"Administration"));
+                return new PersistentConnection(connectionFactory, connectionConfiguration.RetryDelay,"Administration");
             }
         }
 
@@ -52,10 +52,6 @@
             {
                 connectionConsume.Dispose();
             }
-            if (connectionAdministration != null)
-            {
-                connectionAdministration.Dispose();
-            }
             if (connectionPublish != null)
             {
                 connectionPublish.Dispose();
@@ -65,7 +61,6 @@
         IConnectionFactory connectionFactory;
         IConnectionConfiguration connectionConfiguration;
         PersistentConnection connectionConsume;
-        PersistentConnection connectionAdministration;
         PersistentConnection connectionPublish;
     }
 }

--- a/src/NServiceBus.RabbitMQ/RabbitMqDequeueStrategy.cs
+++ b/src/NServiceBus.RabbitMQ/RabbitMqDequeueStrategy.cs
@@ -235,7 +235,8 @@
 
         void Purge()
         {
-            using (var channel = connectionManager.GetAdministrationConnection().CreateModel())
+            using (var connection = connectionManager.GetAdministrationConnection())
+            using (var channel = connection.CreateModel())
             {
                 channel.QueuePurge(workQueue);
             }

--- a/src/NServiceBus.RabbitMQ/RabbitMqQueueCreator.cs
+++ b/src/NServiceBus.RabbitMQ/RabbitMqQueueCreator.cs
@@ -12,7 +12,8 @@
 
         public void CreateQueueIfNecessary(Address address, string account)
         {
-            using (var channel = ConnectionManager.GetAdministrationConnection().CreateModel())
+            using (var connection = ConnectionManager.GetAdministrationConnection())
+            using (var channel = connection.CreateModel())
             {
                 channel.QueueDeclare(address.Queue, Configure.DurableMessagesEnabled(), false, false, null);
 

--- a/src/NServiceBus.RabbitMQ/RabbitMqSubscriptionManager.cs
+++ b/src/NServiceBus.RabbitMQ/RabbitMqSubscriptionManager.cs
@@ -13,7 +13,8 @@
 
         public void Subscribe(Type eventType, Address publisherAddress)
         {
-            using (var channel = ConnectionManager.GetAdministrationConnection().CreateModel())
+            using (var connection = ConnectionManager.GetAdministrationConnection())
+            using (var channel = connection.CreateModel())
             {
                 RoutingTopology.SetupSubscription(channel, eventType, EndpointQueueName);
             }
@@ -21,7 +22,8 @@
 
         public void Unsubscribe(Type eventType, Address publisherAddress)
         {
-            using (var channel = ConnectionManager.GetAdministrationConnection().CreateModel())
+            using (var connection = ConnectionManager.GetAdministrationConnection())
+            using (var channel = connection.CreateModel())
             {
                 RoutingTopology.TeardownSubscription(channel, eventType, EndpointQueueName);
             }


### PR DESCRIPTION
@johnsimons I noticed that all endpoints keep the admin connection (to perform sub/unsubscribe) open. This seems wasteful since all subscribes usually happens on start up.

What do you think?