### PR TITLE
Alternate fix for custom message id strategy loop

### DIFF
--- a/src/NServiceBus.RabbitMQ.AcceptanceTests/NServiceBus.RabbitMQ.AcceptanceTests.csproj
+++ b/src/NServiceBus.RabbitMQ.AcceptanceTests/NServiceBus.RabbitMQ.AcceptanceTests.csproj
@@ -323,6 +323,7 @@
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.0.0\Tx\When_sending_within_an_ambient_transaction.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.0.0\UnicastRoutingExtensions.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.0.0\Versioning\When_multiple_versions_of_a_message_is_published.cs" />
+    <Compile Include="When_using_a_custom_message_id_strategy_that_returns_an_invalid_message_id.cs" />
     <Compile Include="ConfigureEndpointRabbitMQTransport.cs" />
     <Compile Include="TaskEx.cs" />
     <Compile Include="When_receiving_a_reply_that_contains_a_legacy_callback_header.cs" />

--- a/src/NServiceBus.RabbitMQ.AcceptanceTests/When_using_a_custom_message_id_strategy.cs
+++ b/src/NServiceBus.RabbitMQ.AcceptanceTests/When_using_a_custom_message_id_strategy.cs
@@ -1,25 +1,23 @@
 ﻿namespace NServiceBus.Transport.RabbitMQ.AcceptanceTests
 {
-    using System;
     using System.Collections.Generic;
-    using System.IO;
-    using System.Runtime.Serialization.Formatters.Binary;
+    using System.Text;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using Extensibility;
     using Features;
-    using MessageInterfaces;
     using NServiceBus.AcceptanceTests;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
     using Routing;
-    using Serialization;
     using Settings;
 
     public class When_using_a_custom_message_id_strategy : NServiceBusAcceptanceTest
     {
+        const string customMessageId = "CustomMessageId";
+
         [Test]
-        public async Task Should_be_able_to_receive_messages_with_no_id()
+        public async Task Should_use_custom_strategy_to_set_message_id_on_message_with_no_id()
         {
             var context = await Scenario.Define<MyContext>()
                    .WithEndpoint<Receiver>()
@@ -27,6 +25,7 @@
                    .Run();
 
             Assert.True(context.GotTheMessage, "Should receive the message");
+            Assert.AreEqual(context.ReceivedMessageId, customMessageId, "Message Id should equal custom Id value");
         }
 
         public class Receiver : EndpointConfigurationBuilder
@@ -36,10 +35,8 @@
                 EndpointSetup<DefaultServer>(c =>
                 {
                     c.EnableFeature<StarterFeature>();
-                    c.UseSerialization<MyCustomSerializerDefinition>();
                     c.UseTransport<RabbitMQTransport>()
-                        //just returning a guid here, not suitable for production use
-                        .CustomMessageIdStrategy(m => Guid.NewGuid().ToString());
+                        .CustomMessageIdStrategy(m => customMessageId);
                 });
             }
 
@@ -59,24 +56,22 @@
                         this.settings = settings;
                     }
 
-                    protected override async Task OnStart(IMessageSession session)
+                    protected override Task OnStart(IMessageSession session)
                     {
-                        using (var stream = new MemoryStream())
-                        {
-                            var serializer = new MyCustomSerializer();
-                            serializer.Serialize(new MyRequest(), stream);
+                        //Use feature to send message that has no message id
 
-                            var message = new OutgoingMessage(
-                                string.Empty,
-                                new Dictionary<string, string>
-                                {
+                        var messageBody = "<MyRequest></MyRequest>";
+
+                        var message = new OutgoingMessage(
+                            string.Empty,
+                            new Dictionary<string, string>
+                            {
                                     { Headers.EnclosedMessageTypes, typeof(MyRequest).FullName }
-                                },
-                                stream.ToArray());
+                            },
+                            Encoding.UTF8.GetBytes(messageBody));
 
-                            var transportOperation = new TransportOperation(message, new UnicastAddressTag(settings.EndpointName()));
-                            await dispatchMessages.Dispatch(new TransportOperations(transportOperation), new TransportTransaction(), new ContextBag());
-                        }
+                        var transportOperation = new TransportOperation(message, new UnicastAddressTag(settings.EndpointName()));
+                        return dispatchMessages.Dispatch(new TransportOperations(transportOperation), new TransportTransaction(), new ContextBag());
                     }
 
                     protected override Task OnStop(IMessageSession session) => TaskEx.CompletedTask;
@@ -98,13 +93,13 @@
                 public Task Handle(MyRequest message, IMessageHandlerContext context)
                 {
                     myContext.GotTheMessage = true;
+                    myContext.ReceivedMessageId = context.MessageId;
 
                     return TaskEx.CompletedTask;
                 }
             }
         }
 
-        [Serializable]
         class MyRequest : IMessage
         {
         }
