### PR TITLE
Revert "Fix inspection error in ApiGenerator.cs"

### DIFF
--- a/src/NServiceBus.RabbitMQ.Tests/App_Packages/PublicApiGenerator.5.0.0/ApiGenerator.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/App_Packages/PublicApiGenerator.5.0.0/ApiGenerator.cs
@@ -166,7 +166,7 @@ namespace PublicApiGenerator
             if (IsDelegate(publicType))
                 return CreateDelegateDeclaration(publicType);
 
-            var @static = false;
+            bool @static = false;
             TypeAttributes attributes = 0;
             if (publicType.IsPublic || publicType.IsNestedPublic)
                 attributes |= TypeAttributes.Public;


### PR DESCRIPTION
This reverts commit 86a3131ceabc7bd31d59e0f6a8978c43bf8e9d1b.

CI has been upgraded to 2016.3.20161124.94154-eap10 so we should be able to reset ApiGenerator back to the packaged version, which I think is better.

I'll run the build several times to make sure that we don't see the inspectcode bug in eap10.