### PR TITLE
Splitting message converter into header converter and default messageid strategy

### DIFF
--- a/src/NServiceBus.RabbitMQ.Tests/HeaderConverterTests.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/HeaderConverterTests.cs
@@ -1,0 +1,159 @@
+﻿namespace NServiceBus.Transport.RabbitMQ.Tests
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Text;
+    using global::RabbitMQ.Client.Events;
+    using global::RabbitMQ.Client.Framing;
+    using NUnit.Framework;
+
+    [TestFixture]
+    class HeaderConverterTests
+    {
+        [Test]
+        public void TestCanHandleByteArrayHeader()
+        {
+            var message = new BasicDeliverEventArgs
+            {
+                BasicProperties = new BasicProperties
+                {
+                    MessageId = "Blah",
+                    Headers = new Dictionary<string, object>
+                    {
+                        {"Foo", Encoding.UTF8.GetBytes("blah")}
+                    }
+                }
+            };
+
+            var headers = HeaderConverter.RetrieveHeaders(message);
+
+            Assert.NotNull(headers);
+            Assert.AreEqual("blah", headers["Foo"]);
+        }
+
+        [Test]
+        public void Should_set_replyto_header_if_native_replyto_is_present()
+        {
+            var message = new BasicDeliverEventArgs
+            {
+                BasicProperties = new BasicProperties
+                {
+                    ReplyTo = "myaddress",
+                    MessageId = "Blah"
+                }
+            };
+
+            var headers = HeaderConverter.RetrieveHeaders(message);
+
+            Assert.NotNull(headers);
+            Assert.AreEqual("myaddress", headers[Headers.ReplyToAddress]);
+        }
+
+        [Test]
+        public void Should_override_replyto_header_if_native_replyto_is_present()
+        {
+            var message = new BasicDeliverEventArgs
+            {
+                BasicProperties = new BasicProperties
+                {
+                    ReplyTo = "myaddress",
+                    MessageId = "Blah",
+                    Headers = new Dictionary<string, object>
+                    {
+                        {Headers.ReplyToAddress, Encoding.UTF8.GetBytes("nsb set address")}
+                    }
+                }
+            };
+
+            var headers = HeaderConverter.RetrieveHeaders(message);
+
+            Assert.NotNull(headers);
+            Assert.AreEqual("myaddress", headers[Headers.ReplyToAddress]);
+        }
+
+        [Test]
+        public void TestCanHandleStringHeader()
+        {
+            var message = new BasicDeliverEventArgs
+            {
+                BasicProperties = new BasicProperties
+                {
+                    MessageId = "Blah",
+                    Headers = new Dictionary<string, object>
+                    {
+                        {"Foo", "ni"}
+                    }
+                }
+            };
+
+            var headers = HeaderConverter.RetrieveHeaders(message);
+
+            Assert.NotNull(headers);
+            Assert.AreEqual("ni", headers["Foo"]);
+        }
+
+        [Test]
+        public void TestCanHandleStringArrayListsHeader()
+        {
+            var message = new BasicDeliverEventArgs
+            {
+                BasicProperties = new BasicProperties
+                {
+                    MessageId = "Blah",
+                    Headers = new Dictionary<string, object>
+                    {
+                        {"Foo", new ArrayList{"Bing"}}
+                    }
+                }
+            };
+
+            var headers = HeaderConverter.RetrieveHeaders(message);
+
+            Assert.NotNull(headers);
+            Assert.AreEqual("Bing", headers["Foo"]);
+        }
+
+        [Test]
+        public void TestCanHandleStringObjectListHeader()
+        {
+            var message = new BasicDeliverEventArgs
+            {
+                BasicProperties = new BasicProperties
+                {
+                    MessageId = "Blah",
+                    Headers = new Dictionary<string, object>
+                    {
+                        {"Foo", new List<object>{"Bing"}}
+                    }
+                }
+            };
+
+            var headers = HeaderConverter.RetrieveHeaders(message);
+
+            Assert.NotNull(headers);
+            Assert.AreEqual("Bing", headers["Foo"]);
+        }
+
+        [Test]
+        public void TestCanHandleTablesListHeader()
+        {
+            var message = new BasicDeliverEventArgs
+            {
+                BasicProperties = new BasicProperties
+                {
+                    MessageId = "Blah",
+                    Headers = new Dictionary<string, object>
+                    {
+                        {"Foo", new List<object>{new Dictionary<string, object>{{"key1", Encoding.UTF8.GetBytes("value1")}, {"key2", Encoding.UTF8.GetBytes("value2")}}}}
+                    }
+                }
+            };
+
+            var headers = HeaderConverter.RetrieveHeaders(message);
+
+            Assert.NotNull(headers);
+            Assert.AreEqual("key1=value1,key2=value2", Convert.ToString(headers["Foo"]));
+        }
+    }
+}

