### PR TITLE
[SPIKE] Native automatic command routing

### DIFF
--- a/src/CommandWireSample/App.config
+++ b/src/CommandWireSample/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+    </startup>
+</configuration>

--- a/src/CommandWireSample/CommandWireSample.csproj
+++ b/src/CommandWireSample/CommandWireSample.csproj
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{73D8FA4D-BB98-49A8-91B6-51D91F281027}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>CommandWireSample</RootNamespace>
+    <AssemblyName>CommandWireSample</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NServiceBus.6.0.0\lib\net452\NServiceBus.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\NServiceBus.RabbitMQ\NServiceBus.RabbitMQ.csproj">
+      <Project>{ba731749-22c7-4025-8a4d-465ae8e02e61}</Project>
+      <Name>NServiceBus.RabbitMQ</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/CommandWireSample/Program.cs
+++ b/src/CommandWireSample/Program.cs
@@ -25,7 +25,9 @@ namespace CommandWireSample
             Console.WriteLine("Press <enter> to send message");
             Console.ReadLine();
 
-            await endpoint.Send(new Command2());
+            var options = new SendOptions();
+            //options.SetDestination("Dupa");
+            await endpoint.Send(new Command1(), options);
 
             Console.WriteLine("Press <enter> to exit.");
             Console.ReadLine();
@@ -42,11 +44,11 @@ namespace CommandWireSample
     {
     }
 
-    class Command1Handler : IHandleMessages<BaseCommand>
+    class Command1Handler : IHandleMessages<Command1>
     {
-        public Task Handle(BaseCommand message, IMessageHandlerContext context)
+        public Task Handle(Command1 message, IMessageHandlerContext context)
         {
-            Console.WriteLine("Got Command1");
+            Console.WriteLine($"Got {message.GetType().FullName}");
             return Task.FromResult(0);
         }
     }
@@ -55,11 +57,12 @@ namespace CommandWireSample
     {
     }
 
-    //class Command2Handler : IHandleMessages<Command2>
-    //{
-    //    public Task Handle(Command2 message, IMessageHandlerContext context)
-    //    {
-    //        throw new NotImplementedException();
-    //    }
-    //}
+    class Command2Handler : IHandleMessages<Command2>
+    {
+        public Task Handle(Command2 message, IMessageHandlerContext context)
+        {
+            Console.WriteLine($"Got {message.GetType().FullName}");
+            return Task.FromResult(0);
+        }
+    }
 }

--- a/src/CommandWireSample/Program.cs
+++ b/src/CommandWireSample/Program.cs
@@ -25,9 +25,9 @@ namespace CommandWireSample
             Console.WriteLine("Press <enter> to send message");
             Console.ReadLine();
 
-            var options = new SendOptions();
-            //options.SetDestination("Dupa");
-            await endpoint.Send(new Command1(), options);
+            await endpoint.Send(new Command1());
+            await endpoint.Send(new Command2());
+            await endpoint.Publish(new DerivedEvent());
 
             Console.WriteLine("Press <enter> to exit.");
             Console.ReadLine();
@@ -60,6 +60,37 @@ namespace CommandWireSample
     class Command2Handler : IHandleMessages<Command2>
     {
         public Task Handle(Command2 message, IMessageHandlerContext context)
+        {
+            Console.WriteLine($"Got {message.GetType().FullName}");
+            return context.Reply(new Reply());
+        }
+    }
+
+    class BaseEvent : IEvent
+    {
+        
+    }
+
+    class DerivedEvent : BaseEvent
+    {
+    }
+
+    class DerivedEventHandler : IHandleMessages<DerivedEvent>
+    {
+        public Task Handle(DerivedEvent message, IMessageHandlerContext context)
+        {
+            Console.WriteLine($"Got {message.GetType().FullName}");
+            return Task.FromResult(0);
+        }
+    }
+
+    class Reply : IMessage
+    {
+    }
+
+    class ReplyHandler : IHandleMessages<Reply>
+    {
+        public Task Handle(Reply message, IMessageHandlerContext context)
         {
             Console.WriteLine($"Got {message.GetType().FullName}");
             return Task.FromResult(0);

--- a/src/CommandWireSample/Program.cs
+++ b/src/CommandWireSample/Program.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace CommandWireSample
+{
+    using NServiceBus;
+
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            MainAsync().GetAwaiter().GetResult();
+        }
+
+        static async Task MainAsync()
+        {
+            var cfg = new EndpointConfiguration("WireSample");
+            cfg.UsePersistence<InMemoryPersistence>();
+            cfg.UseTransport<RabbitMQTransport>().ConnectionString("host=localhost").UseAutomaticRoutingTopology();
+            cfg.SendFailedMessagesTo("error");
+
+            var endpoint = await Endpoint.Start(cfg);
+
+
+            Console.WriteLine("Press <enter> to send message");
+            Console.ReadLine();
+
+            await endpoint.Send(new Command2());
+
+            Console.WriteLine("Press <enter> to exit.");
+            Console.ReadLine();
+
+            await endpoint.Stop();
+        }
+    }
+
+    class BaseCommand : ICommand
+    {
+    }
+
+    class Command1 : BaseCommand
+    {
+    }
+
+    class Command1Handler : IHandleMessages<BaseCommand>
+    {
+        public Task Handle(BaseCommand message, IMessageHandlerContext context)
+        {
+            Console.WriteLine("Got Command1");
+            return Task.FromResult(0);
+        }
+    }
+
+    class Command2 : ICommand
+    {
+    }
+
+    //class Command2Handler : IHandleMessages<Command2>
+    //{
+    //    public Task Handle(Command2 message, IMessageHandlerContext context)
+    //    {
+    //        throw new NotImplementedException();
+    //    }
+    //}
+}

