### PR TITLE
Make sure Headers collection exists during a RawSendInCaseOfFailure

### DIFF
--- a/src/NServiceBus.RabbitMQ.Tests/When_consuming_messages.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/When_consuming_messages.cs
@@ -44,7 +44,7 @@
         }
 
         [Test]
-        public void Should_be_able_to_receive_a_blank_message()
+        public void Should_move_message_without_message_id_to_error_queue()
         {
             var message = new OutgoingMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>(), new byte[0]);
 
@@ -53,14 +53,15 @@
             {
                 var properties = channel.CreateBasicProperties();
 
-                properties.MessageId = message.MessageId;
-
                 channel.BasicPublish(string.Empty, ReceiverQueue, false, properties, message.Body);
+
+                var received = WaitForMessage();
+
+                var result = channel.BasicGet("error", true);
+
+                Assert.Null(received, "Message should not be processed processed successfully.");
+                Assert.NotNull(result, "Message should be considered poison and moved to the error queue.");
             }
-
-            var received = WaitForMessage();
-
-            Assert.NotNull(received.MessageId, "The message id should be defaulted to a new guid if not set");
         }
 
         [Test]

--- a/src/NServiceBus.RabbitMQ/Connection/ConfirmsAwareChannel.cs
+++ b/src/NServiceBus.RabbitMQ/Connection/ConfirmsAwareChannel.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.Transport.RabbitMQ
 {
     using System;
     using System.Collections.Concurrent;
+    using System.Collections.Generic;
     using System.Threading.Tasks;
     using global::RabbitMQ.Client;
     using global::RabbitMQ.Client.Events;
@@ -80,6 +81,12 @@ namespace NServiceBus.Transport.RabbitMQ
             if (usePublisherConfirms)
             {
                 task = GetConfirmationTask();
+
+                if (properties.Headers == null)
+                {
+                    properties.Headers = new Dictionary<string, object>();
+                }
+
                 properties.SetConfirmationId(channel.NextPublishSeqNo);
             }
             else


### PR DESCRIPTION
This fixes the problem identified in #258 by making sure the Headers collection exists before calling SetConfirmationId.