--- a/src/NServiceBus.RabbitMQ.Tests/MessageConverterTests.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/MessageConverterTests.cs
@@ -1,9 +1,5 @@
 ﻿namespace NServiceBus.Transport.RabbitMQ.Tests
 {
-    using System;
-    using System.Collections;
-    using System.Collections.Generic;
-    using System.Text;
     using global::RabbitMQ.Client.Events;
     using global::RabbitMQ.Client.Framing;
     using NUnit.Framework;
@@ -11,8 +7,6 @@
     [TestFixture]
     class MessageConverterTests
     {
-        MessageConverter converter = new MessageConverter();
-
         [Test]
         public void TestCanHandleNoInterestingProperties()
         {
@@ -24,156 +18,11 @@
                 }
             };
 
-            var messageId = converter.RetrieveMessageId(message);
-            var headers = converter.RetrieveHeaders(message);
+            var messageId = MessageConverter.DefaultMessageIdStrategy(message);
+            var headers = HeaderConverter.RetrieveHeaders(message);
 
             Assert.IsNotNull(messageId);
             Assert.IsNotNull(headers);
-        }
-
-        [Test]
-        public void TestCanHandleByteArrayHeader()
-        {
-            var message = new BasicDeliverEventArgs
-            {
-                BasicProperties = new BasicProperties
-                {
-                    MessageId = "Blah",
-                    Headers = new Dictionary<string, object>
-                    {
-                        {"Foo", Encoding.UTF8.GetBytes("blah")}
-                    }
-                }
-            };
-
-            var headers = converter.RetrieveHeaders(message);
-
-            Assert.NotNull(headers);
-            Assert.AreEqual("blah", headers["Foo"]);
-        }
-
-        [Test]
-        public void Should_set_replyto_header_if_native_replyto_is_present()
-        {
-            var message = new BasicDeliverEventArgs
-            {
-                BasicProperties = new BasicProperties
-                {
-                    ReplyTo = "myaddress",
-                    MessageId = "Blah"
-                }
-            };
-
-            var headers = converter.RetrieveHeaders(message);
-
-            Assert.NotNull(headers);
-            Assert.AreEqual("myaddress", headers[Headers.ReplyToAddress]);
-        }
-
-        [Test]
-        public void Should_override_replyto_header_if_native_replyto_is_present()
-        {
-            var message = new BasicDeliverEventArgs
-            {
-                BasicProperties = new BasicProperties
-                {
-                    ReplyTo = "myaddress",
-                    MessageId = "Blah",
-                    Headers = new Dictionary<string, object>
-                    {
-                        {Headers.ReplyToAddress, Encoding.UTF8.GetBytes("nsb set address")}
-                    }
-                }
-            };
-
-            var headers = converter.RetrieveHeaders(message);
-
-            Assert.NotNull(headers);
-            Assert.AreEqual("myaddress", headers[Headers.ReplyToAddress]);
-        }
-
-        [Test]
-        public void TestCanHandleStringHeader()
-        {
-            var message = new BasicDeliverEventArgs
-            {
-                BasicProperties = new BasicProperties
-                {
-                    MessageId = "Blah",
-                    Headers = new Dictionary<string, object>
-                    {
-                        {"Foo", "ni"}
-                    }
-                }
-            };
-
-            var headers = converter.RetrieveHeaders(message);
-
-            Assert.NotNull(headers);
-            Assert.AreEqual("ni", headers["Foo"]);
-        }
-
-        [Test]
-        public void TestCanHandleStringArrayListsHeader()
-        {
-            var message = new BasicDeliverEventArgs
-            {
-                BasicProperties = new BasicProperties
-                {
-                    MessageId = "Blah",
-                    Headers = new Dictionary<string, object>
-                {
-                    {"Foo", new ArrayList{"Bing"}}
-                }
-                }
-            };
-
-            var headers = converter.RetrieveHeaders(message);
-
-            Assert.NotNull(headers);
-            Assert.AreEqual("Bing", headers["Foo"]);
-        }
-
-        [Test]
-        public void TestCanHandleStringObjectListHeader()
-        {
-            var message = new BasicDeliverEventArgs
-            {
-                BasicProperties = new BasicProperties
-                {
-                    MessageId = "Blah",
-                    Headers = new Dictionary<string, object>
-                    {
-                        {"Foo", new List<object>{"Bing"}}
-                    }
-                }
-            };
-
-            var headers = converter.RetrieveHeaders(message);
-
-            Assert.NotNull(headers);
-            Assert.AreEqual("Bing", headers["Foo"]);
-        }
-
-        [Test]
-        public void TestCanHandleTablesListHeader()
-        {
-            var message = new BasicDeliverEventArgs
-            {
-                BasicProperties = new BasicProperties
-                {
-                    MessageId = "Blah",
-                    Headers = new Dictionary<string, object>
-                {
-                    {"Foo", new List<object>{new Dictionary<string, object>{{"key1", Encoding.UTF8.GetBytes("value1")}, {"key2", Encoding.UTF8.GetBytes("value2")}}}}
-                }
-                }
-            };
-
-            var headers = converter.RetrieveHeaders(message);
-
-            Assert.NotNull(headers);
-            Assert.AreEqual("key1=value1,key2=value2", Convert.ToString(headers["Foo"]));
         }
     }
 }