@@ -112,38 +107,7 @@
         class MyContext : ScenarioContext
         {
             public bool GotTheMessage { get; set; }
-        }
-
-        class MyCustomSerializerDefinition : SerializationDefinition
-        {
-            public override Func<IMessageMapper, IMessageSerializer> Configure(ReadOnlySettings settings)
-            {
-                return mapper => new MyCustomSerializer();
-            }
-        }
-
-        class MyCustomSerializer : IMessageSerializer
-        {
-            public void Serialize(object message, Stream stream)
-            {
-                var serializer = new BinaryFormatter();
-                serializer.Serialize(stream, message);
-            }
-
-            public object[] Deserialize(Stream stream, IList<Type> messageTypes = null)
-            {
-                var serializer = new BinaryFormatter();
-
-                stream.Position = 0;
-                var msg = serializer.Deserialize(stream);
-
-                return new[]
-                {
-                    msg
-                };
-            }
-
-            public string ContentType => "MyCustomSerializer";
+            public string ReceivedMessageId { get; set; }
         }
     }
 }

--- a/src/NServiceBus.RabbitMQ.AcceptanceTests/When_using_a_custom_message_id_strategy.cs
+++ b/src/NServiceBus.RabbitMQ.AcceptanceTests/When_using_a_custom_message_id_strategy.cs
@@ -25,7 +25,7 @@
                    .Run();
 
             Assert.True(context.GotTheMessage, "Should receive the message");
-            Assert.AreEqual(context.ReceivedMessageId, customMessageId, "Message Id should equal custom Id value");
+            Assert.AreEqual(context.ReceivedMessageId, customMessageId, "Message id should equal custom id value");
         }
 
         public class Receiver : EndpointConfigurationBuilder

--- a/src/NServiceBus.RabbitMQ.AcceptanceTests/When_using_a_custom_message_id_strategy_that_returns_an_invalid_message_id.cs
+++ b/src/NServiceBus.RabbitMQ.AcceptanceTests/When_using_a_custom_message_id_strategy_that_returns_an_invalid_message_id.cs
@@ -1,0 +1,60 @@
+﻿namespace NServiceBus.Transport.RabbitMQ.AcceptanceTests
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_using_a_custom_message_id_strategy_that_returns_an_invalid_message_id : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_still_receive_message_if_sent_from_NServiceBus()
+        {
+            var context = await Scenario.Define<MyContext>()
+                   .WithEndpoint<Receiver>(c => c.When(session => session.SendLocal(new MyRequest())))
+                   .Done(c => c.GotTheMessage)
+                   .Run();
+
+            Assert.True(context.GotTheMessage, "Should receive the message");
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.UseTransport<RabbitMQTransport>()
+                        .CustomMessageIdStrategy(m => "");
+                });
+            }
+
+            class MyEventHandler : IHandleMessages<MyRequest>
+            {
+                readonly MyContext myContext;
+
+                public MyEventHandler(MyContext myContext)
+                {
+                    this.myContext = myContext;
+                }
+
+                public Task Handle(MyRequest message, IMessageHandlerContext context)
+                {
+                    myContext.GotTheMessage = true;
+
+                    return TaskEx.CompletedTask;
+                }
+            }
+        }
+
+        class MyRequest : IMessage
+        {
+        }
+
+        class MyContext : ScenarioContext
+        {
+            public bool GotTheMessage { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.RabbitMQ.Tests/MessageConverterTests.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/MessageConverterTests.cs
@@ -32,6 +32,48 @@
         }
 
         [Test]
+        public void Should_throw_exception_when_no_message_id_is_set()
+        {
+            var message = new BasicDeliverEventArgs
+            {
+                BasicProperties = new BasicProperties()
+            };
+
+            Assert.Throws<InvalidOperationException>(() => converter.RetrieveMessageId(message));
+        }
+
+        [Test]
+        public void Should_throw_exception_when_using_custom_strategy_and_no_message_id_is_returned()
+        {
+            var customConverter = new MessageConverter(args => "");
+
+            var message = new BasicDeliverEventArgs
+            {
+                BasicProperties = new BasicProperties()
+            };
+
+            Assert.Throws<InvalidOperationException>(() => customConverter.RetrieveMessageId(message));
+        }
+
+        [Test]
+        public void Should_fall_back_to_message_id_when_custom_strategy_returns_empty_string()
+        {
+            var customConverter = new MessageConverter(args => "");
+
+            var message = new BasicDeliverEventArgs
+            {
+                BasicProperties = new BasicProperties
+                {
+                    MessageId = "Blah"
+                }
+            };
+
+            var messageId = customConverter.RetrieveMessageId(message);
+
+            Assert.AreEqual(messageId, "Blah");
+        }
+
+        [Test]
         public void TestCanHandleByteArrayHeader()
         {
             var message = new BasicDeliverEventArgs

--- a/src/NServiceBus.RabbitMQ.Tests/MessageConverterTests.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/MessageConverterTests.cs
@@ -24,8 +24,8 @@
                 }
             };
 
-            var messageId = converter.RetrieveMessageId(message);
             var headers = converter.RetrieveHeaders(message);
