### PR TITLE
Fix TimeToWaitBeforeTriggeringCircuitBreaker error message

### DIFF
--- a/src/NServiceBus.RabbitMQ/Configuration/ObsoleteAppSettings.cs
+++ b/src/NServiceBus.RabbitMQ/Configuration/ObsoleteAppSettings.cs
@@ -13,7 +13,7 @@
 
             if (timeToWaitBeforeTriggering != null)
             {
-                var message = "The 'TimeToWaitBeforeTriggering' configuration setting has been removed. Use 'EndpointConfiguration.TimeToWaitBeforeTriggeringCircuitBreaker' instead.";
+                var message = "The 'TimeToWaitBeforeTriggering' configuration setting has been removed. Use 'EndpointConfiguration.UseTransport<RabbitMQTransport>().TimeToWaitBeforeTriggeringCircuitBreaker' instead.";
 
                 Logger.Error(message);
 


### PR DESCRIPTION
This fixes the obsolete error message for the `TimeToWaitBeforeTriggeringCircuitBreaker` setting that @WojcikMike pointed out in https://github.com/Particular/NServiceBus.RabbitMQ/pull/227#issuecomment-247286252