--- a/src/CommandWireSample/Properties/AssemblyInfo.cs
+++ b/src/CommandWireSample/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("CommandWireSample")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("CommandWireSample")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("73d8fa4d-bb98-49a8-91b6-51d91f281027")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/CommandWireSample/packages.config
+++ b/src/CommandWireSample/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NServiceBus" version="6.0.0" targetFramework="net452" />
+</packages>

--- a/src/NServiceBus.RabbitMQ.AcceptanceTests/App_Packages/NSB.AcceptanceTests.6.0.0/Audit/When_auditing.cs
+++ b/src/NServiceBus.RabbitMQ.AcceptanceTests/App_Packages/NSB.AcceptanceTests.6.0.0/Audit/When_auditing.cs
@@ -14,7 +14,7 @@
         {
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<EndpointWithAuditOff>(b => b.When(session => session.SendLocal(new MessageToBeAudited())))
-                .WithEndpoint<EndpointThatHandlesAuditMessages>()
+                .WithEndpoint<AuditSpyEndpoint>()
                 .Done(c => c.IsMessageHandlingComplete)
                 .Run();
 
@@ -26,7 +26,7 @@
         {
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<EndpointWithAuditOn>(b => b.When(session => session.SendLocal(new MessageToBeAudited())))
-                .WithEndpoint<EndpointThatHandlesAuditMessages>()
+                .WithEndpoint<AuditSpyEndpoint>()
                 .Done(c => c.IsMessageHandlingComplete && c.IsMessageHandledByTheAuditEndpoint)
                 .Run();
 
@@ -47,7 +47,7 @@
                 // even though the user has specified audit config, because auditing is explicitly turned
                 // off, no messages should be audited.
                 EndpointSetup<DefaultServer>(c => c.DisableFeature<Audit>())
-                    .AuditTo<EndpointThatHandlesAuditMessages>();
+                    .AuditTo<AuditSpyEndpoint>();
             }
 
             class MessageToBeAuditedHandler : IHandleMessages<MessageToBeAudited>
@@ -67,7 +67,7 @@
             public EndpointWithAuditOn()
             {
                 EndpointSetup<DefaultServer>()
-                    .AuditTo<EndpointThatHandlesAuditMessages>();
+                    .AuditTo<AuditSpyEndpoint>();
             }
 
             class MessageToBeAuditedHandler : IHandleMessages<MessageToBeAudited>
@@ -82,9 +82,9 @@
             }
         }
 
