### PR TITLE
Fix waiting for messages with RabbitMqContext

### DIFF
--- a/src/NServiceBus.RabbitMQ.Tests/RabbitMqContext.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/RabbitMqContext.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.Linq;
     using System.Threading.Tasks;
     using NUnit.Framework;
@@ -102,6 +101,6 @@
         BlockingCollection<IncomingMessage> receivedMessages;
         ConventionalRoutingTopology routingTopology;
 
-        static readonly TimeSpan incomingMessageTimeout = TimeSpan.FromSeconds(Debugger.IsAttached ? 600 : 1);
+        static readonly TimeSpan incomingMessageTimeout = TimeSpan.FromSeconds(1);
     }
 }

--- a/src/NServiceBus.RabbitMQ.Tests/When_consuming_messages.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/When_consuming_messages.cs
@@ -18,9 +18,9 @@
 
             await messageDispatcher.Dispatch(transportOperations, new TransportTransaction(), new ContextBag());
 
-            var received = WaitForMessage();
+            var receivedMessage = ReceiveMessage();
 
-            Assert.AreEqual(message.MessageId, received.MessageId);
+            Assert.AreEqual(message.MessageId, receivedMessage.MessageId);
         }
 
         [Test]
@@ -38,9 +38,9 @@
                 channel.BasicPublish(string.Empty, ReceiverQueue, false, properties, message.Body);
             }
 
-            var received = WaitForMessage();
+            var receivedMessage = ReceiveMessage();
 
-            Assert.AreEqual(message.MessageId, received.MessageId);
+            Assert.AreEqual(message.MessageId, receivedMessage.MessageId);
         }
 
         [Test]
@@ -55,11 +55,11 @@
 
                 channel.BasicPublish(string.Empty, ReceiverQueue, false, properties, message.Body);
 
-                var received = WaitForMessage();
+                var messageWasReceived = TryWaitForMessageReceipt();
 
                 var result = channel.BasicGet(ErrorQueue, true);
 
-                Assert.Null(received, "Message should not be processed processed successfully.");
+                Assert.False(messageWasReceived, "Message should not be processed processed successfully.");
                 Assert.NotNull(result, "Message should be considered poison and moved to the error queue.");
             }
         }
@@ -82,10 +82,10 @@
                 channel.BasicPublish(string.Empty, ReceiverQueue, false, properties, message.Body);
             }
 
-            var received = WaitForMessage();
+            var receivedMessage = ReceiveMessage();
 
-            Assert.AreEqual(typeName, received.Headers[Headers.EnclosedMessageTypes]);
-            Assert.AreEqual(typeof(MyMessage), Type.GetType(received.Headers[Headers.EnclosedMessageTypes]));
+            Assert.AreEqual(typeName, receivedMessage.Headers[Headers.EnclosedMessageTypes]);
+            Assert.AreEqual(typeof(MyMessage), Type.GetType(receivedMessage.Headers[Headers.EnclosedMessageTypes]));
         }
 
         class MyMessage

--- a/src/NServiceBus.RabbitMQ.Tests/When_subscribed_to_a_event.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/When_subscribed_to_a_event.cs
@@ -146,9 +146,9 @@
 
         void AssertReceived<T>()
         {
-            var receivedEvent = WaitForMessage();
+            var receivedMessage = ReceiveMessage();
 
-            AssertReceived<T>(receivedEvent);
+            AssertReceived<T>(receivedMessage);
         }
 
         void AssertReceived<T>(IncomingMessage receivedEvent)
@@ -158,9 +158,9 @@
 
         void AssertNoEventReceived()
         {
-            var receivedEvent = WaitForMessage();
+            var messageWasReceived = TryWaitForMessageReceipt();
 
-            Assert.Null(receivedEvent);
+            Assert.False(messageWasReceived);
         }
     }
 


### PR DESCRIPTION
Unless I'm missing something, this is currently fundamentally flawed. If the timeout is exceeded, the current method returns a null and the calling test just assumes that return value isn't null and de-references it which would result in an NRE. This PR switches to explicit methods designed for each use case.