### PR TITLE
Release 3.3.1

### DIFF
--- a/src/NServiceBus.RabbitMQ/Connection/RabbitMqConnectionFactory.cs
+++ b/src/NServiceBus.RabbitMQ/Connection/RabbitMqConnectionFactory.cs
@@ -46,6 +46,7 @@
 
         public virtual IConnection CreateConnection(string connectionName)
         {
+            connectionFactory.ClientProperties["purpose"] = connectionName;
             return connectionFactory.CreateConnection(connectionName);
         }
 


### PR DESCRIPTION
This works around the bug in the 3.6.2 release of the RabbitMQ.Client where the new connection name setting isn't being set properly so it doesn't show up in the management ui.

@Particular/rabbitmq-transport-maintainers If we want to make a change to the nuspec version range to lock in to 3.6.2, we should make the change here before we release 3.3.1.