### PR TITLE
Prefetch count settings changes

### DIFF
--- a/src/NServiceBus.RabbitMQ.Tests/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.RabbitMQ.Tests/APIApprovals.Approve.approved.txt
@@ -19,6 +19,7 @@ namespace NServiceBus
             "mentedException. Will be removed in version 5.0.0.", true)]
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> DisableCallbackReceiver(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions) { }
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> PrefetchCount(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions, ushort prefetchCount) { }
+        public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> PrefetchMultiplier(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions, int prefetchMultiplier) { }
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> TimeToWaitBeforeTriggeringCircuitBreaker(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions, System.TimeSpan waitTime) { }
         [System.ObsoleteAttribute("The member currently throws a NotImplementedException. Will be removed in version" +
             " 5.0.0.", true)]

--- a/src/NServiceBus.RabbitMQ.Tests/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.RabbitMQ.Tests/APIApprovals.Approve.approved.txt
@@ -18,7 +18,7 @@ namespace NServiceBus
         [System.ObsoleteAttribute("Replaced by NServiceBus.Callbacks package. The member currently throws a NotImple" +
             "mentedException. Will be removed in version 5.0.0.", true)]
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> DisableCallbackReceiver(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions) { }
-        public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> PrefetchCountPerMessageProcessor(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions, ushort prefetchCountPerMessageProcessor) { }
+        public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> PrefetchCount(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions, ushort prefetchCount) { }
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> TimeToWaitBeforeTriggeringCircuitBreaker(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions, System.TimeSpan waitTime) { }
         [System.ObsoleteAttribute("The member currently throws a NotImplementedException. Will be removed in version" +
             " 5.0.0.", true)]

--- a/src/NServiceBus.RabbitMQ.Tests/RabbitMqContext.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/RabbitMqContext.cs
@@ -74,7 +74,7 @@
 
             var purger = new QueuePurger(connectionFactory);
 
-            messagePump = new MessagePump(connectionFactory, new MessageConverter(), "Unit test", channelProvider, purger, TimeSpan.FromMinutes(2), 0);
+            messagePump = new MessagePump(connectionFactory, new MessageConverter(), "Unit test", channelProvider, purger, TimeSpan.FromMinutes(2), 3, 0);
 
             MakeSureQueueAndExchangeExists(ReceiverQueue);
 

--- a/src/NServiceBus.RabbitMQ.Tests/RabbitMqContext.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/RabbitMqContext.cs
@@ -74,7 +74,7 @@
 
             var purger = new QueuePurger(connectionFactory);
 
-            messagePump = new MessagePump(connectionFactory, new MessageConverter(), "Unit test", channelProvider, purger, TimeSpan.FromMinutes(2), 3);
+            messagePump = new MessagePump(connectionFactory, new MessageConverter(), "Unit test", channelProvider, purger, TimeSpan.FromMinutes(2), 0);
 
             MakeSureQueueAndExchangeExists(ReceiverQueue);
 

--- a/src/NServiceBus.RabbitMQ/Configuration/ConnectionStringParser.cs
+++ b/src/NServiceBus.RabbitMQ/Configuration/ConnectionStringParser.cs
@@ -66,7 +66,7 @@
 
             if (ContainsKey("prefetchcount"))
             {
-                var message = "The 'PrefetchCount' connection string option has been removed. Use 'EndpointConfiguration.LimitMessageProcessingConcurrencyTo' and 'EndpointConfiguration.PrefetchCountPerMessageProcessor' instead.";
+                var message = "The 'PrefetchCount' connection string option has been removed. Use 'EndpointConfiguration.UseTransport<RabbitMQTransport>().PrefetchCount' instead.";
 
                 Logger.Error(message);
 

--- a/src/NServiceBus.RabbitMQ/Configuration/RabbitMQTransportSettingsExtensions.cs
+++ b/src/NServiceBus.RabbitMQ/Configuration/RabbitMQTransportSettingsExtensions.cs
@@ -78,13 +78,13 @@
         }
 
         /// <summary>
-        /// Specifies the prefetch count per message processor.
+        /// Overrides the default prefetch count calculation with the specified value.
         /// </summary>
         /// <param name="transportExtensions"></param>