-        public class EndpointThatHandlesAuditMessages : EndpointConfigurationBuilder
+        public class AuditSpyEndpoint : EndpointConfigurationBuilder
         {
-            public EndpointThatHandlesAuditMessages()
+            public AuditSpyEndpoint()
             {
                 EndpointSetup<DefaultServer>();
             }

--- a/src/NServiceBus.RabbitMQ.AcceptanceTests/ConfigureEndpointRabbitMQTransport.cs
+++ b/src/NServiceBus.RabbitMQ.AcceptanceTests/ConfigureEndpointRabbitMQTransport.cs
@@ -25,8 +25,12 @@ class ConfigureEndpointRabbitMQTransport : IConfigureEndpointTestExecution
     public Task Configure(string endpointName, EndpointConfiguration configuration, RunSettings settings)
     {
         connectionString = settings.Get<string>("Transport.ConnectionString");
-        configuration.UseTransport<RabbitMQTransport>().ConnectionString(connectionString).UseAutomaticRoutingTopology();
+        var transport = configuration.UseTransport<RabbitMQTransport>().ConnectionString(connectionString);
 
+        if (!endpointName.Contains("AuditSpyEndpoint"))
+        {
+            transport.UseAutomaticRoutingTopology();
+        }
         return TaskEx.CompletedTask;
     }
 

--- a/src/NServiceBus.RabbitMQ.AcceptanceTests/ConfigureEndpointRabbitMQTransport.cs
+++ b/src/NServiceBus.RabbitMQ.AcceptanceTests/ConfigureEndpointRabbitMQTransport.cs
@@ -25,7 +25,7 @@ class ConfigureEndpointRabbitMQTransport : IConfigureEndpointTestExecution
     public Task Configure(string endpointName, EndpointConfiguration configuration, RunSettings settings)
     {
         connectionString = settings.Get<string>("Transport.ConnectionString");
-        configuration.UseTransport<RabbitMQTransport>().ConnectionString(connectionString);
+        configuration.UseTransport<RabbitMQTransport>().ConnectionString(connectionString).UseAutomaticRoutingTopology();
 
         return TaskEx.CompletedTask;
     }

--- a/src/NServiceBus.RabbitMQ.sln
+++ b/src/NServiceBus.RabbitMQ.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus.RabbitMQ", "NServiceBus.RabbitMQ\NServiceBus.RabbitMQ.csproj", "{BA731749-22C7-4025-8A4D-465AE8E02E61}"
 EndProject
@@ -20,6 +20,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus.RabbitMQ.Tests", "NServiceBus.RabbitMQ.Tests\NServiceBus.RabbitMQ.Tests.csproj", "{8B773CFD-E0F8-402F-AABC-04580289C76A}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus.Transport.RabbitMQ.TransportTests", "NServiceBus.Transport.RabbitMQ.TransportTests\NServiceBus.Transport.RabbitMQ.TransportTests.csproj", "{8FF5D995-D13A-479E-98A2-4915AC1573DE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CommandWireSample", "CommandWireSample\CommandWireSample.csproj", "{73D8FA4D-BB98-49A8-91B6-51D91F281027}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -43,6 +45,10 @@ Global
 		{8FF5D995-D13A-479E-98A2-4915AC1573DE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8FF5D995-D13A-479E-98A2-4915AC1573DE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8FF5D995-D13A-479E-98A2-4915AC1573DE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{73D8FA4D-BB98-49A8-91B6-51D91F281027}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{73D8FA4D-BB98-49A8-91B6-51D91F281027}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{73D8FA4D-BB98-49A8-91B6-51D91F281027}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{73D8FA4D-BB98-49A8-91B6-51D91F281027}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/NServiceBus.RabbitMQ/Administration/QueueCreator.cs
+++ b/src/NServiceBus.RabbitMQ/Administration/QueueCreator.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.Transport.RabbitMQ
 {
     using System.Threading.Tasks;
-    using global::RabbitMQ.Client;
 
     class QueueCreator : ICreateQueues
     {
@@ -27,13 +26,6 @@
             {
                 CreateQueueIfNecessary(sendingAddress);
             }
-
-            using (var connection = connectionFactory.CreateAdministrationConnection())
-            using (var channel = connection.CreateModel())
-            {
-                channel.ExchangeDeclare("Commands", "headers", true);
-            }
-
             return TaskEx.CompletedTask;
         }
 

--- a/src/NServiceBus.RabbitMQ/Administration/QueueCreator.cs
+++ b/src/NServiceBus.RabbitMQ/Administration/QueueCreator.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Transport.RabbitMQ
 {
     using System.Threading.Tasks;
+    using global::RabbitMQ.Client;
 
     class QueueCreator : ICreateQueues
     {
@@ -25,6 +26,12 @@
             foreach (var sendingAddress in queueBindings.SendingAddresses)
             {
                 CreateQueueIfNecessary(sendingAddress);
+            }
+
+            using (var connection = connectionFactory.CreateAdministrationConnection())
+            using (var channel = connection.CreateModel())
+            {
+                channel.ExchangeDeclare("Commands", "headers", true);
             }
 
             return TaskEx.CompletedTask;

--- a/src/NServiceBus.RabbitMQ/Configuration/RabbitMQTransportSettingsExtensions.cs
+++ b/src/NServiceBus.RabbitMQ/Configuration/RabbitMQTransportSettingsExtensions.cs
@@ -40,8 +40,12 @@
         /// <param name="transportExtensions"></param>
         public static TransportExtensions<RabbitMQTransport> UseAutomaticRoutingTopology(this TransportExtensions<RabbitMQTransport> transportExtensions)
         {
-            transportExtensions.GetSettings().EnableFeatureByDefault<AutomaticRoutingTopologyFeature>();
-            transportExtensions.GetSettings().Set<IRoutingTopology>(new AutomaticRoutingTopology());
+            var settings = transportExtensions.GetSettings();
+
+            settings.EnableFeatureByDefault<AutomaticRoutingTopologyFeature>();
+            settings.Set<IRoutingTopology>(new AutomaticRoutingTopology(settings));
+            //Disable default autosubscribe feature
+            settings.Set(typeof(AutoSubscribe).FullName, FeatureState.Disabled);
             return transportExtensions;
         }
 

--- a/src/NServiceBus.RabbitMQ/Configuration/RabbitMQTransportSettingsExtensions.cs
+++ b/src/NServiceBus.RabbitMQ/Configuration/RabbitMQTransportSettingsExtensions.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using Configuration.AdvanceExtensibility;
+    using Features;
     using RabbitMQ.Client.Events;
     using Transport.RabbitMQ;
 
@@ -30,6 +31,17 @@
 
             transportExtensions.GetSettings().Set<DirectRoutingTopology.Conventions>(new DirectRoutingTopology.Conventions(exchangeNameConvention, routingKeyConvention));
 
+            return transportExtensions;
+        }
+
+        /// <summary>
+        /// Uses the automatic routing topology with the specified conventions.
+        /// </summary>
+        /// <param name="transportExtensions"></param>
+        public static TransportExtensions<RabbitMQTransport> UseAutomaticRoutingTopology(this TransportExtensions<RabbitMQTransport> transportExtensions)
+        {
+            transportExtensions.GetSettings().EnableFeatureByDefault<AutomaticRoutingTopologyFeature>();
+            transportExtensions.GetSettings().Set<IRoutingTopology>(new AutomaticRoutingTopology());
             return transportExtensions;
         }
 

--- a/src/NServiceBus.RabbitMQ/Connection/ConfirmsAwareChannel.cs
+++ b/src/NServiceBus.RabbitMQ/Connection/ConfirmsAwareChannel.cs
@@ -35,7 +35,7 @@ namespace NServiceBus.Transport.RabbitMQ
 
         public bool IsClosed => channel.IsClosed;
 
-        public Task SendMessage(string address, OutgoingMessage message, IBasicProperties properties)
+        public Task SendMessage(IOutgoingTransportOperation operation, IBasicProperties properties)
         {
             Task task;
 
@@ -49,12 +49,12 @@ namespace NServiceBus.Transport.RabbitMQ
                 task = TaskEx.CompletedTask;
             }
 
-            routingTopology.Send(channel, address, message, properties);
+            routingTopology.Send(channel, operation, properties);
 
             return task;
         }
 
-        public Task PublishMessage(Type type, OutgoingMessage message, IBasicProperties properties)
+        public Task PublishMessage(IOutgoingTransportOperation operation, IBasicProperties properties)
         {
             Task task;
 
@@ -68,7 +68,7 @@ namespace NServiceBus.Transport.RabbitMQ
                 task = TaskEx.CompletedTask;
             }
 
-            routingTopology.Publish(channel, type, message, properties);
+            routingTopology.Publish(channel, operation, properties);
 
             return task;
         }

--- a/src/NServiceBus.RabbitMQ/NServiceBus.RabbitMQ.csproj
+++ b/src/NServiceBus.RabbitMQ/NServiceBus.RabbitMQ.csproj
@@ -73,6 +73,7 @@
     <Reference Include="System.Data" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Routing\AutomaticRoutingTopologyFeature.cs" />
     <Compile Include="Connection\ChannelProvider.cs" />
     <Compile Include="Configuration\ObsoleteAppSettings.cs" />
     <Compile Include="Configuration\ConnectionStringParser.cs" />
@@ -82,6 +83,7 @@
     <Compile Include="Configuration\SettingsKeys.cs" />
     <Compile Include="Connection\ConfirmsAwareChannel.cs" />
     <Compile Include="Receiving\ModelExtensions.cs" />
+    <Compile Include="Routing\AutomaticRoutingTopology.cs" />
     <Compile Include="Routing\DefaultRoutingKeyConvention.cs" />
     <Compile Include="Configuration\ConnectionConfiguration.cs" />
     <Compile Include="Connection\ConnectionFactory.cs" />
@@ -91,6 +93,7 @@
     <Compile Include="obsoletes.cs" />
     <Compile Include="Administration\QueuePurger.cs" />
     <Compile Include="AssemblyInfo.cs" />
+    <Compile Include="Routing\MulticastSendRouterBehavior.cs" />
     <Compile Include="Sending\MessageDispatcher.cs" />
     <Compile Include="Administration\QueueCreator.cs" />
     <Compile Include="Administration\SubscriptionManager.cs" />

--- a/src/NServiceBus.RabbitMQ/RabbitMQTransport.cs
+++ b/src/NServiceBus.RabbitMQ/RabbitMQTransport.cs
@@ -15,7 +15,10 @@
         /// <param name="settings">An instance of the current settings.</param>
         /// <param name="connectionString">The connection string.</param>
         /// <returns>The supported factories.</returns>
-        public override TransportInfrastructure Initialize(SettingsHolder settings, string connectionString) => new RabbitMQTransportInfrastructure(settings, connectionString);
+        public override TransportInfrastructure Initialize(SettingsHolder settings, string connectionString)
+        {
+            return new RabbitMQTransportInfrastructure(settings, connectionString);
+        }
 
         /// <summary>
         /// Gets an example connection string to use when reporting the lack of a configured connection string to the user.

--- a/src/NServiceBus.RabbitMQ/RabbitMQTransportInfrastructure.cs
+++ b/src/NServiceBus.RabbitMQ/RabbitMQTransportInfrastructure.cs
@@ -52,7 +52,7 @@
         {
             return new TransportReceiveInfrastructure(
                     () => CreateMessagePump(),
-                    () => new QueueCreator(connectionFactory, routingTopology, settings.DurableMessagesEnabled()),
+                    () => new QueueCreator(connectionFactory, routingTopology, settings.DurableMessagesEnabled(), settings.LocalAddress()),
                     () => Task.FromResult(ObsoleteAppSettings.Check()));
         }
 

--- a/src/NServiceBus.RabbitMQ/RabbitMQTransportInfrastructure.cs
+++ b/src/NServiceBus.RabbitMQ/RabbitMQTransportInfrastructure.cs
@@ -40,9 +40,11 @@
 
         public override IEnumerable<Type> DeliveryConstraints => new[] { typeof(DiscardIfNotReceivedBefore), typeof(NonDurableDelivery) };
 
-        public override OutboundRoutingPolicy OutboundRoutingPolicy => new OutboundRoutingPolicy(OutboundRoutingType.Unicast, OutboundRoutingType.Multicast, OutboundRoutingType.Unicast);
+        public override OutboundRoutingPolicy OutboundRoutingPolicy => routingTopology.OutboundRoutingPolicy;
 
         public override TransportTransactionMode TransactionMode => TransportTransactionMode.ReceiveOnly;
+
+        public ConnectionFactory ConnectionFactory => connectionFactory;
 
         public override EndpointInstance BindToLocalEndpoint(EndpointInstance instance) => instance;
 
@@ -65,7 +67,7 @@
         {
             return new TransportSubscriptionInfrastructure(() => new SubscriptionManager(connectionFactory, routingTopology, settings.LocalAddress()));
         }
-
+        
         public override string ToTransportAddress(LogicalAddress logicalAddress)
         {
             var queue = new StringBuilder(logicalAddress.EndpointInstance.Endpoint);

--- a/src/NServiceBus.RabbitMQ/Routing/AutomaticRoutingTopology.cs
+++ b/src/NServiceBus.RabbitMQ/Routing/AutomaticRoutingTopology.cs
@@ -33,12 +33,12 @@
 
         public void SetupSubscription(IModel channel, Type type, string subscriberName)
         {
-            throw new Exception("Manual subscribing is not allowed in automatic routing topology.");
+            //throw new Exception("Manual subscribing is not allowed in automatic routing topology.");
         }
 
         public void TeardownSubscription(IModel channel, Type type, string subscriberName)
         {
-            throw new Exception("Manual unsubscribing is not allowed in automatic routing topology.");
+            //throw new Exception("Manual unsubscribing is not allowed in automatic routing topology.");
         }
 
         public void Publish(IModel channel, IOutgoingTransportOperation operation, IBasicProperties properties)

--- a/src/NServiceBus.RabbitMQ/Routing/AutomaticRoutingTopologyFeature.cs
+++ b/src/NServiceBus.RabbitMQ/Routing/AutomaticRoutingTopologyFeature.cs
@@ -25,7 +25,7 @@
             var topology = (AutomaticRoutingTopology) context.Settings.Get<IRoutingTopology>();
             var transportInfrastructure = (RabbitMQTransportInfrastructure)context.Settings.Get<TransportInfrastructure>();
 
-            context.Pipeline.Replace("UnicastSendRouterConnector", new MulticastSendRouterConnector());
+            context.Pipeline.Replace("UnicastSendRouterConnector", new MulticastSendRouterConnector(context.Settings.LocalAddress()));
             if (!context.Settings.GetOrDefault<bool>("Endpoint.SendOnly"))
             {
                 context.RegisterStartupTask(b =>

--- a/src/NServiceBus.RabbitMQ/Routing/AutomaticRoutingTopologyFeature.cs
+++ b/src/NServiceBus.RabbitMQ/Routing/AutomaticRoutingTopologyFeature.cs
@@ -1,0 +1,94 @@
+﻿namespace NServiceBus
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Features;
+    using RabbitMQ.Client;
+    using Transport;
+    using Transport.RabbitMQ;
+    using Unicast;
+    using ConnectionFactory = Transport.RabbitMQ.ConnectionFactory;
+
+    class AutomaticRoutingTopologyFeature : Feature
+    {
+        protected override void Setup(FeatureConfigurationContext context)
+        {
+            var conventions = context.Settings.Get<Conventions>();
+            var transportInfrastructure = (RabbitMQTransportInfrastructure)context.Settings.Get<TransportInfrastructure>();
+
+            context.Pipeline.Replace("UnicastSendRouterConnector", new MulticastSendRouterConnector());
+
+            context.RegisterStartupTask(b =>
+            {
+                var handlerRegistry = b.Build<MessageHandlerRegistry>();
+                var messageTypesHandled = GetMessageTypesHandledByThisEndpoint(handlerRegistry, conventions);
+                return new ApplyBindings(transportInfrastructure.ConnectionFactory, context.Settings.LocalAddress(), messageTypesHandled);
+            });
+        }
+
+        static List<Type> GetMessageTypesHandledByThisEndpoint(MessageHandlerRegistry handlerRegistry, Conventions conventions)
+        {
+            var messageTypesHandled = handlerRegistry.GetMessageTypes() //get all potential messages
+                .Where(t => !conventions.IsInSystemConventionList(t)) //never auto-wire system messages
+                .Where(t => !conventions.IsEventType(t)) //events should not be wired this way
+                .ToList();
+
+            return messageTypesHandled;
+        }
+
+        class ApplyBindings : FeatureStartupTask
+        {
+            public ApplyBindings(ConnectionFactory connectionFactory, string inputQueue, IEnumerable<Type> messagesHandledByThisEndpoint)
+            {
+                this.connectionFactory = connectionFactory;
+                this.inputQueue = inputQueue;
+                this.messagesHandledByThisEndpoint = messagesHandledByThisEndpoint;
+            }
+
+            protected override Task OnStart(IMessageSession session)
+            {
+                var detourExchangeName = $"Commands-{inputQueue}-{Guid.NewGuid()}";
+                var localFanoutExchange = $"Commands-{inputQueue}";
+
+                using (var connection = connectionFactory.CreateAdministrationConnection())
+                using (var channel = connection.CreateModel())
+                {
+                    channel.ExchangeDeclare(detourExchangeName, "fanout", true);
+                    channel.QueueBind(inputQueue, detourExchangeName, string.Empty);
+                    BindMessageTypes(channel, detourExchangeName);
+
+                    channel.ExchangeDelete(localFanoutExchange);
+                    channel.ExchangeDeclare(localFanoutExchange, "fanout", true);
+                    channel.QueueBind(inputQueue, localFanoutExchange, string.Empty);
+                    BindMessageTypes(channel, localFanoutExchange);
+
+                    channel.ExchangeDelete(detourExchangeName);
+                }
+                return Task.FromResult(0);
+            }
+
+            void BindMessageTypes(IModel channel, string localFanoutExchange)
+            {
+                foreach (var type in messagesHandledByThisEndpoint)
+                {
+                    var arguments = new Dictionary<string, object>
+                    {
+                        ["Type"] = type.AssemblyQualifiedName
+                    };
+                    channel.ExchangeBind(localFanoutExchange, "Commands", string.Empty, arguments);
+                }
+            }
+
+            protected override Task OnStop(IMessageSession session)
+            {
+                return TaskEx.CompletedTask;
+            }
+
+            ConnectionFactory connectionFactory;
+            string inputQueue;
+            IEnumerable<Type> messagesHandledByThisEndpoint;
+        }
+    }
+}

--- a/src/NServiceBus.RabbitMQ/Routing/ConventionalRoutingTopology.cs
+++ b/src/NServiceBus.RabbitMQ/Routing/ConventionalRoutingTopology.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Concurrent;
+    using System.Collections.Generic;
     using global::RabbitMQ.Client;
 
     /// <summary>

--- a/src/NServiceBus.RabbitMQ/Routing/ConventionalRoutingTopology.cs
+++ b/src/NServiceBus.RabbitMQ/Routing/ConventionalRoutingTopology.cs
@@ -68,7 +68,7 @@
 
             channel.BasicPublish(op.Destination, String.Empty, true, properties, op.Message.Body);
         }
-
+        
         public void RawSendInCaseOfFailure(IModel channel, string address, byte[] body, IBasicProperties properties)
         {
             channel.BasicPublish(address, String.Empty, true, properties, body);

--- a/src/NServiceBus.RabbitMQ/Routing/DirectRoutingTopology.cs
+++ b/src/NServiceBus.RabbitMQ/Routing/DirectRoutingTopology.cs
@@ -38,7 +38,7 @@
 
             channel.BasicPublish(string.Empty, op.Destination, true, properties, op.Message.Body);
         }
-
+        
         public void RawSendInCaseOfFailure(IModel channel, string address, byte[] body, IBasicProperties properties)
         {
             channel.BasicPublish(string.Empty, address, true, properties, body);

--- a/src/NServiceBus.RabbitMQ/Routing/DirectRoutingTopology.cs
+++ b/src/NServiceBus.RabbitMQ/Routing/DirectRoutingTopology.cs
@@ -25,14 +25,18 @@
             channel.QueueUnbind(subscriberName, ExchangeName(), GetRoutingKeyForBinding(type), null);
         }
 
-        public void Publish(IModel channel, Type type, OutgoingMessage message, IBasicProperties properties)
+        public void Publish(IModel channel, IOutgoingTransportOperation operation, IBasicProperties properties)
         {
-            channel.BasicPublish(ExchangeName(), GetRoutingKeyForPublish(type), false, properties, message.Body);
+            var op = (MulticastTransportOperation)operation;
+
+            channel.BasicPublish(ExchangeName(), GetRoutingKeyForPublish(op.MessageType), false, properties, op.Message.Body);
         }
 
-        public void Send(IModel channel, string address, OutgoingMessage message, IBasicProperties properties)
+        public void Send(IModel channel, IOutgoingTransportOperation operation, IBasicProperties properties)
         {
-            channel.BasicPublish(string.Empty, address, true, properties, message.Body);
+            var op = (UnicastTransportOperation)operation;
+
+            channel.BasicPublish(string.Empty, op.Destination, true, properties, op.Message.Body);
         }
 
         public void RawSendInCaseOfFailure(IModel channel, string address, byte[] body, IBasicProperties properties)
@@ -44,6 +48,8 @@
         {
             //nothing needs to be done for direct routing
         }
+
+        public OutboundRoutingPolicy OutboundRoutingPolicy => new OutboundRoutingPolicy(OutboundRoutingType.Unicast, OutboundRoutingType.Multicast, OutboundRoutingType.Unicast);
 
         string ExchangeName() => conventions.ExchangeName(null, null);
 

--- a/src/NServiceBus.RabbitMQ/Routing/IRoutingTopology.cs
+++ b/src/NServiceBus.RabbitMQ/Routing/IRoutingTopology.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Transport.RabbitMQ
 {
     using System;
+    using System.Collections.Generic;
     using global::RabbitMQ.Client;
 
     /// <summary>

--- a/src/NServiceBus.RabbitMQ/Routing/IRoutingTopology.cs
+++ b/src/NServiceBus.RabbitMQ/Routing/IRoutingTopology.cs
@@ -28,19 +28,17 @@
         /// Publishes a message of the specified type.
         /// </summary>
         /// <param name="channel">The RabbitMQ channel to operate on.</param>
-        /// <param name="type">The type of the message to be published.</param>
-        /// <param name="message">The message to publish.</param>
+        /// <param name="operation">Transport operation.</param>
         /// <param name="properties">The RabbitMQ properties of the message to publish.</param>
-        void Publish(IModel channel, Type type, OutgoingMessage message, IBasicProperties properties);
+        void Publish(IModel channel, IOutgoingTransportOperation operation, IBasicProperties properties);
 
         /// <summary>
         /// Sends a message to the specified endpoint.
         /// </summary>
         /// <param name="channel">The RabbitMQ channel to operate on.</param>
-        /// <param name="address">The address of the destination endpoint.</param>
-        /// <param name="message">The message to send.</param>
+        /// <param name="operation">Transport operation.</param>
         /// <param name="properties">The RabbitMQ properties of the message to send.</param>
-        void Send(IModel channel, string address, OutgoingMessage message, IBasicProperties properties);
+        void Send(IModel channel, IOutgoingTransportOperation operation, IBasicProperties properties);
 
         /// <summary>
         /// Sends a raw message body to the specified endpoint.
@@ -57,5 +55,10 @@
         /// <param name="channel">The RabbitMQ channel to operate on.</param>
         /// <param name="main">The name of the queue to perform initialization on.</param>
         void Initialize(IModel channel, string main);
+
+        /// <summary>
+        /// Gets the outbound routing policy for this topology.
+        /// </summary>
+        OutboundRoutingPolicy OutboundRoutingPolicy { get; }
     }
 }

--- a/src/NServiceBus.RabbitMQ/Routing/IRoutingTopology.cs
+++ b/src/NServiceBus.RabbitMQ/Routing/IRoutingTopology.cs
@@ -39,7 +39,7 @@
         /// <param name="operation">Transport operation.</param>
         /// <param name="properties">The RabbitMQ properties of the message to send.</param>
         void Send(IModel channel, IOutgoingTransportOperation operation, IBasicProperties properties);
-
+        
         /// <summary>
         /// Sends a raw message body to the specified endpoint.
         /// </summary>

--- a/src/NServiceBus.RabbitMQ/Routing/MulticastSendRouterBehavior.cs
+++ b/src/NServiceBus.RabbitMQ/Routing/MulticastSendRouterBehavior.cs
@@ -1,0 +1,25 @@
+namespace NServiceBus
+{
+    using System;
+    using System.Threading.Tasks;
+    using Pipeline;
+    using Routing;
+
+    class MulticastSendRouterConnector : StageConnector<IOutgoingSendContext, IOutgoingLogicalMessageContext>
+    {
+        public override Task Invoke(IOutgoingSendContext context, Func<IOutgoingLogicalMessageContext, Task> stage)
+        {
+            context.Headers[Headers.MessageIntent] = MessageIntentEnum.Send.ToString();
+
+            var logicalMessageContext = this.CreateOutgoingLogicalMessageContext(
+                context.Message,
+                new[]
+                {
+                    new MulticastRoutingStrategy(context.Message.MessageType)
+                },
+                context);
+
+            return stage(logicalMessageContext);
+        }
+    }
+}

--- a/src/NServiceBus.RabbitMQ/Routing/MulticastSendRouterBehavior.cs
+++ b/src/NServiceBus.RabbitMQ/Routing/MulticastSendRouterBehavior.cs
@@ -15,7 +15,8 @@ namespace NServiceBus
                 context.Message,
                 new[]
                 {
-                    new MulticastRoutingStrategy(context.Message.MessageType)
+                    new UnicastRoutingStrategy($"#type:{context.Message.MessageType.FullName}")
+                    //new MulticastRoutingStrategy(context.Message.MessageType) //Hack that allow core TM to work
                 },
                 context);
 

--- a/src/NServiceBus.RabbitMQ/Routing/MulticastSendRouterBehavior.cs
+++ b/src/NServiceBus.RabbitMQ/Routing/MulticastSendRouterBehavior.cs
@@ -1,21 +1,58 @@
 namespace NServiceBus
 {
     using System;
+    using System.Reflection;
     using System.Threading.Tasks;
     using Pipeline;
     using Routing;
 
     class MulticastSendRouterConnector : StageConnector<IOutgoingSendContext, IOutgoingLogicalMessageContext>
     {
+        const string optionsTypeFullName = "NServiceBus.UnicastSendRouterConnector+State";
+
+        static Assembly coreAssembly = typeof(IEndpointInstance).Assembly;
+        static Type StateType = coreAssembly.GetType(optionsTypeFullName, true);
+        static PropertyInfo OptionProp = StateType.GetProperty("Option", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+        static PropertyInfo ExplicitDestinationProp = StateType.GetProperty("ExplicitDestination", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+        object[] emptyArgs = new object[0];
+
+        string localAddress;
+
+        public MulticastSendRouterConnector(string localAddress)
+        {
+            this.localAddress = localAddress;
+        }
+
         public override Task Invoke(IOutgoingSendContext context, Func<IOutgoingLogicalMessageContext, Task> stage)
         {
+            var destinationString = $"#type:{context.Message.MessageType.FullName}";
+
+            object opts;
+            var hasOptions = context.Extensions.TryGet(optionsTypeFullName, out opts);
+            if (hasOptions)
+            {
+                var option = OptionProp.GetValue(opts, emptyArgs).ToString();
+                if (option == "ExplicitDestination")
+                {
+                    destinationString = (string)ExplicitDestinationProp.GetValue(opts, emptyArgs);
+                }
+                else if (option == "RouteToAnyInstanceOfThisEndpoint")
+                {
+                    destinationString = localAddress;
+                }
+                else
+                {
+                    throw new Exception("Unsupported option: " + option);
+                }
+            }
+
             context.Headers[Headers.MessageIntent] = MessageIntentEnum.Send.ToString();
 
             var logicalMessageContext = this.CreateOutgoingLogicalMessageContext(
                 context.Message,
                 new[]
                 {
-                    new UnicastRoutingStrategy($"#type:{context.Message.MessageType.FullName}")
+                    new UnicastRoutingStrategy(destinationString)
                     //new MulticastRoutingStrategy(context.Message.MessageType) //Hack that allow core TM to work
                 },
                 context);

--- a/src/NServiceBus.RabbitMQ/Sending/MessageDispatcher.cs
+++ b/src/NServiceBus.RabbitMQ/Sending/MessageDispatcher.cs
@@ -8,7 +8,6 @@
     class MessageDispatcher : IDispatchMessages
     {
         readonly IChannelProvider channelProvider;
-        static readonly string SendIntent = MessageIntentEnum.Send.ToString();
         static readonly string PublishIntent = MessageIntentEnum.Publish.ToString();
 
         public MessageDispatcher(IChannelProvider channelProvider)
@@ -47,13 +46,13 @@
         void SendOrPublish(IOutgoingTransportOperation operation, List<Task> tasks, ConfirmsAwareChannel channel)
         {
             var intentHeader = operation.Message.Headers[Headers.MessageIntent];
-            if (intentHeader.Equals(SendIntent, StringComparison.Ordinal))
-            {
-                tasks.Add(SendMessage(operation, channel));
-            }
-            else if (intentHeader.Equals(PublishIntent, StringComparison.Ordinal))
+            if (intentHeader.Equals(PublishIntent, StringComparison.Ordinal))
             {
                 tasks.Add(PublishMessage(operation, channel));
+            }
+            else
+            {
+                tasks.Add(SendMessage(operation, channel));
             }
         }
 


### PR DESCRIPTION
Connects to https://github.com/Particular/PlatformDevelopment/issues/980

Adds another toplogy that enables configuration-free command routing
- Commands are routed to the endpoints that have handlers for them
- Command inheritence is not supported :-(
- When an endpoint is re-deployed without a handler for a given command, the routing is automatically adjusted to not route that command any more
- When there is an endpoint that "claimed" a given command, no other endpoint can define a route for it, preventing commands to be routed to multiple endpoints
- When there is no endpoint handling a given command, the sender gets an exception when sending (preventing message loss)
### Topology

![native command routing](https://cloud.githubusercontent.com/assets/163318/19387642/d7d5aef4-921b-11e6-978f-c7acc440cd0d.png)

There is a global `Commands` exchange that is used to publish all commands. Each handling endpoints creates its own `Commands-{endpointName}` exchange which is used to configure its routing. When the endpoints starts up, it creates a "detour" exchange which allows it to drop and re-create the  `Commands-{endpointName}` without missing a message. Re-creating this exchange drops all the bindings thus if a given message is no longer handled, the binding is removed. The `{commandType}` exchange is used to ensure that only one endpoint can handle a given type of command. When creating it, the endpoint sets the `alternate-exchange` property to its `/dev/null` fanout exchange. When another endpoint wants to create an exchange for the same command type using its `/dev/null` fanout exchange, it gets an exception.
### TODO
- [x] Change the subscription logic to also go through additional endpoint to allow graceful unsubscribing when an endpoint no longer has a handler for a given event
- [ ] Automatically re-route commands to proper destinations when a handler has been removed
