### PR TITLE
upgrade to R# CTL 2016.3 EAP9

### DIFF
--- a/build.csx
+++ b/build.csx
@@ -7,11 +7,12 @@
 using System;
 using System.IO;
 using System.IO.Compression;
+using System.Linq;
 using static SimpleTargets;
 
 // locations
-var resharperCltUrl = "https://download.jetbrains.com/resharper/JetBrains.ReSharper.CommandLineTools.2016.2.20160913.100041.zip";
-var resharperCltPath = $"{Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)}/.resharper/JetBrains.ReSharper.CommandLineTools.2016.2.20160913.100041.zip";
+var resharperCltUrl = new Uri("https://download.jetbrains.com/resharper/JetBrains.ReSharper.CommandLineTools.2016.3.20161116.170907-eap9.zip");
+var resharperCltPath = $"{Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)}/.resharper/{resharperCltUrl.Segments.Last()}";
 var inspectCodePath = "./.resharper/inspectcode.exe";
 var msBuild = $"{Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86)}/MSBuild/14.0/Bin/msbuild.exe";
 var solution = "./src/NServiceBus.RabbitMQ.sln";

--- a/scripts/download.csx
+++ b/scripts/download.csx
@@ -2,7 +2,7 @@ using System;
 using System.IO;
 using System.Net;
 
-public static void Download(string url, string path)
+public static void Download(Uri url, string path)
 {
     var directory = Path.GetDirectoryName(path);
     if (!Directory.Exists(directory))


### PR DESCRIPTION
The intermittent bug which causes inspection failure [seems to be fixed in this EAP](https://youtrack.jetbrains.com/issue/RSRP-461241#comment=27-1730891).

I'm not sure if we want to merge this in now or wait for RTM. It won't affect CI of course, but at least it will give us more reliable local inspections.