-        /// <param name="prefetchCountPerMessageProcessor">The prefetch count per message processor.</param>
-        public static TransportExtensions<RabbitMQTransport> PrefetchCountPerMessageProcessor(this TransportExtensions<RabbitMQTransport> transportExtensions, ushort prefetchCountPerMessageProcessor)
+        /// <param name="prefetchCount">The prefetch count to use.</param>
+        public static TransportExtensions<RabbitMQTransport> PrefetchCount(this TransportExtensions<RabbitMQTransport> transportExtensions, ushort prefetchCount)
         {
-            transportExtensions.GetSettings().Set(SettingsKeys.PrefetchCountPerMessageProcessor, prefetchCountPerMessageProcessor);
+            transportExtensions.GetSettings().Set(SettingsKeys.PrefetchCount, prefetchCount);
             return transportExtensions;
         }
     }

--- a/src/NServiceBus.RabbitMQ/Configuration/RabbitMQTransportSettingsExtensions.cs
+++ b/src/NServiceBus.RabbitMQ/Configuration/RabbitMQTransportSettingsExtensions.cs
@@ -78,6 +78,22 @@
         }
 
         /// <summary>
+        /// Specifies the multiplier to apply to the maximum concurrency value to calculate the prefetch count.
+        /// </summary>
+        /// <param name="transportExtensions"></param>
+        /// <param name="prefetchMultiplier">The multiplier value to use in the prefetch calculation.</param>
+        public static TransportExtensions<RabbitMQTransport> PrefetchMultiplier(this TransportExtensions<RabbitMQTransport> transportExtensions, int prefetchMultiplier)
+        {
+            if (prefetchMultiplier <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(prefetchMultiplier), "The prefetch multiplier must be greater than zero.");
+            }
+
+            transportExtensions.GetSettings().Set(SettingsKeys.PrefetchMultiplier, prefetchMultiplier);
+            return transportExtensions;
+        }
+
+        /// <summary>
         /// Overrides the default prefetch count calculation with the specified value.
         /// </summary>
         /// <param name="transportExtensions"></param>

--- a/src/NServiceBus.RabbitMQ/Configuration/SettingsKeys.cs
+++ b/src/NServiceBus.RabbitMQ/Configuration/SettingsKeys.cs
@@ -5,6 +5,7 @@
         public const string CustomMessageIdStrategy = "RabbitMQ.CustomMessageIdStrategy";
         public const string TimeToWaitBeforeTriggeringCircuitBreaker = "RabbitMQ.TimeToWaitBeforeTriggeringCircuitBreaker";
         public const string UsePublisherConfirms = "RabbitMQ.UsePublisherConfirms";
+        public const string PrefetchMultiplier = "RabbitMQ.PrefetchMultiplier";
         public const string PrefetchCount = "RabbitMQ.PrefetchCount";
     }
 }

--- a/src/NServiceBus.RabbitMQ/Configuration/SettingsKeys.cs
+++ b/src/NServiceBus.RabbitMQ/Configuration/SettingsKeys.cs
@@ -5,6 +5,6 @@
         public const string CustomMessageIdStrategy = "RabbitMQ.CustomMessageIdStrategy";
         public const string TimeToWaitBeforeTriggeringCircuitBreaker = "RabbitMQ.TimeToWaitBeforeTriggeringCircuitBreaker";
         public const string UsePublisherConfirms = "RabbitMQ.UsePublisherConfirms";
-        public const string PrefetchCountPerMessageProcessor = "RabbitMQ.PrefetchCountPerMessageProcessor";
+        public const string PrefetchCount = "RabbitMQ.PrefetchCount";
     }
 }

--- a/src/NServiceBus.RabbitMQ/RabbitMQTransportInfrastructure.cs
+++ b/src/NServiceBus.RabbitMQ/RabbitMQTransportInfrastructure.cs
@@ -140,13 +140,19 @@
                 timeToWaitBeforeTriggeringCircuitBreaker = TimeSpan.FromMinutes(2);
             }
 
