### PR TITLE
Implement a ChannelProvider that pools ConfirmsAwareChannels

### DIFF
--- a/src/NServiceBus.RabbitMQ.Tests/ConnectionString/ConnectionConfigurationTests.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/ConnectionString/ConnectionConfigurationTests.cs
@@ -62,12 +62,6 @@
         }
 
         [Test]
-        public void Should_set_default_max_wait_time_for_confirms()
-        {
-            Assert.AreEqual(defaults.MaxWaitTimeForConfirms, TimeSpan.FromSeconds(30));
-        }
-
-        [Test]
         public void Should_set_default_retry_delay()
         {
             Assert.AreEqual(defaults.RetryDelay, TimeSpan.FromSeconds(10));

--- a/src/NServiceBus.RabbitMQ.Tests/ConnectionString/ConnectionStringParserTests.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/ConnectionString/ConnectionStringParserTests.cs
@@ -10,7 +10,7 @@
     {
         const string connectionString =
             "virtualHost=Copa;username=Copa;host=192.168.1.1:1234;password=abc_xyz;port=12345;requestedHeartbeat=3;" +
-            "usePublisherConfirms=true;maxWaitTimeForConfirms=02:03:39;retryDelay=01:02:03;useTls=true;certPath=/path/to/client/keycert.p12;certPassPhrase=abc123";
+            "usePublisherConfirms=true;retryDelay=01:02:03;useTls=true;certPath=/path/to/client/keycert.p12;certPassPhrase=abc123";
 
         SettingsHolder settings;
 
@@ -34,7 +34,6 @@
             Assert.AreEqual(connectionConfiguration.Password, "abc_xyz");
             Assert.AreEqual(connectionConfiguration.RequestedHeartbeat, 3);
             Assert.AreEqual(connectionConfiguration.UsePublisherConfirms, true);
-            Assert.AreEqual(connectionConfiguration.MaxWaitTimeForConfirms, new TimeSpan(2, 3, 39)); //02:03:39
             Assert.AreEqual(connectionConfiguration.RetryDelay, new TimeSpan(1, 2, 3)); //01:02:03
             Assert.AreEqual(connectionConfiguration.UseTls, true);
             Assert.AreEqual(connectionConfiguration.CertPath, "/path/to/client/keycert.p12");
@@ -171,16 +170,6 @@
         }
 
         [Test]
-        public void Should_throw_if_given_badly_formatted_max_wait_time_for_confirms()
-        {
-            var parser = new ConnectionStringParser(settings);
-            var formatException = Assert.Throws<FormatException>(
-                () => parser.Parse("host=localhost;maxWaitTimeForConfirms=00:0d0:10"));
-
-            Assert.AreEqual("00:0d0:10 is not a valid value for TimeSpan.", formatException.Message);
-        }
-
-        [Test]
         public void Should_throw_if_given_badly_formatted_retry_delay()
         {
             var parser = new ConnectionStringParser(settings);
@@ -235,6 +224,25 @@
 
             Assert.IsNotNull(exception);
             Assert.That(exception.Message, Is.StringContaining("The 'DequeueTimeout' connection string option has been removed"));
+        }
+
+        [Test]
+        public void Should_inform_that_max_wait_time_for_confirmss_has_been_removed()
+        {
+            var parser = new ConnectionStringParser(settings);
+            Exception exception = null;
+
+            try
+            {
+                parser.Parse("host=localhost;maxWaitTimeForConfirms=02:03:39");
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+
+            Assert.IsNotNull(exception);
+            Assert.That(exception.Message, Is.StringContaining("The 'MaxWaitTimeForConfirms' connection string option has been removed"));
         }
 
         [Test]

--- a/src/NServiceBus.RabbitMQ.Tests/RabbitMqContext.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/RabbitMqContext.cs
@@ -70,7 +70,7 @@
 
             connectionFactory = new RabbitMqConnectionFactory(config);
             connectionManager = new ConnectionManager(connectionFactory);
-            var channelProvider = new ChannelProvider(connectionManager, config.UsePublisherConfirms, config.MaxWaitTimeForConfirms);
+            var channelProvider = new ChannelProvider(connectionManager, config.UsePublisherConfirms);
 
             messageDispatcher = new MessageDispatcher(routingTopology, channelProvider);
 

--- a/src/NServiceBus.RabbitMQ/Configuration/ConnectionConfiguration.cs
+++ b/src/NServiceBus.RabbitMQ/Configuration/ConnectionConfiguration.cs
@@ -23,8 +23,6 @@
 
         public bool UsePublisherConfirms { get; set; }
 
-        public TimeSpan MaxWaitTimeForConfirms { get; set; }
-
         public TimeSpan RetryDelay { get; set; }
 
         public bool UseTls { get; set; }
@@ -44,7 +42,6 @@
             Password = "guest";
             RequestedHeartbeat = 5;
             UsePublisherConfirms = true;
-            MaxWaitTimeForConfirms = TimeSpan.FromSeconds(30);
             RetryDelay = TimeSpan.FromSeconds(10);
             UseTls = false;
             CertPath = "";

--- a/src/NServiceBus.RabbitMQ/Configuration/ConnectionStringParser.cs
+++ b/src/NServiceBus.RabbitMQ/Configuration/ConnectionStringParser.cs
@@ -55,6 +55,15 @@
                 throw new NotSupportedException(message);
             }
 
+            if (ContainsKey("maxwaittimeforconfirms"))
+            {
+                var message = "The 'MaxWaitTimeForConfirms' connection string option has been removed. Consult the documentation for further information";
+
+                Logger.Error(message);
+
+                throw new NotSupportedException(message);
+            }
+
             if (ContainsKey("prefetchcount"))
             {
                 var message = "The 'PrefetchCount' connection string option has been removed. Please use 'EndpointConfiguration.LimitMessageProcessingConcurrencyTo' instead.";

--- a/src/NServiceBus.RabbitMQ/Connection/ChannelProvider.cs
+++ b/src/NServiceBus.RabbitMQ/Connection/ChannelProvider.cs
@@ -4,11 +4,10 @@ namespace NServiceBus.Transport.RabbitMQ
 
     class ChannelProvider : IChannelProvider
     {
-        public ChannelProvider(ConnectionManager connectionManager, bool usePublisherConfirms, TimeSpan maxWaitTimeForConfirms)
+        public ChannelProvider(ConnectionManager connectionManager, bool usePublisherConfirms)
         {
             this.connectionManager = connectionManager;
             this.usePublisherConfirms = usePublisherConfirms;
-            this.maxWaitTimeForConfirms = maxWaitTimeForConfirms;
 
             channels = new ConcurrentQueue<ConfirmsAwareChannel>();
         }
@@ -21,7 +20,7 @@ namespace NServiceBus.Transport.RabbitMQ
             {
                 channel?.Dispose();
 
-                channel = new ConfirmsAwareChannel(connectionManager.GetPublishConnection(), usePublisherConfirms, maxWaitTimeForConfirms);
+                channel = new ConfirmsAwareChannel(connectionManager.GetPublishConnection(), usePublisherConfirms);
             }
 
             return channel;
@@ -41,7 +40,6 @@ namespace NServiceBus.Transport.RabbitMQ
 
         readonly ConnectionManager connectionManager;
         readonly bool usePublisherConfirms;
-        readonly TimeSpan maxWaitTimeForConfirms;
         readonly ConcurrentQueue<ConfirmsAwareChannel> channels;
     }
 }

--- a/src/NServiceBus.RabbitMQ/Connection/ConfirmsAwareChannel.cs
+++ b/src/NServiceBus.RabbitMQ/Connection/ConfirmsAwareChannel.cs
@@ -10,12 +10,11 @@ namespace NServiceBus.Transport.RabbitMQ
 
     class ConfirmsAwareChannel : IDisposable
     {
-        public ConfirmsAwareChannel(IConnection connection, bool usePublisherConfirms, TimeSpan maxWaitTimeForConfirms)
+        public ConfirmsAwareChannel(IConnection connection, bool usePublisherConfirms)
         {
             channel = connection.CreateModel();
 
             this.usePublisherConfirms = usePublisherConfirms;
-            this.maxWaitTimeForConfirms = maxWaitTimeForConfirms;
 
             if (usePublisherConfirms)
             {
@@ -103,20 +102,8 @@ namespace NServiceBus.Transport.RabbitMQ
                 throw new Exception($"Failed to add {channel.NextPublishSeqNo}");
             }
 
-            //Task.Run(() => CheckForConfirmationTimeout(channel.NextPublishSeqNo));
-
             return tcs.Task;
         }
-
-        //async Task CheckForConfirmationTimeout(ulong deliveryTag)
-        //{
-        //    await Task.Delay(maxWaitTimeForConfirms).ConfigureAwait(false);
-
-        //    TaskCompletionSource<bool> tcs;
-        //    messages.TryRemove(deliveryTag, out tcs);
-
-        //    tcs?.SetException(new Exception("Operation has timed out while waiting for confirmation from broker."));
-        //}
 
         void Channel_BasicAcks(object sender, BasicAckEventArgs e)
         {
@@ -218,7 +205,6 @@ namespace NServiceBus.Transport.RabbitMQ
 
         IModel channel;
         readonly bool usePublisherConfirms;
-        readonly TimeSpan maxWaitTimeForConfirms;
         readonly ConcurrentDictionary<ulong, TaskCompletionSource<bool>> messages;
 
         static readonly ILog Logger = LogManager.GetLogger(typeof(ConfirmsAwareChannel));

--- a/src/NServiceBus.RabbitMQ/Connection/ConfirmsAwareChannel.cs
+++ b/src/NServiceBus.RabbitMQ/Connection/ConfirmsAwareChannel.cs
@@ -1,62 +1,226 @@
 namespace NServiceBus.Transport.RabbitMQ
 {
     using System;
-    using System.Text.RegularExpressions;
+    using System.Collections.Concurrent;
+    using System.Threading.Tasks;
     using global::RabbitMQ.Client;
-    using global::RabbitMQ.Client.Exceptions;
-    using Janitor;
-    using Unicast.Queuing;
+    using global::RabbitMQ.Client.Events;
+    using Logging;
+    using Transports;
 
-    [SkipWeaving]
     class ConfirmsAwareChannel : IDisposable
     {
-        public IModel Channel { get; }
-
         public ConfirmsAwareChannel(IConnection connection, bool usePublisherConfirms, TimeSpan maxWaitTimeForConfirms)
         {
+            channel = connection.CreateModel();
+
             this.usePublisherConfirms = usePublisherConfirms;
             this.maxWaitTimeForConfirms = maxWaitTimeForConfirms;
-            Channel = connection.CreateModel();
 
             if (usePublisherConfirms)
             {
-                Channel.ConfirmSelect();
+                channel.ConfirmSelect();
+
+                channel.BasicAcks += Channel_BasicAcks;
+                channel.BasicNacks += Channel_BasicNacks;
+                channel.BasicReturn += Channel_BasicReturn;
+                channel.ModelShutdown += Channel_ModelShutdown;
+
+                messages = new ConcurrentDictionary<ulong, TaskCompletionSource<bool>>();
             }
+        }
+
+        public IBasicProperties CreateBasicProperties() => channel.CreateBasicProperties();
+
+        public bool IsOpen => channel.IsOpen;
+
+        public bool IsClosed => channel.IsClosed;
+
+        public Task SendMessage(Action<IModel, string, OutgoingMessage, IBasicProperties> send, string address, OutgoingMessage message, IBasicProperties properties)
+        {
+            Task task;
+
+            if (usePublisherConfirms)
+            {
+                task = GetConfirmationTask();
+                properties.SetConfirmationId(channel.NextPublishSeqNo);
+            }
+            else
+            {
+                task = TaskEx.CompletedTask;
+            }
+
+            send(channel, address, message, properties);
+
+            return task;
+        }
+
+        public Task PublishMessage(Action<IModel, Type, OutgoingMessage, IBasicProperties> publish, Type type, OutgoingMessage message, IBasicProperties properties)
+        {
+            Task task;
+
+            if (usePublisherConfirms)
+            {
+                task = GetConfirmationTask();
+                properties.SetConfirmationId(channel.NextPublishSeqNo);
+            }
+            else
+            {
+                task = TaskEx.CompletedTask;
+            }
+
+            publish(channel, type, message, properties);
+
+            return task;
+        }
+
+        public Task RawSendInCaseOfFailure(Action<IModel, string, byte[], IBasicProperties> rawSend, string address, byte[] body, IBasicProperties properties)
+        {
+            Task task;
+
+            if (usePublisherConfirms)
+            {
+                task = GetConfirmationTask();
+                properties.SetConfirmationId(channel.NextPublishSeqNo);
+            }
+            else
+            {
+                task = TaskEx.CompletedTask;
+            }
+
+            rawSend(channel, address, body, properties);
+
+            return task;
+        }
+
+        Task GetConfirmationTask()
+        {
+            var tcs = new TaskCompletionSource<bool>();
+            var added = messages.TryAdd(channel.NextPublishSeqNo, tcs);
+
+            if (!added) //debug check, this shouldn't happen
+            {
+                throw new Exception($"Failed to add {channel.NextPublishSeqNo}");
+            }
+
+            //Task.Run(() => CheckForConfirmationTimeout(channel.NextPublishSeqNo));
+
+            return tcs.Task;
+        }
+
+        //async Task CheckForConfirmationTimeout(ulong deliveryTag)
+        //{
+        //    await Task.Delay(maxWaitTimeForConfirms).ConfigureAwait(false);
+
+        //    TaskCompletionSource<bool> tcs;
+        //    messages.TryRemove(deliveryTag, out tcs);
+
+        //    tcs?.SetException(new Exception("Operation has timed out while waiting for confirmation from broker."));
+        //}
+
+        void Channel_BasicAcks(object sender, BasicAckEventArgs e)
+        {
+            Task.Run(() =>
+            {
+                if (!e.Multiple)
+                {
+                    TaskCompletionSource<bool> tcs;
+                    messages.TryRemove(e.DeliveryTag, out tcs);
+
+                    tcs?.SetResult(true);
+                }
+                else
+                {
+                    foreach (var message in messages)
+                    {
+                        if (message.Key <= e.DeliveryTag)
+                        {
+                            TaskCompletionSource<bool> tcs;
+                            messages.TryRemove(message.Key, out tcs);
+
+                            tcs?.SetResult(true);
+                        }
+                    }
+                }
+            });
+        }
+
+        void Channel_BasicNacks(object sender, BasicNackEventArgs e)
+        {
+            Task.Run(() =>
+            {
+                if (!e.Multiple)
+                {
+                    TaskCompletionSource<bool> tcs;
+                    messages.TryRemove(e.DeliveryTag, out tcs);
+
+                    tcs?.SetException(new Exception("Message rejected by broker."));
+                }
+                else
+                {
+                    foreach (var message in messages)
+                    {
+                        if (message.Key <= e.DeliveryTag)
+                        {
+                            TaskCompletionSource<bool> tcs;
+                            messages.TryRemove(message.Key, out tcs);
+
+                            tcs?.SetException(new Exception("Message rejected by broker."));
+                        }
+                    }
+                }
+            });
+        }
+
+        void Channel_BasicReturn(object sender, BasicReturnEventArgs e)
+        {
+            Task.Run(() =>
+            {
+                var message = $"Message could not be routed to {e.Exchange + e.RoutingKey}: {e.ReplyCode} {e.ReplyText}";
+
+                ulong deliveryTag;
+
+                if (e.BasicProperties.TryGetConfirmationId(out deliveryTag))
+                {
+                    TaskCompletionSource<bool> tcs;
+                    messages.TryRemove(deliveryTag, out tcs);
+
+                    tcs?.SetException(new Exception(message));
+                }
+                else
+                {
+                    Logger.Warn(message);
+                }
+            });
+        }
+
+        void Channel_ModelShutdown(object sender, ShutdownEventArgs e)
+        {
+            Task.Run(() =>
+            {
+                do
+                {
+                    foreach (var message in messages)
+                    {
+                        TaskCompletionSource<bool> tcs;
+                        messages.TryRemove(message.Key, out tcs);
+
+                        tcs?.SetException(new Exception($"Channel has been closed: {e}"));
+                    }
+                } while (!messages.IsEmpty);
+            });
         }
 
         public void Dispose()
         {
-            try
-            {
-                if (usePublisherConfirms)
-                {
-                    try
-                    {
-                        Channel.WaitForConfirmsOrDie(maxWaitTimeForConfirms);
-                    }
-                    catch (AlreadyClosedException ex)
-                    {
-                        if (ex.ShutdownReason != null && ex.ShutdownReason.ReplyCode == 404)
-                        {
-                            var msg = ex.ShutdownReason.ReplyText;
-                            var matches = Regex.Matches(msg, @"'([^' ]*)'");
-                            var exchangeName = matches.Count > 0 && matches[0].Groups.Count > 1 ? matches[0].Groups[1].Value : null;
-                            throw new QueueNotFoundException(exchangeName, "Exchange for the recipient does not exist", ex);
-                        }
-
-                        throw;
-                    }
-                }
-            }
-            finally
-            {
-                // After decompiling it looks like Abort is a safest method to call instead of Close/Dispose
-                // Close/Dispose throws exceptions if the channel is already closed!
-                Channel.Abort();
-            }
+            //injected
         }
 
+        IModel channel;
         readonly bool usePublisherConfirms;
         readonly TimeSpan maxWaitTimeForConfirms;
+        readonly ConcurrentDictionary<ulong, TaskCompletionSource<bool>> messages;
+
+        static readonly ILog Logger = LogManager.GetLogger(typeof(ConfirmsAwareChannel));
     }
 }

--- a/src/NServiceBus.RabbitMQ/Connection/IChannelProvider.cs
+++ b/src/NServiceBus.RabbitMQ/Connection/IChannelProvider.cs
@@ -2,6 +2,8 @@
 {
     interface IChannelProvider
     {
-        ConfirmsAwareChannel GetNewPublishChannel();
+        ConfirmsAwareChannel GetPublishChannel();
+
+        void ReturnPublishChannel(ConfirmsAwareChannel channel);
     }
 }

--- a/src/NServiceBus.RabbitMQ/RabbitMQTransportInfrastructure.cs
+++ b/src/NServiceBus.RabbitMQ/RabbitMQTransportInfrastructure.cs
@@ -17,6 +17,7 @@
         readonly SettingsHolder settings;
         readonly ConnectionConfiguration connectionConfiguration;
         readonly ConnectionManager connectionManager;
+        readonly ChannelProvider channelProvider;
         IRoutingTopology topology;
 
         public RabbitMQTransportInfrastructure(SettingsHolder settings, string connectionString)
@@ -25,6 +26,7 @@
 
             connectionConfiguration = new ConnectionStringParser(settings).Parse(connectionString);
             connectionManager = new ConnectionManager(new RabbitMqConnectionFactory(connectionConfiguration));
+            channelProvider = new ChannelProvider(connectionManager, connectionConfiguration.UsePublisherConfirms);
 
             CreateTopology();
 
@@ -49,10 +51,8 @@
 
         public override TransportSendInfrastructure ConfigureSendInfrastructure()
         {
-            var provider = new ChannelProvider(connectionManager, connectionConfiguration.UsePublisherConfirms);
-
             return new TransportSendInfrastructure(
-                () => new MessageDispatcher(topology, provider),
+                () => new MessageDispatcher(topology, channelProvider),
                 () => Task.FromResult(StartupCheckResult.Success));
         }
 
@@ -127,8 +127,7 @@
 
             var consumerTag = $"{hostDisplayName} - {settings.EndpointName()}";
 
-            var provider = new ChannelProvider(connectionManager, connectionConfiguration.UsePublisherConfirms);
-            var poisonMessageForwarder = new PoisonMessageForwarder(provider, topology);
+            var poisonMessageForwarder = new PoisonMessageForwarder(channelProvider, topology);
 
             var queuePurger = new QueuePurger(connectionManager);
 

--- a/src/NServiceBus.RabbitMQ/RabbitMQTransportInfrastructure.cs
+++ b/src/NServiceBus.RabbitMQ/RabbitMQTransportInfrastructure.cs
@@ -49,7 +49,7 @@
 
         public override TransportSendInfrastructure ConfigureSendInfrastructure()
         {
-            var provider = new ChannelProvider(connectionManager, connectionConfiguration.UsePublisherConfirms, connectionConfiguration.MaxWaitTimeForConfirms);
+            var provider = new ChannelProvider(connectionManager, connectionConfiguration.UsePublisherConfirms);
 
             return new TransportSendInfrastructure(
                 () => new MessageDispatcher(topology, provider),
@@ -127,7 +127,7 @@
 
             var consumerTag = $"{hostDisplayName} - {settings.EndpointName()}";
 
-            var provider = new ChannelProvider(connectionManager, connectionConfiguration.UsePublisherConfirms, connectionConfiguration.MaxWaitTimeForConfirms);
+            var provider = new ChannelProvider(connectionManager, connectionConfiguration.UsePublisherConfirms);
             var poisonMessageForwarder = new PoisonMessageForwarder(provider, topology);
 
             var queuePurger = new QueuePurger(connectionManager);

--- a/src/NServiceBus.RabbitMQ/Receiving/MessagePump.cs
+++ b/src/NServiceBus.RabbitMQ/Receiving/MessagePump.cs
@@ -146,7 +146,7 @@
                 }
                 catch (Exception ex)
                 {
-                    poisonMessageForwarder.ForwardPoisonMessageToErrorQueue(message, ex, settings.ErrorQueue);
+                    await poisonMessageForwarder.ForwardPoisonMessageToErrorQueue(message, ex, settings.ErrorQueue).ConfigureAwait(true);
                 }
 
                 CancellationTokenSource tokenSource = null;

--- a/src/NServiceBus.RabbitMQ/Routing/ConventionalRoutingTopology.cs
+++ b/src/NServiceBus.RabbitMQ/Routing/ConventionalRoutingTopology.cs
@@ -64,12 +64,12 @@
 
         public void Send(IModel channel, string address, OutgoingMessage message, IBasicProperties properties)
         {
-            channel.BasicPublish(address, String.Empty, false, properties, message.Body);
+            channel.BasicPublish(address, String.Empty, true, properties, message.Body);
         }
 
         public void RawSendInCaseOfFailure(IModel channel, string address, byte[] body, IBasicProperties properties)
         {
-            channel.BasicPublish(address, String.Empty, false, properties, body);
+            channel.BasicPublish(address, String.Empty, true, properties, body);
         }
 
         public void Initialize(IModel channel, string mainQueue)

--- a/src/NServiceBus.RabbitMQ/Routing/DirectRoutingTopology.cs
+++ b/src/NServiceBus.RabbitMQ/Routing/DirectRoutingTopology.cs
@@ -33,12 +33,12 @@
 
         public void Send(IModel channel, string address, OutgoingMessage message, IBasicProperties properties)
         {
-            channel.BasicPublish(string.Empty, address, false, properties, message.Body);
+            channel.BasicPublish(string.Empty, address, true, properties, message.Body);
         }
 
         public void RawSendInCaseOfFailure(IModel channel, string address, byte[] body, IBasicProperties properties)
         {
-            channel.BasicPublish(string.Empty, address, false, properties, body);
+            channel.BasicPublish(string.Empty, address, true, properties, body);
         }
 
         public void Initialize(IModel channel, string main)


### PR DESCRIPTION
Instead of creating and disposing channels for each send operation, the `ChannelProvider` will pool the created channels and reuse them.

Keeping the channels around means that event handlers for `BasicAcks`, `BasicNacks`, `BasicReturn`, and `ModelShutdown` can be registered. Using these events along with `TaskCompletionSource` allows us to preserve the ability to associate a sent message with a confirmation when using publisher confirms, but without having to block a thread and wait for them to come back.

This provides a substantial performance boost for several sending scenarios.

Being able to use the `BasicReturn` event should also go a long way to resolving the problems discussed in #135 also.

Connects to https://github.com/Particular/PlatformDevelopment/issues/719