--- a/src/NServiceBus.RabbitMQ.Tests/NServiceBus.RabbitMQ.Tests.csproj
+++ b/src/NServiceBus.RabbitMQ.Tests/NServiceBus.RabbitMQ.Tests.csproj
@@ -103,6 +103,7 @@
     <Compile Include="App_Packages\ApiApprover.3.0.1\PublicApiGenerator.cs" />
     <Compile Include="ConnectionString\ConnectionConfigurationTests.cs" />
     <Compile Include="ConnectionString\ConnectionStringParserTests.cs" />
+    <Compile Include="HeaderConverterTests.cs" />
     <Compile Include="MessageConverterTests.cs" />
     <Compile Include="RabbitMqContext.cs" />
     <Compile Include="TestCategory.cs" />

--- a/src/NServiceBus.RabbitMQ.Tests/RabbitMqContext.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/RabbitMqContext.cs
@@ -75,7 +75,7 @@
             var purger = new QueuePurger(connectionFactory);
             var poisonMessageForwarder = new PoisonMessageForwarder(channelProvider);
 
-            messagePump = new MessagePump(connectionFactory, new MessageConverter(), "Unit test", poisonMessageForwarder, purger, TimeSpan.FromMinutes(2));
+            messagePump = new MessagePump(connectionFactory, MessageConverter.DefaultMessageIdStrategy, "Unit test", poisonMessageForwarder, purger, TimeSpan.FromMinutes(2));
 
             MakeSureQueueAndExchangeExists(ReceiverQueue);
 

--- a/src/NServiceBus.RabbitMQ.Tests/When_sending_a_message_over_rabbitmq.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/When_sending_a_message_over_rabbitmq.cs
@@ -105,13 +105,11 @@
 
             var result = Consume(messageId, queueToReceiveOn);
 
