### PR TITLE
Create IRoutingTopology with factory delegate

### DIFF
--- a/src/NServiceBus.RabbitMQ.Tests/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.RabbitMQ.Tests/APIApprovals.Approve.approved.txt
@@ -26,6 +26,11 @@ namespace NServiceBus
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> UseConnectionManager<T>(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions) { }
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> UseDirectRoutingTopology(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions, System.Func<System.Type, string> routingKeyConvention = null, System.Func<string, System.Type, string> exchangeNameConvention = null) { }
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> UsePublisherConfirms(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions, bool usePublisherConfirms) { }
+        public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> UseRoutingTopology(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions, System.Func<bool, NServiceBus.Transport.RabbitMQ.IRoutingTopology> topologyFactory) { }
+        [System.ObsoleteAttribute("Use `RabbitMQTransportSettingsExtensions.UseRoutingTopology(TransportExtensions<R" +
+            "abbitMQTransport> transportExtensions, Func<bool, IRoutingTopology>)` instead. W" +
+            "ill be treated as an error from version 5.0.0. Will be removed in version 6.0.0." +
+            "", false)]
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> UseRoutingTopology<T>(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions)
             where T : NServiceBus.Transport.RabbitMQ.IRoutingTopology, new () { }
     }

--- a/src/NServiceBus.RabbitMQ/Configuration/RabbitMQTransportSettingsExtensions.cs
+++ b/src/NServiceBus.RabbitMQ/Configuration/RabbitMQTransportSettingsExtensions.cs
@@ -11,6 +11,17 @@
     public static partial class RabbitMQTransportSettingsExtensions
     {
         /// <summary>
+        /// Registers a custom routing topology.
+        /// </summary>
+        /// <param name="transportExtensions"></param>
+        /// <param name="topologyFactory">The function used to create the routing topology instance. The parameter of the function indicates whether exchanges and queues declared by the routing topology should be durable.</param>
+        public static TransportExtensions<RabbitMQTransport> UseRoutingTopology(this TransportExtensions<RabbitMQTransport> transportExtensions, Func<bool, IRoutingTopology> topologyFactory)
+        {
+            transportExtensions.GetSettings().Set<Func<bool, IRoutingTopology>>(topologyFactory);
+            return transportExtensions;
+        }
+
+        /// <summary>
         /// Uses the direct routing topology with the specified conventions.
         /// </summary>
         /// <param name="transportExtensions"></param>
@@ -28,7 +39,7 @@
                 exchangeNameConvention = (address, eventType) => "amq.topic";
             }
 
-            transportExtensions.GetSettings().Set<DirectRoutingTopology.Conventions>(new DirectRoutingTopology.Conventions(exchangeNameConvention, routingKeyConvention));
+            transportExtensions.UseRoutingTopology(durable => new DirectRoutingTopology(new DirectRoutingTopology.Conventions(exchangeNameConvention, routingKeyConvention), durable));
 
             return transportExtensions;
         }
@@ -36,9 +47,10 @@
         /// <summary>
         /// Registers a custom routing topology.
         /// </summary>
+        [ObsoleteEx(RemoveInVersion = "6.0", TreatAsErrorFromVersion = "5.0", ReplacementTypeOrMember = "RabbitMQTransportSettingsExtensions.UseRoutingTopology(TransportExtensions<RabbitMQTransport> transportExtensions, Func<bool, IRoutingTopology>)")]
         public static TransportExtensions<RabbitMQTransport> UseRoutingTopology<T>(this TransportExtensions<RabbitMQTransport> transportExtensions) where T : IRoutingTopology, new()
         {
-            transportExtensions.GetSettings().Set<IRoutingTopology>(new T());
+            transportExtensions.UseRoutingTopology(durable => new T());
             return transportExtensions;
         }
 


### PR DESCRIPTION
This adds a `UseRoutingTopology` overload that accepts a factory delegate in order to allow creating instances with a non-default constructor.

The original `UseRoutingTopology` method and `UseDirectRoutingTopology` have been reimplemented using the new factory approach. The original `UseRoutingTopology` method should be obsoleted on the next major release.

Since both `ConventionalRoutingTopology` and `DirectRoutingTopology` receive `useDurableExchanges` in their constructors, the factory delegate also passes this in. External implementations should now be at feature parity with our internal topologies.

The routing topology creation  in `RabbitMQTransportInfrastructure` has been updated and simplified as part of this as well.

This addresses the concern raised in https://github.com/Particular/NServiceBus.RabbitMQ/issues/248#issuecomment-254238054 by @volak.