### PR TITLE
isolate tests on a "nsb-rabbitmq-test" virtual host

### DIFF
--- a/build.csx
+++ b/build.csx
@@ -1,4 +1,5 @@
 #r "System.IO.Compression.FileSystem.dll"
+#load "scripts/broker.csx"
 #load "scripts/cmd.csx"
 #load "scripts/download.csx"
 #load "scripts/inspect.csx"
@@ -55,10 +56,18 @@ targets.Add(
         }
     });
 
-targets.Add("unit-test", DependsOn("build"), () => Cmd(nunit, unitTests));
+targets.Add("delete-virtual-host", () => DeleteVirtualHost());
 
-targets.Add("acceptance-test", DependsOn("build"), () => Cmd(nunit, acceptanceTests));
+targets.Add("create-virtual-host", () => CreateVirtualHost());
 
-targets.Add("transport-test", DependsOn("build"), () => Cmd(nunit, transportTests));
+targets.Add("add-user-to-virtual-host", () => AddUserToVirtualHost());
+
+targets.Add("prepare-virtual-host", DependsOn("delete-virtual-host", "create-virtual-host", "add-user-to-virtual-host"));
+
+targets.Add("unit-test", DependsOn("build", "prepare-virtual-host"), () => Cmd(nunit, unitTests));
+
+targets.Add("acceptance-test", DependsOn("build", "prepare-virtual-host"), () => Cmd(nunit, acceptanceTests));
+
+targets.Add("transport-test", DependsOn("build", "prepare-virtual-host"), () => Cmd(nunit, transportTests));
 
 Run(Args, targets);

--- a/scripts/broker.csx
+++ b/scripts/broker.csx
@@ -1,0 +1,108 @@
+#r "System.Data"
+#r "../src/packages/RabbitMQ.Client.4.1.1/lib/net451/RabbitMQ.Client.dll"
+
+using System.Data.Common;
+using System.Net;
+using RabbitMQ.Client;
+
+public void DeleteVirtualHost()
+{
+    try
+    {
+        CreateVirtualHostRequest("DELETE", GetBroker()).GetResponse().Dispose();
+    }
+    catch (WebException ex) when ((ex?.Response as HttpWebResponse)?.StatusCode == HttpStatusCode.NotFound)
+    {
+    }
+}
+
+public void CreateVirtualHost() => CreateVirtualHostRequest("PUT", GetBroker()).GetResponse().Dispose();
+
+public void AddUserToVirtualHost() => CreateUserPermissionRequest("PUT", GetBroker()).GetResponse().Dispose();
+
+public Broker GetBroker()
+{
+    var connectionStringBuilder = new DbConnectionStringBuilder
+    {
+        ConnectionString = Environment.GetEnvironmentVariable("RabbitMQTransport.ConnectionString")
+    };
+
+    ApplyDefault(connectionStringBuilder, "username", "guest");
+    ApplyDefault(connectionStringBuilder, "password", "guest");
+    ApplyDefault(connectionStringBuilder, "virtualhost", "nsb-rabbitmq-test");
+    ApplyDefault(connectionStringBuilder, "host", "localhost");
+
+    return new Broker
+    {
+        UserName = connectionStringBuilder["username"].ToString(),
+        Password = connectionStringBuilder["password"].ToString(),
+        VirtualHost = connectionStringBuilder["virtualhost"].ToString(),
+        HostName = connectionStringBuilder["host"].ToString(),
+        Port = 15672,
+    };
+}
+
+public void ApplyDefault(DbConnectionStringBuilder builder, string key, string value)
+{
+    if (!builder.ContainsKey(key))
+    {
+        builder.Add(key, value);
+    }
+}
+
+public HttpWebRequest CreateVirtualHostRequest(string method, Broker broker) =>
+    CreateHttpWebRequest(
+        $"http://{broker.HostName}:{broker.Port}/api/vhosts/{Uri.EscapeDataString(broker.VirtualHost)}",
+        method,
+        broker);
+
+public HttpWebRequest CreateUserPermissionRequest(string method, Broker broker)
+{
+    var uriString = $"http://{broker.HostName}:{broker.Port}/api/permissions/{Uri.EscapeDataString(broker.VirtualHost)}/{Uri.EscapeDataString(broker.UserName)}";
+
+    var request = CreateHttpWebRequest(uriString, method, broker);
+
+    var bodyString =
+@"{
+    ""scope""       : ""client"",
+    ""configure""   : "".*"",
+    ""write""       : "".*"",
+    ""read""        : "".*""
+}";
+
+    var bodyBytes = new ASCIIEncoding().GetBytes(bodyString);
+
+    request.ContentLength = bodyBytes.Length;
+
+    using (var stream = request.GetRequestStream())
+    {
+        stream.Write(bodyBytes, 0, bodyBytes.Length);
+    }
+
+    return request;
+}
+
+public HttpWebRequest CreateHttpWebRequest(string uriString, string method, Broker broker)
+{
+    var request = HttpWebRequest.CreateHttp(uriString);
+
+    var encoded = Convert.ToBase64String(Encoding.GetEncoding("ISO-8859-1").GetBytes(broker.UserName + ":" + broker.Password));
+    request.Headers.Add("Authorization", "Basic " + encoded);
+    request.ContentType = "application/json";
+    request.Method = method;
+
+    return request;
+}
+
+public class Broker
+{
+    public string HostName { get; set; }
+    
+    public int Port { get; set; }
+    
+    public string VirtualHost { get; set; }
+    
+    public string UserName { get; set; }
+    
+    public string Password { get; set; }
+}

--- a/src/NServiceBus.RabbitMQ.Tests/RabbitMqContext.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/RabbitMqContext.cs
@@ -65,6 +65,7 @@
             {
                 config = new ConnectionConfiguration(settings);
                 config.Host = "localhost";
+                config.VirtualHost = "nsb-rabbitmq-test";
             }
 
             connectionFactory = new ConnectionFactory(config);


### PR DESCRIPTION
fixes #271 

I added an env var on the CI server so that it continues to use the `/` virtual host.

This also helps when running tests from Visual Studio. Before you run a test, you can drop to a command prompt and run `.\build.cmd prepare-virtual-host`. 😎 