### PR TITLE
Use StartNew helper method in ConfirmsAwareChannel

### DIFF
--- a/src/NServiceBus.RabbitMQ/TaskEx.cs
+++ b/src/NServiceBus.RabbitMQ/TaskEx.cs
@@ -9,6 +9,8 @@ namespace NServiceBus.Transport.RabbitMQ
         //TODO: remove when we update to 4.6 and can use Task.CompletedTask
         public static readonly Task CompletedTask = Task.FromResult(0);
 
+        public static Task StartNew(object state, Action<object> action) => StartNew(state, action, TaskScheduler.Default);
+
         public static Task StartNew(object state, Action<object> action, TaskScheduler scheduler) => Task.Factory.StartNew(action, state, CancellationToken.None, TaskCreationOptions.DenyChildAttach, scheduler);
     }
 }


### PR DESCRIPTION
This updates `ConfirmsAwareChannel` to use the newly added `TaskEx.StartNew` helper method. An additional overload to avoid needing to pass in the default tasks scheduler was added.