### PR TITLE
ignore the databus folder... at last

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ run-git.cmd
 src/Chocolatey/Build/*
 src/.nuget/NuGet.exe
 *.sln.inspections.xml
+databus
 
 installer/[F|f]iles
 installer/[C|c]ustom[A|a]ctions


### PR DESCRIPTION
This infuriating thing appears and pollutes my working directory every time I run the tests.

Why I didn't send this PR months ago I'll never know... `ლ(ಠ益ಠლ)`