### PR TITLE
[SPIKE] move queue declare to topology (non-breaking)

### DIFF
--- a/src/NServiceBus.RabbitMQ.Tests/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.RabbitMQ.Tests/APIApprovals.Approve.approved.txt
@@ -26,7 +26,12 @@ namespace NServiceBus
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> UseConnectionManager<T>(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions) { }
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> UseDirectRoutingTopology(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions, System.Func<System.Type, string> routingKeyConvention = null, System.Func<string, System.Type, string> exchangeNameConvention = null) { }
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> UsePublisherConfirms(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions, bool usePublisherConfirms) { }
+        [System.ObsoleteAttribute("Use `RabbitMQTransportSettingsExtensions.UseRoutingTopology(TransportExtensions<R" +
+            "abbitMQTransport> transportExtensions, Func<bool, IRoutingTopology2>)` instead. " +
+            "Will be treated as an error from version 5.0.0. Will be removed in version 6.0.0" +
+            ".", false)]
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> UseRoutingTopology(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions, System.Func<bool, NServiceBus.Transport.RabbitMQ.IRoutingTopology> topologyFactory) { }
+        public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> UseRoutingTopology(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions, System.Func<bool, NServiceBus.Transport.RabbitMQ.IRoutingTopology2> topologyFactory) { }
         [System.ObsoleteAttribute("Use `RabbitMQTransportSettingsExtensions.UseRoutingTopology(TransportExtensions<R" +
             "abbitMQTransport> transportExtensions, Func<bool, IRoutingTopology>)` instead. W" +
             "ill be treated as an error from version 5.0.0. Will be removed in version 6.0.0." +
@@ -37,9 +42,20 @@ namespace NServiceBus
 }
 namespace NServiceBus.Transport.RabbitMQ
 {
+    [System.ObsoleteAttribute("Use `IRoutingTopology2` instead. Will be treated as an error from version 5.0.0. " +
+        "Will be removed in version 6.0.0.", false)]
     public interface IRoutingTopology
     {
         void Initialize(RabbitMQ.Client.IModel channel, string main);
+        void Publish(RabbitMQ.Client.IModel channel, System.Type type, NServiceBus.Transport.OutgoingMessage message, RabbitMQ.Client.IBasicProperties properties);
+        void RawSendInCaseOfFailure(RabbitMQ.Client.IModel channel, string address, byte[] body, RabbitMQ.Client.IBasicProperties properties);
+        void Send(RabbitMQ.Client.IModel channel, string address, NServiceBus.Transport.OutgoingMessage message, RabbitMQ.Client.IBasicProperties properties);
+        void SetupSubscription(RabbitMQ.Client.IModel channel, System.Type type, string subscriberName);
+        void TeardownSubscription(RabbitMQ.Client.IModel channel, System.Type type, string subscriberName);
+    }
+    public interface IRoutingTopology2
+    {
+        void Initialize(RabbitMQ.Client.IModel channel, System.Collections.Generic.IEnumerable<string> addresses);
         void Publish(RabbitMQ.Client.IModel channel, System.Type type, NServiceBus.Transport.OutgoingMessage message, RabbitMQ.Client.IBasicProperties properties);
         void RawSendInCaseOfFailure(RabbitMQ.Client.IModel channel, string address, byte[] body, RabbitMQ.Client.IBasicProperties properties);
         void Send(RabbitMQ.Client.IModel channel, string address, NServiceBus.Transport.OutgoingMessage message, RabbitMQ.Client.IBasicProperties properties);

--- a/src/NServiceBus.RabbitMQ.Tests/RabbitMqContext.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/RabbitMqContext.cs
@@ -20,7 +20,7 @@
                 //to make sure we kill old subscriptions
                 DeleteExchange(queueName);
 
-                routingTopology.Initialize(channel, queueName);
+                routingTopology.Initialize(channel, new[] { queueName });
             }
         }
 

--- a/src/NServiceBus.RabbitMQ/Administration/SubscriptionManager.cs
+++ b/src/NServiceBus.RabbitMQ/Administration/SubscriptionManager.cs
@@ -7,10 +7,10 @@
     class SubscriptionManager : IManageSubscriptions
     {
         readonly ConnectionFactory connectionFactory;
-        readonly IRoutingTopology routingTopology;
+        readonly IRoutingTopology2 routingTopology;
         readonly string localQueue;
 
-        public SubscriptionManager(ConnectionFactory connectionFactory, IRoutingTopology routingTopology, string localQueue)
+        public SubscriptionManager(ConnectionFactory connectionFactory, IRoutingTopology2 routingTopology, string localQueue)
         {
             this.connectionFactory = connectionFactory;
             this.routingTopology = routingTopology;

--- a/src/NServiceBus.RabbitMQ/Configuration/RabbitMQTransportSettingsExtensions.cs
+++ b/src/NServiceBus.RabbitMQ/Configuration/RabbitMQTransportSettingsExtensions.cs
@@ -15,9 +15,21 @@
         /// </summary>
         /// <param name="transportExtensions"></param>
         /// <param name="topologyFactory">The function used to create the routing topology instance. The parameter of the function indicates whether exchanges and queues declared by the routing topology should be durable.</param>
+        [ObsoleteEx(RemoveInVersion = "6.0", TreatAsErrorFromVersion = "5.0", ReplacementTypeOrMember = "RabbitMQTransportSettingsExtensions.UseRoutingTopology(TransportExtensions<RabbitMQTransport> transportExtensions, Func<bool, IRoutingTopology2>)")]
         public static TransportExtensions<RabbitMQTransport> UseRoutingTopology(this TransportExtensions<RabbitMQTransport> transportExtensions, Func<bool, IRoutingTopology> topologyFactory)
         {
             transportExtensions.GetSettings().Set<Func<bool, IRoutingTopology>>(topologyFactory);
+            return transportExtensions;
+        }
+
+        /// <summary>
+        /// Registers a custom routing topology.
+        /// </summary>
+        /// <param name="transportExtensions"></param>
+        /// <param name="topologyFactory">The function used to create the routing topology instance. The parameter of the function indicates whether exchanges and queues declared by the routing topology should be durable.</param>
+        public static TransportExtensions<RabbitMQTransport> UseRoutingTopology(this TransportExtensions<RabbitMQTransport> transportExtensions, Func<bool, IRoutingTopology2> topologyFactory)
+        {
+            transportExtensions.GetSettings().Set<Func<bool, IRoutingTopology2>>(topologyFactory);
             return transportExtensions;
         }
 

--- a/src/NServiceBus.RabbitMQ/Connection/ChannelProvider.cs
+++ b/src/NServiceBus.RabbitMQ/Connection/ChannelProvider.cs
@@ -6,7 +6,7 @@ namespace NServiceBus.Transport.RabbitMQ
 
     class ChannelProvider : IChannelProvider, IDisposable
     {
-        public ChannelProvider(ConnectionFactory connectionFactory, IRoutingTopology routingTopology, bool usePublisherConfirms)
+        public ChannelProvider(ConnectionFactory connectionFactory, IRoutingTopology2 routingTopology, bool usePublisherConfirms)
         {
             connection = new Lazy<IConnection>(() => connectionFactory.CreatePublishConnection());
 
@@ -56,7 +56,7 @@ namespace NServiceBus.Transport.RabbitMQ
         }
 
         readonly Lazy<IConnection> connection;
-        readonly IRoutingTopology routingTopology;
+        readonly IRoutingTopology2 routingTopology;
         readonly bool usePublisherConfirms;
         readonly ConcurrentQueue<ConfirmsAwareChannel> channels;
     }

--- a/src/NServiceBus.RabbitMQ/Connection/ConfirmsAwareChannel.cs
+++ b/src/NServiceBus.RabbitMQ/Connection/ConfirmsAwareChannel.cs
@@ -9,7 +9,7 @@ namespace NServiceBus.Transport.RabbitMQ
 
     class ConfirmsAwareChannel : IDisposable
     {
-        public ConfirmsAwareChannel(IConnection connection, IRoutingTopology routingTopology, bool usePublisherConfirms)
+        public ConfirmsAwareChannel(IConnection connection, IRoutingTopology2 routingTopology, bool usePublisherConfirms)
         {
             channel = connection.CreateModel();
             channel.BasicReturn += Channel_BasicReturn;
@@ -217,7 +217,7 @@ namespace NServiceBus.Transport.RabbitMQ
         }
 
         IModel channel;
-        readonly IRoutingTopology routingTopology;
+        readonly IRoutingTopology2 routingTopology;
         readonly bool usePublisherConfirms;
         readonly ConcurrentDictionary<ulong, TaskCompletionSource<bool>> messages;
 

--- a/src/NServiceBus.RabbitMQ/NServiceBus.RabbitMQ.csproj
+++ b/src/NServiceBus.RabbitMQ/NServiceBus.RabbitMQ.csproj
@@ -91,6 +91,8 @@
     <Compile Include="obsoletes.cs" />
     <Compile Include="Administration\QueuePurger.cs" />
     <Compile Include="AssemblyInfo.cs" />
+    <Compile Include="Routing\IRoutingTopology2.cs" />
+    <Compile Include="Routing\RoutingTopology2Adapter.cs" />
     <Compile Include="Sending\MessageDispatcher.cs" />
     <Compile Include="Administration\QueueCreator.cs" />
     <Compile Include="Administration\SubscriptionManager.cs" />

--- a/src/NServiceBus.RabbitMQ/Routing/ConventionalRoutingTopology.cs
+++ b/src/NServiceBus.RabbitMQ/Routing/ConventionalRoutingTopology.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Concurrent;
+    using System.Collections.Generic;
     using global::RabbitMQ.Client;
 
     /// <summary>
@@ -19,7 +20,7 @@
     /// <item><description>we generate an exchange for each queue so that we can do direct sends to the queue. it is bound as a fanout exchange</description></item>
     /// </list>
     /// </summary>
-    class ConventionalRoutingTopology : IRoutingTopology
+    class ConventionalRoutingTopology : IRoutingTopology2
     {
         readonly bool useDurableExchanges;
 
@@ -70,10 +71,14 @@
             channel.BasicPublish(address, String.Empty, true, properties, body);
         }
 
-        public void Initialize(IModel channel, string mainQueue)
+        public void Initialize(IModel channel, IEnumerable<string> addresses)
         {
-            CreateExchange(channel, mainQueue);
-            channel.QueueBind(mainQueue, mainQueue, string.Empty);
+            foreach(var address in addresses)
+            {
+                channel.QueueDeclare(address, useDurableExchanges, false, false, null);
+                CreateExchange(channel, address);
+                channel.QueueBind(address, address, string.Empty);
+            }
         }
 
         static string ExchangeName(Type type) => type.Namespace + ":" + type.Name;

--- a/src/NServiceBus.RabbitMQ/Routing/DirectRoutingTopology.cs
+++ b/src/NServiceBus.RabbitMQ/Routing/DirectRoutingTopology.cs
@@ -1,12 +1,13 @@
 ﻿namespace NServiceBus.Transport.RabbitMQ
 {
     using System;
+    using System.Collections.Generic;
     using global::RabbitMQ.Client;
 
     /// <summary>
     /// Route using a static routing convention for routing messages from publishers to subscribers using routing keys.
     /// </summary>
-    class DirectRoutingTopology : IRoutingTopology
+    class DirectRoutingTopology : IRoutingTopology2
     {
         public DirectRoutingTopology(Conventions conventions, bool useDurableExchanges)
         {
@@ -40,9 +41,12 @@
             channel.BasicPublish(string.Empty, address, true, properties, body);
         }
 
-        public void Initialize(IModel channel, string main)
+        public void Initialize(IModel channel, IEnumerable<string> addresses)
         {
-            //nothing needs to be done for direct routing
+            foreach (var address in addresses)
+            {
+                channel.QueueDeclare(address, useDurableExchanges, false, false, null);
+            }
         }
 
         string ExchangeName() => conventions.ExchangeName(null, null);

--- a/src/NServiceBus.RabbitMQ/Routing/IRoutingTopology2.cs
+++ b/src/NServiceBus.RabbitMQ/Routing/IRoutingTopology2.cs
@@ -1,13 +1,13 @@
 ﻿namespace NServiceBus.Transport.RabbitMQ
 {
     using System;
+    using System.Collections.Generic;
     using global::RabbitMQ.Client;
 
     /// <summary>
     /// Topology for routing messages on the transport.
     /// </summary>
-    [ObsoleteEx(RemoveInVersion = "6.0", TreatAsErrorFromVersion = "5.0", ReplacementTypeOrMember = "IRoutingTopology2")]
-    public interface IRoutingTopology
+    public interface IRoutingTopology2
     {
         /// <summary>
         /// Sets up a subscription for the subscriber to the specified type.
@@ -53,10 +53,10 @@
         void RawSendInCaseOfFailure(IModel channel, string address, byte[] body, IBasicProperties properties);
 
         /// <summary>
-        /// Performs any initialization logic needed (e.g., creating exchanges and bindings).
+        /// Performs any initialization logic needed (e.g., creating queues, exchanges and bindings).
         /// </summary>
         /// <param name="channel">The RabbitMQ channel to operate on.</param>
-        /// <param name="main">The name of the queue to perform initialization on.</param>
-        void Initialize(IModel channel, string main);
+        /// <param name="addresses">The addresses of the queues to perform initialization on.</param>
+        void Initialize(IModel channel, IEnumerable<string> addresses);
     }
 }

--- a/src/NServiceBus.RabbitMQ/Routing/RoutingTopology2Adapter.cs
+++ b/src/NServiceBus.RabbitMQ/Routing/RoutingTopology2Adapter.cs
@@ -1,0 +1,52 @@
+﻿namespace NServiceBus.Transport.RabbitMQ
+{
+    using System;
+    using System.Collections.Generic;
+    using global::RabbitMQ.Client;
+
+    class RoutingTopology2Adapter : IRoutingTopology2
+    {
+        private readonly IRoutingTopology routingTopology;
+        private readonly bool durableMessagesEnabled;
+
+        public RoutingTopology2Adapter(IRoutingTopology routingTopology, bool durableMessagesEnabled)
+        {
+            this.routingTopology = routingTopology;
+            this.durableMessagesEnabled = durableMessagesEnabled;
+        }
+
+        public void Initialize(IModel channel, IEnumerable<string> addresses)
+        {
+            foreach (var address in addresses)
+            {
+                channel.QueueDeclare(address, durableMessagesEnabled, false, false, null);
+                this.routingTopology.Initialize(channel, address);
+            }
+        }
+
+        public void Publish(IModel channel, Type type, OutgoingMessage message, IBasicProperties properties)
+        {
+            this.routingTopology.Publish(channel, type, message, properties);
+        }
+
+        public void RawSendInCaseOfFailure(IModel channel, string address, byte[] body, IBasicProperties properties)
+        {
+            this.routingTopology.RawSendInCaseOfFailure(channel, address, body, properties);
+        }
+
+        public void Send(IModel channel, string address, OutgoingMessage message, IBasicProperties properties)
+        {
+            this.routingTopology.Send(channel, address, message, properties);
+        }
+
+        public void SetupSubscription(IModel channel, Type type, string subscriberName)
+        {
+            this.routingTopology.SetupSubscription(channel, type, subscriberName);
+        }
+
+        public void TeardownSubscription(IModel channel, Type type, string subscriberName)
+        {
+            this.routingTopology.TeardownSubscription(channel, type, subscriberName);
+        }
+    }
+}


### PR DESCRIPTION
This kind of cool, but also kind of crazy.

Ultimately, the constraint is that it's impossible to version interfaces in a non-breaking way so we need a new interface.

If an old routing topology factory is provided in config, it's immediately wrapped in an adapter to the new interface and the rest of the code base uses the new interface.

`IRoutingTopology2` is a tear jerking name for the new interface, but what's better? `IRoutingTopologyNew`, `IRoutingTopologyAdvanced`, `IRoutingTopologyExt`? All equally repulsive to me.

Connects to #248.