### PR TITLE
remove rabbitmq client reference in build script

### DIFF
--- a/scripts/broker.csx
+++ b/scripts/broker.csx
@@ -1,9 +1,7 @@
 #r "System.Data"
-#r "../src/packages/RabbitMQ.Client.4.1.1/lib/net451/RabbitMQ.Client.dll"
 
 using System.Data.Common;
 using System.Net;
-using RabbitMQ.Client;
 
 public void DeleteVirtualHost()
 {


### PR DESCRIPTION
I think I added it when I was originally using `NServiceBus.RabbitMQ` types to retrieve the connection string, but then neglected to remove when I changed the approach 😊 