### PR TITLE
trim README.md and point to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,5 @@
 # RabbitMQ Transport for NServiceBus
 
-Install this to enable NServiceBus to facilitate messaging over RabbitMQ
+The [NServiceBus.RabbitMQ NuGet package](https://www.nuget.org/packages/NServiceBus.RabbitMQ) provides support for sending messages over [RabbitMQ](http://www.rabbitmq.com/).
 
-## Installation
-
-Before doing anything else, make sure you have RabbitMQ up and running in your environment. Also make sure it is accessible from all the machines in your setup.
-
-1. Add NServiceBus.RabbitMQ to your project(s). The easiest way to do that is by installing the [NServiceBus.RabbitMQ nuget package](https://www.nuget.org/packages/NServiceBus.RabbitMQ).
-
-2. In your app.config make sure to provides the necessary connection information needed to communicate to the RabbitMQ server. A typical setup would be:
-
-````xml
-<connectionStrings>
-  <add name="NServiceBus/Transport" connectionString="host=localhost"/>
-</connectionStrings>
-````
-
-## Samples
-
-See http://docs.particular.net/samples/rabbitmq/
-
-## Maintainers
-The following team is responsible for this repository: @Particular/rabbitmq-transport-maintainers
+For more information, see the [documentation](https://docs.particular.net/nservicebus/rabbitmq/).


### PR DESCRIPTION
My thinking here is that there's no point doing a weak repetition of docs in the README.md. Better to just point to the actual docs.

BTW - the maintainer group was never accessible publicly, so no point having it here.