-            var converter = new MessageConverter();
-
             using (var body = new MemoryStream(result.Body))
             {
                 var incomingMessage = new IncomingMessage(
-                    converter.RetrieveMessageId(result),
-                    converter.RetrieveHeaders(result),
+                    MessageConverter.DefaultMessageIdStrategy(result),
+                    HeaderConverter.RetrieveHeaders(result),
                     body
                 );
 

--- a/src/NServiceBus.RabbitMQ/NServiceBus.RabbitMQ.csproj
+++ b/src/NServiceBus.RabbitMQ/NServiceBus.RabbitMQ.csproj
@@ -81,6 +81,7 @@
     <Compile Include="RabbitMQTransportInfrastructure.cs" />
     <Compile Include="Configuration\SettingsKeys.cs" />
     <Compile Include="Connection\ConfirmsAwareChannel.cs" />
+    <Compile Include="Receiving\HeaderConverter.cs" />
     <Compile Include="Routing\DefaultRoutingKeyConvention.cs" />
     <Compile Include="Configuration\ConnectionConfiguration.cs" />
     <Compile Include="Connection\ConnectionFactory.cs" />

--- a/src/NServiceBus.RabbitMQ/RabbitMQTransportInfrastructure.cs
+++ b/src/NServiceBus.RabbitMQ/RabbitMQTransportInfrastructure.cs
@@ -108,15 +108,15 @@
 
         IPushMessages CreateMessagePump()
         {
-            MessageConverter messageConverter;
-
+            Func<BasicDeliverEventArgs, string> messageIdRetriever;
             if (settings.HasSetting(SettingsKeys.CustomMessageIdStrategy))
             {
-                messageConverter = new MessageConverter(settings.Get<Func<BasicDeliverEventArgs, string>>(SettingsKeys.CustomMessageIdStrategy));
+                messageIdRetriever = settings.Get<Func<BasicDeliverEventArgs, string>>(SettingsKeys.CustomMessageIdStrategy);
             }
             else
             {
-                messageConverter = new MessageConverter();
+                // ReSharper disable once ConvertClosureToMethodGroup
+                messageIdRetriever = args => MessageConverter.DefaultMessageIdStrategy(args);
             }
 
             string hostDisplayName;
@@ -137,7 +137,7 @@
                 timeToWaitBeforeTriggeringCircuitBreaker = TimeSpan.FromMinutes(2);
             }
 
-            return new MessagePump(connectionFactory, messageConverter, consumerTag, poisonMessageForwarder, queuePurger, timeToWaitBeforeTriggeringCircuitBreaker);
+            return new MessagePump(connectionFactory, messageIdRetriever, consumerTag, poisonMessageForwarder, queuePurger, timeToWaitBeforeTriggeringCircuitBreaker);
         }
     }
 }

