### PR TITLE
Add new() constraint on RabbitMQTransportSettingsExtensions.UseRoutingTopology type param

### DIFF
--- a/src/NServiceBus.RabbitMQ.Tests/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.RabbitMQ.Tests/APIApprovals.Approve.approved.txt
@@ -24,7 +24,7 @@ namespace NServiceBus
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> UseConnectionManager<T>(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions) { }
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> UseDirectRoutingTopology(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions, System.Func<System.Type, string> routingKeyConvention = null, System.Func<string, System.Type, string> exchangeNameConvention = null) { }
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> UseRoutingTopology<T>(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions)
-            where T : NServiceBus.Transport.RabbitMQ.IRoutingTopology { }
+            where T : NServiceBus.Transport.RabbitMQ.IRoutingTopology, new () { }
     }
 }
 namespace NServiceBus.Transport.RabbitMQ

--- a/src/NServiceBus.RabbitMQ/Configuration/RabbitMQTransportSettingsExtensions.cs
+++ b/src/NServiceBus.RabbitMQ/Configuration/RabbitMQTransportSettingsExtensions.cs
@@ -36,9 +36,9 @@
         /// <summary>
         /// Registers a custom routing topology.
         /// </summary>
-        public static TransportExtensions<RabbitMQTransport> UseRoutingTopology<T>(this TransportExtensions<RabbitMQTransport> transportExtensions) where T : IRoutingTopology
+        public static TransportExtensions<RabbitMQTransport> UseRoutingTopology<T>(this TransportExtensions<RabbitMQTransport> transportExtensions) where T : IRoutingTopology, new()
         {
-            transportExtensions.GetSettings().Set<IRoutingTopology>(Activator.CreateInstance<T>());
+            transportExtensions.GetSettings().Set<IRoutingTopology>(new T());
             return transportExtensions;
         }
 


### PR DESCRIPTION
Currently, a runtime exception will be thrown if the type being used does not have a parameter-less constructor. This moves this to a compile time error.