### PR TITLE
Simplify Message pump ack and reject methods

### DIFF
--- a/src/NServiceBus.RabbitMQ/Receiving/MessagePump.cs
+++ b/src/NServiceBus.RabbitMQ/Receiving/MessagePump.cs
@@ -223,24 +223,24 @@
 
         Task AcknowledgeMessage(IModel channel, ulong deliveryTag)
         {
-            return Task.Factory.StartNew(state =>
+            return TaskEx.StartNew(new MessageState { Channel = channel, DeliveryTag = deliveryTag }, state =>
             {
                 var messageState = (MessageState)state;
 
                 messageState.Channel.BasicAck(messageState.DeliveryTag, false);
 
-            }, new MessageState { Channel = channel, DeliveryTag = deliveryTag }, CancellationToken.None, TaskCreationOptions.DenyChildAttach, exclusiveScheduler);
+            }, exclusiveScheduler);
         }
 
         Task RejectMessage(IModel channel, ulong deliveryTag)
         {
-            return Task.Factory.StartNew(state =>
+            return TaskEx.StartNew(new MessageState { Channel = channel, DeliveryTag = deliveryTag }, state =>
             {
                 var messageState = (MessageState)state;
 
                 messageState.Channel.BasicReject(messageState.DeliveryTag, true);
 
-            }, new MessageState { Channel = channel, DeliveryTag = deliveryTag }, CancellationToken.None, TaskCreationOptions.DenyChildAttach, exclusiveScheduler);
+            }, exclusiveScheduler);
         }
 
         public void Dispose()

--- a/src/NServiceBus.RabbitMQ/TaskEx.cs
+++ b/src/NServiceBus.RabbitMQ/TaskEx.cs
@@ -1,10 +1,14 @@
 namespace NServiceBus.Transport.RabbitMQ
 {
+    using System;
+    using System.Threading;
     using System.Threading.Tasks;
 
     static class TaskEx
     {
         //TODO: remove when we update to 4.6 and can use Task.CompletedTask
         public static readonly Task CompletedTask = Task.FromResult(0);
+
+        public static Task StartNew(object state, Action<object> action, TaskScheduler scheduler) => Task.Factory.StartNew(action, state, CancellationToken.None, TaskCreationOptions.DenyChildAttach, scheduler);
     }
 }


### PR DESCRIPTION
This is the set of changes originally in #165 related to the `MessagePump` class.

I've split them into two commits, so hopefully that makes it easier to follow the changes.