### PR TITLE
[SPIKE] move queue declare to topology (breaking)

### DIFF
--- a/src/NServiceBus.RabbitMQ.Tests/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.RabbitMQ.Tests/APIApprovals.Approve.approved.txt
@@ -39,7 +39,7 @@ namespace NServiceBus.Transport.RabbitMQ
 {
     public interface IRoutingTopology
     {
-        void Initialize(RabbitMQ.Client.IModel channel, string main);
+        void Initialize(RabbitMQ.Client.IModel channel, System.Collections.Generic.IEnumerable<string> addresses);
         void Publish(RabbitMQ.Client.IModel channel, System.Type type, NServiceBus.Transport.OutgoingMessage message, RabbitMQ.Client.IBasicProperties properties);
         void RawSendInCaseOfFailure(RabbitMQ.Client.IModel channel, string address, byte[] body, RabbitMQ.Client.IBasicProperties properties);
         void Send(RabbitMQ.Client.IModel channel, string address, NServiceBus.Transport.OutgoingMessage message, RabbitMQ.Client.IBasicProperties properties);

--- a/src/NServiceBus.RabbitMQ.Tests/RabbitMqContext.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/RabbitMqContext.cs
@@ -20,7 +20,7 @@
                 //to make sure we kill old subscriptions
                 DeleteExchange(queueName);
 
-                routingTopology.Initialize(channel, queueName);
+                routingTopology.Initialize(channel, new[] { queueName });
             }
         }
 

--- a/src/NServiceBus.RabbitMQ/Administration/QueueCreator.cs
+++ b/src/NServiceBus.RabbitMQ/Administration/QueueCreator.cs
@@ -1,19 +1,17 @@
 ﻿namespace NServiceBus.Transport.RabbitMQ
 {
+    using System.Linq;
     using System.Threading.Tasks;
-    using global::RabbitMQ.Client;
 
     class QueueCreator : ICreateQueues
     {
         readonly ConnectionFactory connectionFactory;
         readonly IRoutingTopology routingTopology;
-        readonly bool durableMessagesEnabled;
 
-        public QueueCreator(ConnectionFactory connectionFactory, IRoutingTopology routingTopology, bool durableMessagesEnabled)
+        public QueueCreator(ConnectionFactory connectionFactory, IRoutingTopology routingTopology)
         {
             this.connectionFactory = connectionFactory;
             this.routingTopology = routingTopology;
-            this.durableMessagesEnabled = durableMessagesEnabled;
         }
 
         public Task CreateQueueIfNecessary(QueueBindings queueBindings, string identity)
@@ -21,25 +19,10 @@
             using (var connection = connectionFactory.CreateAdministrationConnection())
             using (var channel = connection.CreateModel())
             {
-                foreach (var receivingAddress in queueBindings.ReceivingAddresses)
-                {
-                    CreateQueueIfNecessary(channel, receivingAddress);
-                }
-
-                foreach (var sendingAddress in queueBindings.SendingAddresses)
-                {
-                    CreateQueueIfNecessary(channel, sendingAddress);
-                }
+                routingTopology.Initialize(channel, queueBindings.ReceivingAddresses.Concat(queueBindings.SendingAddresses));
             }
 
             return TaskEx.CompletedTask;
-        }
-
-        void CreateQueueIfNecessary(IModel channel, string receivingAddress)
-        {
-            channel.QueueDeclare(receivingAddress, durableMessagesEnabled, false, false, null);
-
-            routingTopology.Initialize(channel, receivingAddress);
         }
     }
 }

--- a/src/NServiceBus.RabbitMQ/RabbitMQTransportInfrastructure.cs
+++ b/src/NServiceBus.RabbitMQ/RabbitMQTransportInfrastructure.cs
@@ -50,7 +50,7 @@
         {
             return new TransportReceiveInfrastructure(
                     () => CreateMessagePump(),
-                    () => new QueueCreator(connectionFactory, routingTopology, settings.DurableMessagesEnabled()),
+                    () => new QueueCreator(connectionFactory, routingTopology),
                     () => Task.FromResult(ObsoleteAppSettings.Check()));
         }
 

--- a/src/NServiceBus.RabbitMQ/Routing/ConventionalRoutingTopology.cs
+++ b/src/NServiceBus.RabbitMQ/Routing/ConventionalRoutingTopology.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Concurrent;
+    using System.Collections.Generic;
     using global::RabbitMQ.Client;
 
     /// <summary>
@@ -70,10 +71,14 @@
             channel.BasicPublish(address, String.Empty, true, properties, body);
         }
 
-        public void Initialize(IModel channel, string mainQueue)
+        public void Initialize(IModel channel, IEnumerable<string> addresses)
         {
-            CreateExchange(channel, mainQueue);
-            channel.QueueBind(mainQueue, mainQueue, string.Empty);
+            foreach(var address in addresses)
+            {
+                channel.QueueDeclare(address, useDurableExchanges, false, false, null);
+                CreateExchange(channel, address);
+                channel.QueueBind(address, address, string.Empty);
+            }
         }
 
         static string ExchangeName(Type type) => type.Namespace + ":" + type.Name;

--- a/src/NServiceBus.RabbitMQ/Routing/DirectRoutingTopology.cs
+++ b/src/NServiceBus.RabbitMQ/Routing/DirectRoutingTopology.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Transport.RabbitMQ
 {
     using System;
+    using System.Collections.Generic;
     using global::RabbitMQ.Client;
 
     /// <summary>
@@ -40,9 +41,12 @@
             channel.BasicPublish(string.Empty, address, true, properties, body);
         }
 
-        public void Initialize(IModel channel, string main)
+        public void Initialize(IModel channel, IEnumerable<string> addresses)
         {
-            //nothing needs to be done for direct routing
+            foreach (var address in addresses)
+            {
+                channel.QueueDeclare(address, useDurableExchanges, false, false, null);
+            }
         }
 
         string ExchangeName() => conventions.ExchangeName(null, null);

--- a/src/NServiceBus.RabbitMQ/Routing/IRoutingTopology.cs
+++ b/src/NServiceBus.RabbitMQ/Routing/IRoutingTopology.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Transport.RabbitMQ
 {
     using System;
+    using System.Collections.Generic;
     using global::RabbitMQ.Client;
 
     /// <summary>
@@ -52,10 +53,10 @@
         void RawSendInCaseOfFailure(IModel channel, string address, byte[] body, IBasicProperties properties);
 
         /// <summary>
-        /// Performs any initialization logic needed (e.g., creating exchanges and bindings).
+        /// Performs any initialization logic needed (e.g., creating queues, exchanges and bindings).
         /// </summary>
         /// <param name="channel">The RabbitMQ channel to operate on.</param>
-        /// <param name="main">The name of the queue to perform initialization on.</param>
-        void Initialize(IModel channel, string main);
+        /// <param name="addresses">The addresses of the queues to perform initialization on.</param>
+        void Initialize(IModel channel, IEnumerable<string> addresses);
     }
 }


### PR DESCRIPTION
As a reference point, this is how moving queue declare to the routing topologies could look if we didn't mind the breaking change to `IRoutingTopology`.

Connects to #248.