+            var messageId = converter.RetrieveMessageId(message, headers);
 
             Assert.IsNotNull(messageId);
             Assert.IsNotNull(headers);
@@ -39,7 +39,9 @@
                 BasicProperties = new BasicProperties()
             };
 
-            Assert.Throws<InvalidOperationException>(() => converter.RetrieveMessageId(message));
+            var headers = new Dictionary<string, string>();
+
+            Assert.Throws<InvalidOperationException>(() => converter.RetrieveMessageId(message, headers));
         }
 
         [Test]
@@ -52,23 +54,24 @@
                 BasicProperties = new BasicProperties()
             };
 
-            Assert.Throws<InvalidOperationException>(() => customConverter.RetrieveMessageId(message));
+            var headers = new Dictionary<string, string>();
+
+            Assert.Throws<InvalidOperationException>(() => customConverter.RetrieveMessageId(message, headers));
         }
 
         [Test]
-        public void Should_fall_back_to_message_id_when_custom_strategy_returns_empty_string()
+        public void Should_fall_back_to_message_id_header_when_custom_strategy_returns_empty_string()
         {
             var customConverter = new MessageConverter(args => "");
 
             var message = new BasicDeliverEventArgs
             {
-                BasicProperties = new BasicProperties
-                {
-                    MessageId = "Blah"
-                }
+                BasicProperties = new BasicProperties()
             };
 
-            var messageId = customConverter.RetrieveMessageId(message);
+            var headers = new Dictionary<string, string> { { Headers.MessageId, "Blah" } };
+
+            var messageId = customConverter.RetrieveMessageId(message, headers);
 
             Assert.AreEqual(messageId, "Blah");
         }

--- a/src/NServiceBus.RabbitMQ.Tests/When_sending_a_message_over_rabbitmq.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/When_sending_a_message_over_rabbitmq.cs
@@ -104,12 +104,10 @@
             var result = Consume(messageId, queueToReceiveOn);
 
             var converter = new MessageConverter();
+            var convertedHeaders = converter.RetrieveHeaders(result);
+            var convertedMessageId = converter.RetrieveMessageId(result, convertedHeaders);
 
-            var incomingMessage = new IncomingMessage(
-                converter.RetrieveMessageId(result),
-                converter.RetrieveHeaders(result),
-                result.Body
-            );
+            var incomingMessage = new IncomingMessage(convertedMessageId, convertedHeaders, result.Body);
 
             assertion(incomingMessage, result);
         }

--- a/src/NServiceBus.RabbitMQ/Receiving/MessageConverter.cs
+++ b/src/NServiceBus.RabbitMQ/Receiving/MessageConverter.cs
@@ -19,7 +19,17 @@
             this.messageIdStrategy = messageIdStrategy;
         }
 
-        public string RetrieveMessageId(BasicDeliverEventArgs message) => messageIdStrategy(message);
+        public string RetrieveMessageId(BasicDeliverEventArgs message)
+        {
+            var messageId = messageIdStrategy(message);
+
+            if (string.IsNullOrWhiteSpace(messageId))
+            {
+                messageId = DefaultMessageIdStrategy(message);
+            }
+
+            return messageId;
+        }
 
         public Dictionary<string, string> RetrieveHeaders(BasicDeliverEventArgs message)
         {

--- a/src/NServiceBus.RabbitMQ/Receiving/MessageConverter.cs
+++ b/src/NServiceBus.RabbitMQ/Receiving/MessageConverter.cs
@@ -25,7 +25,7 @@
 
             if (string.IsNullOrWhiteSpace(messageId) && !headers.TryGetValue(Headers.MessageId, out messageId))
             {
-                throw new InvalidOperationException("The registered message id strategy did not provide a message id, and the message does not have an 'NServiceBus.MessageId' header.");
+                throw new InvalidOperationException("The message id strategy did not provide a message id, and the message does not have an 'NServiceBus.MessageId' header.");
             }
 
             return messageId;

--- a/src/NServiceBus.RabbitMQ/Receiving/MessageConverter.cs
+++ b/src/NServiceBus.RabbitMQ/Receiving/MessageConverter.cs
@@ -19,13 +19,13 @@
             this.messageIdStrategy = messageIdStrategy;
         }
 
-        public string RetrieveMessageId(BasicDeliverEventArgs message)
+        public string RetrieveMessageId(BasicDeliverEventArgs message, Dictionary<string, string> headers)
         {
             var messageId = messageIdStrategy(message);
 
-            if (string.IsNullOrWhiteSpace(messageId))
+            if (string.IsNullOrWhiteSpace(messageId) && !headers.TryGetValue(Headers.MessageId, out messageId))
             {
-                messageId = DefaultMessageIdStrategy(message);
+                throw new InvalidOperationException("The registered message id strategy did not provide a message id, and the message does not have an 'NServiceBus.MessageId' header.");
             }
 
             return messageId;


### PR DESCRIPTION
Building on #262, here's how we could use the NSB message header instead of the default message id strategy.

Changing the processing order does mean that the poison message errors will never have a chance of including a message id, so I went ahead and removed that.