+            int prefetchMultiplier;
+            if (!settings.TryGet(SettingsKeys.PrefetchMultiplier, out prefetchMultiplier))
+            {
+                prefetchMultiplier = 3;
+            }
+
             ushort prefetchCount;
             if (!settings.TryGet(SettingsKeys.PrefetchCount, out prefetchCount))
             {
                 prefetchCount = 0;
             }
 
-            return new MessagePump(connectionFactory, messageConverter, consumerTag, channelProvider, queuePurger, timeToWaitBeforeTriggeringCircuitBreaker, prefetchCount);
+            return new MessagePump(connectionFactory, messageConverter, consumerTag, channelProvider, queuePurger, timeToWaitBeforeTriggeringCircuitBreaker, prefetchMultiplier, prefetchCount);
         }
     }
 }

--- a/src/NServiceBus.RabbitMQ/RabbitMQTransportInfrastructure.cs
+++ b/src/NServiceBus.RabbitMQ/RabbitMQTransportInfrastructure.cs
@@ -140,13 +140,13 @@
                 timeToWaitBeforeTriggeringCircuitBreaker = TimeSpan.FromMinutes(2);
             }
 
-            ushort prefetchCountPerMessageProcessor;
-            if (!settings.TryGet(SettingsKeys.PrefetchCountPerMessageProcessor, out prefetchCountPerMessageProcessor))
+            ushort prefetchCount;
+            if (!settings.TryGet(SettingsKeys.PrefetchCount, out prefetchCount))
             {
-                prefetchCountPerMessageProcessor = 3;
+                prefetchCount = 0;
             }
 
-            return new MessagePump(connectionFactory, messageConverter, consumerTag, channelProvider, queuePurger, timeToWaitBeforeTriggeringCircuitBreaker, prefetchCountPerMessageProcessor);
+            return new MessagePump(connectionFactory, messageConverter, consumerTag, channelProvider, queuePurger, timeToWaitBeforeTriggeringCircuitBreaker, prefetchCount);
         }
     }
 }

--- a/src/NServiceBus.RabbitMQ/Receiving/MessagePump.cs
+++ b/src/NServiceBus.RabbitMQ/Receiving/MessagePump.cs
@@ -22,6 +22,7 @@
         readonly IChannelProvider channelProvider;
         readonly QueuePurger queuePurger;
         readonly TimeSpan timeToWaitBeforeTriggeringCircuitBreaker;
+        readonly int prefetchMultiplier;
         readonly ushort overriddenPrefetchCount;
 
         // Init
@@ -41,7 +42,7 @@
         // Stop
         TaskCompletionSource<bool> connectionShutdownCompleted;
 
-        public MessagePump(ConnectionFactory connectionFactory, MessageConverter messageConverter, string consumerTag, IChannelProvider channelProvider, QueuePurger queuePurger, TimeSpan timeToWaitBeforeTriggeringCircuitBreaker, ushort overriddenPrefetchCount)
+        public MessagePump(ConnectionFactory connectionFactory, MessageConverter messageConverter, string consumerTag, IChannelProvider channelProvider, QueuePurger queuePurger, TimeSpan timeToWaitBeforeTriggeringCircuitBreaker, int prefetchMultiplier, ushort overriddenPrefetchCount)
         {
             this.connectionFactory = connectionFactory;
             this.messageConverter = messageConverter;
@@ -49,6 +50,7 @@
             this.channelProvider = channelProvider;
             this.queuePurger = queuePurger;
             this.timeToWaitBeforeTriggeringCircuitBreaker = timeToWaitBeforeTriggeringCircuitBreaker;
+            this.prefetchMultiplier = prefetchMultiplier;
             this.overriddenPrefetchCount = overriddenPrefetchCount;
         }
 
@@ -80,7 +82,6 @@
 
             var channel = connection.CreateModel();
 
-            int prefetchMultiplier = 3;
             long prefetchCount;
 
             if (overriddenPrefetchCount > 0)


### PR DESCRIPTION
First, I modified things to a PrefetchCount setting that overrides the calculation.

As a separate commit, I then exposed the multiplier as a setting that can also be controlled, but if we don't want do do this now, I can always drop the commit.

What do you think? I think the name works, and with the intellisense description of what the PrefetchCount method does, I didn't think it needed to renamed when the PrefetchMultiplier method is also around.

Connects to #198