### PR TITLE
Add support for Transport Layer Security to the connection string

### DIFF
--- a/src/NServiceBus.RabbitMQ.Tests/ConnectionString/ConnectionConfigurationTests.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/ConnectionString/ConnectionConfigurationTests.cs
@@ -94,5 +94,23 @@
             Assert.That(exception.Message, Is.StringContaining("Multiple hosts are no longer supported"));
             Assert.That(exception.Message, Is.StringContaining("consider using a load balancer"));
         }
+
+        [Test]
+        public void Should_set_default_use_tls()
+        {
+            Assert.AreEqual(defaults.UseTls, false);
+        }
+
+        [Test]
+        public void Should_set_default_cert_path()
+        {
+            Assert.AreEqual(defaults.CertPath, "");
+        }
+
+        [Test]
+        public void Should_set_default_retry_cert_passphrase()
+        {
+            Assert.AreEqual(defaults.CertPassphrase, null);
+        }
     }
 }

--- a/src/NServiceBus.RabbitMQ.Tests/ConnectionString/ConnectionStringParserTests.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/ConnectionString/ConnectionStringParserTests.cs
@@ -10,7 +10,7 @@
     {
         const string connectionString =
             "virtualHost=Copa;username=Copa;host=192.168.1.1:1234;password=abc_xyz;port=12345;requestedHeartbeat=3;" +
-            "prefetchcount=2;maxRetries=4;usePublisherConfirms=true;maxWaitTimeForConfirms=02:03:39;retryDelay=01:02:03";
+            "prefetchcount=2;maxRetries=4;usePublisherConfirms=true;maxWaitTimeForConfirms=02:03:39;retryDelay=01:02:03;useTls=true;certPath=/path/to/client/keycert.p12;certPassPhrase=abc123";
 
         [Test]
         public void Should_correctly_parse_full_connection_string()
@@ -29,6 +29,9 @@
             Assert.AreEqual(connectionConfiguration.UsePublisherConfirms, true);
             Assert.AreEqual(connectionConfiguration.MaxWaitTimeForConfirms, new TimeSpan(2, 3, 39)); //02:03:39
             Assert.AreEqual(connectionConfiguration.RetryDelay, new TimeSpan(1, 2, 3)); //01:02:03
+            Assert.AreEqual(connectionConfiguration.UseTls, true);
+            Assert.AreEqual(connectionConfiguration.CertPath, "/path/to/client/keycert.p12");
+            Assert.AreEqual(connectionConfiguration.CertPassphrase, "abc123");
         }
 
         [Test]
@@ -144,6 +147,34 @@
             var parser = new ConnectionStringParser(new SettingsHolder());
             var connectionConfiguration = parser.Parse("host=localhost;virtualHost=myVirtualHost");
             Assert.AreEqual("myVirtualHost", connectionConfiguration.VirtualHost);
+        }
+
+        [Test]
+        public void Should_parse_use_tls()
+        {
+            var parser = new ConnectionStringParser(new SettingsHolder());
+            var connectionConfiguration = parser.Parse("host=localhost;useTls=true");
+
+            Assert.AreEqual(true, connectionConfiguration.UseTls);
+            Assert.AreEqual(5671, connectionConfiguration.Port);
+        }
+
+        [Test]
+        public void Should_parse_the_cert_path()
+        {
+            var parser = new ConnectionStringParser(new SettingsHolder());
+            var connectionConfiguration = parser.Parse("host=localhost;certPath=/path/keyfile.p12");
+
+            Assert.AreEqual("/path/keyfile.p12", connectionConfiguration.CertPath);
+        }
+
+        [Test]
+        public void Should_parse_the_cert_passphrase()
+        {
+            var parser = new ConnectionStringParser(new SettingsHolder());
+            var connectionConfiguration = parser.Parse("host=localhost;certPassphrase=abc123");
+
+            Assert.AreEqual("abc123", connectionConfiguration.CertPassphrase);
         }
 
         [Test]

--- a/src/NServiceBus.RabbitMQ/Config/ConnectionConfiguration.cs
+++ b/src/NServiceBus.RabbitMQ/Config/ConnectionConfiguration.cs
@@ -43,6 +43,7 @@
             get { return clientProperties; }
             private set { clientProperties = value; }
         }
+
         public bool UseTls { get; set; }
 
         public string CertPath { get; set; }

--- a/src/NServiceBus.RabbitMQ/Config/ConnectionConfiguration.cs
+++ b/src/NServiceBus.RabbitMQ/Config/ConnectionConfiguration.cs
@@ -43,6 +43,11 @@
             get { return clientProperties; }
             private set { clientProperties = value; }
         }
+        public bool UseTls { get; set; }
+
+        public string CertPath { get; set; }
+
+        public string CertPassphrase { get; set; }
 
         public HostConfiguration HostConfiguration { get; private set; }
 
@@ -68,6 +73,9 @@
             var applicationName = Path.GetFileName(applicationNameAndPath);
             var applicationPath = Path.GetDirectoryName(applicationNameAndPath);
             var hostname = RuntimeEnvironment.MachineName;
+            UseTls = false;
+            CertPath = String.Empty;
+            CertPassphrase = null;
 
             clientProperties.Add("client_api", "NServiceBus");
             clientProperties.Add("nservicebus_version", version);

--- a/src/NServiceBus.RabbitMQ/Config/ConnectionStringParser.cs
+++ b/src/NServiceBus.RabbitMQ/Config/ConnectionStringParser.cs
@@ -33,6 +33,11 @@
                         }))
                 pair.Property.SetValue(connectionConfiguration, TypeDescriptor.GetConverter(pair.Property.PropertyType).ConvertFromString(pair.Value), null);
 
+            if (connectionConfiguration.UseTls && !ContainsKey("port"))
+            {
+                connectionConfiguration.Port = 5671;
+            }
+
             if (ContainsKey("host"))
             {
                 connectionConfiguration.ParseHosts(this["host"] as string);

--- a/src/NServiceBus.RabbitMQ/Connection/RabbitMqConnectionFactory.cs
+++ b/src/NServiceBus.RabbitMQ/Connection/RabbitMqConnectionFactory.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Transports.RabbitMQ.Connection
 {
     using System;
+    using System.Security.Authentication;
     using global::RabbitMQ.Client;
     using NServiceBus.Transports.RabbitMQ.Config;
 
@@ -31,7 +32,15 @@
                 UserName = Configuration.UserName,
                 Password = Configuration.Password,
                 RequestedHeartbeat = Configuration.RequestedHeartbeat,
-                ClientProperties = Configuration.ClientProperties
+                ClientProperties = Configuration.ClientProperties,
+                Ssl =
+                {
+                    ServerName = connectionConfiguration.HostConfiguration.Host,
+                    CertPath = connectionConfiguration.CertPath,
+                    CertPassphrase = connectionConfiguration.CertPassphrase,
+                    Version = SslProtocols.Tls12,
+                    Enabled = connectionConfiguration.UseTls
+                }
             };
         }
 


### PR DESCRIPTION
This is the backport of TLS feature, see http://docs.particular.net/nservicebus/rabbitmq/configuration-api#transport-layer-security-support for more info

<!-- connects to https://github.com/Particular/PlatformDevelopment/issues/719 -->