### PR TITLE
add tasks for vscode

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,47 @@
+{
+    "version": "0.1.0",
+    "windows": {
+        "command": "build.cmd",
+        "showOutput": "always",
+        "tasks": [
+            {
+                "taskName": "acceptance-test"
+            },
+            {
+                "taskName": "build",
+                "isBuildCommand": true
+            },
+            {
+                "taskName": "default"
+            },
+            {
+                "taskName": "inspect"
+            },
+            {
+                "taskName": "prepare-virtual-host"
+            },
+            {
+                "taskName": "transport-test"
+            },
+            {
+                "taskName": "unit-test",
+                "isTestCommand": true
+            },
+            {
+                "taskName": "(list targets and dependencies)",
+                "args": [
+                    "-D"
+                ],
+                "suppressTaskName": true
+            },
+            {
+                "taskName": "default (dry run)",
+                "args": [
+                    "default",
+                    "-n"
+                ],
+                "suppressTaskName": true
+            }
+        ]
+    }
+}


### PR DESCRIPTION
I'm using vscode more and more for lightweight changes, and this would be an awesome addition. I realise it's a tooling preference, but it shouldn't interfere with anything else.

This is what it provides:

![image](https://cloud.githubusercontent.com/assets/677704/20622651/36a6132a-b304-11e6-8587-2f2be2b86e00.png)

(See the output window at the bottom, showing the results of the previous run.)