--- a/src/NServiceBus.RabbitMQ/Receiving/HeaderConverter.cs
+++ b/src/NServiceBus.RabbitMQ/Receiving/HeaderConverter.cs
@@ -1,0 +1,103 @@
+namespace NServiceBus.Transport.RabbitMQ
+{
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Text;
+    using global::RabbitMQ.Client.Events;
+
+    static class HeaderConverter
+    {
+        public static Dictionary<string, string> RetrieveHeaders(BasicDeliverEventArgs message)
+        {
+            var properties = message.BasicProperties;
+
+            var headers = DeserializeHeaders(properties.Headers);
+
+            if (properties.IsReplyToPresent())
+            {
+                headers[Headers.ReplyToAddress] = properties.ReplyTo;
+            }
+
+            if (properties.IsCorrelationIdPresent())
+            {
+                headers[Headers.CorrelationId] = properties.CorrelationId;
+            }
+
+            //When doing native interop we only require the type to be set the "fullName" of the message
+            if (!headers.ContainsKey(Headers.EnclosedMessageTypes) && properties.IsTypePresent())
+            {
+                headers[Headers.EnclosedMessageTypes] = properties.Type;
+            }
+
+            if (properties.IsDeliveryModePresent())
+            {
+                headers[Headers.NonDurableMessage] = (properties.DeliveryMode == 1).ToString();
+            }
+
+            if (headers.ContainsKey("NServiceBus.RabbitMQ.CallbackQueue"))
+            {
+                headers[Headers.ReplyToAddress] = headers["NServiceBus.RabbitMQ.CallbackQueue"];
+            }
+
+            return headers;
+        }
+
+        static Dictionary<string, string> DeserializeHeaders(IDictionary<string, object> headers)
+        {
+            var deserializedHeaders = new Dictionary<string, string>();
+
+            if (headers != null)
+            {
+                var messageHeaders = headers as Dictionary<string, object>
+                    ?? new Dictionary<string, object>(headers);
+
+                foreach (var header in messageHeaders)
+                {
+                    deserializedHeaders.Add(header.Key, header.Value == null ? null : ValueToString(header.Value));
+                }
+            }
+
+            return deserializedHeaders;
+        }
+
+        static string ValueToString(object value)
+        {
+            var s = value as string;
+            if (s != null)
+            {
+                return s;
+            }
+
+            var bytes = value as byte[];
+            if (bytes != null)
+            {
+                return Encoding.UTF8.GetString(bytes);
+            }
+
+            var dictionary = value as IDictionary<string, object>;
+            if (dictionary != null)
+            {
+                var valuesToJoin = new List<string>();
+                // ReSharper disable once LoopCanBeConvertedToQuery
+                foreach (var kvp in dictionary)
+                {
+                    valuesToJoin.Add(string.Concat(kvp.Key, "=", ValueToString(kvp.Value)));
+                }
+                return string.Join(",", valuesToJoin);
+            }
+
+            var list = value as IList;
+            if (list != null)
+            {
+                var valuesToJoin = new List<string>();
+                foreach (var entry in list)
+                {
+                    valuesToJoin.Add(ValueToString(entry));
+                }
+                return string.Join(";", valuesToJoin);
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/NServiceBus.RabbitMQ/Receiving/MessageConverter.cs
+++ b/src/NServiceBus.RabbitMQ/Receiving/MessageConverter.cs
@@ -1,63 +1,11 @@
 ﻿namespace NServiceBus.Transport.RabbitMQ
 {
     using System;
-    using System.Collections;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
     using global::RabbitMQ.Client.Events;
-    using Logging;
 
-    class MessageConverter
+    static class MessageConverter
     {
-        public MessageConverter()
-        {
-            messageIdStrategy = DefaultMessageIdStrategy;
-        }
-
-        public MessageConverter(Func<BasicDeliverEventArgs, string> messageIdStrategy)
-        {
-            this.messageIdStrategy = messageIdStrategy;
-        }
-
-        public string RetrieveMessageId(BasicDeliverEventArgs message) => messageIdStrategy(message);
-
-        public Dictionary<string, string> RetrieveHeaders(BasicDeliverEventArgs message)
-        {
-            var properties = message.BasicProperties;
-
-            var headers = DeserializeHeaders(properties.Headers);
-
-            if (properties.IsReplyToPresent())
-            {
-                headers[Headers.ReplyToAddress] = properties.ReplyTo;
-            }
-
-            if (properties.IsCorrelationIdPresent())
-            {
-                headers[Headers.CorrelationId] = properties.CorrelationId;
-            }
-
-            //When doing native interop we only require the type to be set the "fullName" of the message
-            if (!headers.ContainsKey(Headers.EnclosedMessageTypes) && properties.IsTypePresent())
-            {
-                headers[Headers.EnclosedMessageTypes] = properties.Type;
-            }
-
-            if (properties.IsDeliveryModePresent())
-            {
-                headers[Headers.NonDurableMessage] = (properties.DeliveryMode == 1).ToString();
-            }
-
-            if (headers.ContainsKey("NServiceBus.RabbitMQ.CallbackQueue"))
-            {
-                headers[Headers.ReplyToAddress] = headers["NServiceBus.RabbitMQ.CallbackQueue"];
-            }
-
-            return headers;
-        }
-
-        string DefaultMessageIdStrategy(BasicDeliverEventArgs message)
+        public static string DefaultMessageIdStrategy(BasicDeliverEventArgs message)
         {
             var properties = message.BasicProperties;
 
@@ -68,56 +16,5 @@
 
             return properties.MessageId;
         }
-
-        static Dictionary<string, string> DeserializeHeaders(IDictionary<string, object> headers)
-        {
-            var deserializedHeaders = new Dictionary<string, string>();
-
-            if (headers != null)
-            {
-                var messageHeaders = headers as Dictionary<string, object>
-                    ?? new Dictionary<string, object>(headers);
-
-                foreach (var header in messageHeaders)
-                {
-                    deserializedHeaders.Add(header.Key, header.Value == null ? null : ValueToString(header.Value));
-                }
-            }
-
-            return deserializedHeaders;
-        }
-
-        static string ValueToString(object value)
-        {
-            var s = value as string;
-            if (s != null)
-            {
-                return s;
-            }
-
-            var bytes = value as byte[];
-            if (bytes != null)
-            {
-                return Encoding.UTF8.GetString(bytes);
-            }
-
-            var dictionary = value as IDictionary<string, object>;
-            if (dictionary != null)
-            {
-                return String.Join(",", dictionary.Select(kvp => kvp.Key + "=" + ValueToString(kvp.Value)));
-            }
-
-            var list = value as IList;
-            if (list != null)
-            {
-                return String.Join(";", list.Cast<object>().Select(o => ValueToString(o)));
-            }
-
-            return null;
-        }
-
-        readonly Func<BasicDeliverEventArgs, string> messageIdStrategy;
-
-        static ILog Logger = LogManager.GetLogger(typeof(MessageConverter));
     }
 }


### PR DESCRIPTION
For #186 is was spelunking in the code and saw that the message converter could be made static. One lead to another and I split out the different responsibilities of that class into header converter and default messageid strategy. 

I also removed LINQ for the ValuesToString method

Hope you like it.