### PR TITLE
Fix inspection error in ApiGenerator.cs

### DIFF
--- a/src/NServiceBus.RabbitMQ.Tests/App_Packages/PublicApiGenerator.5.0.0/ApiGenerator.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/App_Packages/PublicApiGenerator.5.0.0/ApiGenerator.cs
@@ -166,7 +166,7 @@ namespace PublicApiGenerator
             if (IsDelegate(publicType))
                 return CreateDelegateDeclaration(publicType);
 
-            bool @static = false;
+            var @static = false;
             TypeAttributes attributes = 0;
             if (publicType.IsPublic || publicType.IsNestedPublic)
                 attributes |= TypeAttributes.Public;


### PR DESCRIPTION
This should get rid of the last inspection error that shows up when the R# inspections mess up on the CI server after updating to PublicApiGenerator 5.0.0.

I normally would try to avoid touching files in App_Packages, but this problem is too annoying!