### PR TITLE
Fix UsePublisherConfirms connection string error message

### DIFF
--- a/src/NServiceBus.RabbitMQ/Configuration/ConnectionStringParser.cs
+++ b/src/NServiceBus.RabbitMQ/Configuration/ConnectionStringParser.cs
@@ -75,7 +75,7 @@
 
             if (ContainsKey("usepublisherconfirms"))
             {
-                var message = "The 'UsePublisherConfirms' connection string option has been removed. Use 'EndpointConfiguration.UsePublisherConfirms' instead.";
+                var message = "The 'UsePublisherConfirms' connection string option has been removed. Use 'EndpointConfiguration.UseTransport<RabbitMQTransport>().UsePublisherConfirms' instead.";
 
                 Logger.Error(message);
 


### PR DESCRIPTION
While working on #226 I realized that the publisherconfirms message was referring to the wrong thing also.

I went ahead and used the more verbose message that I mentioned in https://github.com/Particular/NServiceBus.RabbitMQ/pull/226#r78827464.

Connects to #185