### PR TITLE
Add setting to pass client certificates to RabbitMQ client

### DIFF
--- a/src/NServiceBus.RabbitMQ.Tests/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.RabbitMQ.Tests/APIApprovals.Approve.approved.txt
@@ -20,6 +20,7 @@ namespace NServiceBus
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> DisableCallbackReceiver(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions) { }
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> PrefetchCount(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions, ushort prefetchCount) { }
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> PrefetchMultiplier(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions, int prefetchMultiplier) { }
+        public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> SetClientCertificates(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions, System.Security.Cryptography.X509Certificates.X509CertificateCollection clientCertificates) { }
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> TimeToWaitBeforeTriggeringCircuitBreaker(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions, System.TimeSpan waitTime) { }
         [System.ObsoleteAttribute("The member currently throws a NotImplementedException. Will be removed in version" +
             " 5.0.0.", true)]

--- a/src/NServiceBus.RabbitMQ.Tests/RabbitMqContext.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/RabbitMqContext.cs
@@ -35,7 +35,7 @@
                 config.VirtualHost = "nsb-rabbitmq-test";
             }
 
-            connectionFactory = new ConnectionFactory(config);
+            connectionFactory = new ConnectionFactory(config, null);
             channelProvider = new ChannelProvider(connectionFactory, routingTopology, true);
 
             messageDispatcher = new MessageDispatcher(channelProvider);

--- a/src/NServiceBus.RabbitMQ/Configuration/RabbitMQTransportSettingsExtensions.cs
+++ b/src/NServiceBus.RabbitMQ/Configuration/RabbitMQTransportSettingsExtensions.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using System.Security.Cryptography.X509Certificates;
     using Configuration.AdvanceExtensibility;
     using RabbitMQ.Client.Events;
     using Transport.RabbitMQ;
@@ -113,6 +114,18 @@
         public static TransportExtensions<RabbitMQTransport> PrefetchCount(this TransportExtensions<RabbitMQTransport> transportExtensions, ushort prefetchCount)
         {
             transportExtensions.GetSettings().Set(SettingsKeys.PrefetchCount, prefetchCount);
+            return transportExtensions;
+        }
+
+        /// <summary>
+        /// Specifies the certificates to use for client authentication when connecting to the broker via TLS.
+        /// </summary>
+        /// <param name="transportExtensions"></param>
+        /// <param name="clientCertificates">The collection of certificates to use for client authentication.</param>
+        /// <returns></returns>
+        public static TransportExtensions<RabbitMQTransport> SetClientCertificates(this TransportExtensions<RabbitMQTransport> transportExtensions, X509CertificateCollection clientCertificates)
+        {
+            transportExtensions.GetSettings().Set(SettingsKeys.ClientCertificates, clientCertificates);
             return transportExtensions;
         }
     }

--- a/src/NServiceBus.RabbitMQ/Configuration/SettingsKeys.cs
+++ b/src/NServiceBus.RabbitMQ/Configuration/SettingsKeys.cs
@@ -7,5 +7,6 @@
         public const string UsePublisherConfirms = "RabbitMQ.UsePublisherConfirms";
         public const string PrefetchMultiplier = "RabbitMQ.PrefetchMultiplier";
         public const string PrefetchCount = "RabbitMQ.PrefetchCount";
+        public const string ClientCertificates = "RabbitMQ.ClientCertificates";
     }
 }

--- a/src/NServiceBus.RabbitMQ/Connection/ConnectionFactory.cs
+++ b/src/NServiceBus.RabbitMQ/Connection/ConnectionFactory.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Security.Authentication;
+    using System.Security.Cryptography.X509Certificates;
     using global::RabbitMQ.Client;
 
     class ConnectionFactory
@@ -9,7 +10,7 @@
         readonly global::RabbitMQ.Client.ConnectionFactory connectionFactory;
         readonly object lockObject = new object();
 
-        public ConnectionFactory(ConnectionConfiguration connectionConfiguration)
+        public ConnectionFactory(ConnectionConfiguration connectionConfiguration, X509CertificateCollection clientCertificates)
         {
             if (connectionConfiguration == null)
             {
@@ -35,6 +36,7 @@
             };
 
             connectionFactory.Ssl.ServerName = connectionConfiguration.Host;
+            connectionFactory.Ssl.Certs = clientCertificates;
             connectionFactory.Ssl.CertPath = connectionConfiguration.CertPath;
             connectionFactory.Ssl.CertPassphrase = connectionConfiguration.CertPassphrase;
             connectionFactory.Ssl.Version = SslProtocols.Tls12;

--- a/src/NServiceBus.RabbitMQ/RabbitMQTransportInfrastructure.cs
+++ b/src/NServiceBus.RabbitMQ/RabbitMQTransportInfrastructure.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Security.Cryptography.X509Certificates;
     using System.Text;
     using System.Threading.Tasks;
     using global::RabbitMQ.Client.Events;
@@ -23,7 +24,10 @@
             this.settings = settings;
 
             var connectionConfiguration = new ConnectionStringParser(settings.EndpointName()).Parse(connectionString);
-            connectionFactory = new ConnectionFactory(connectionConfiguration);
+
+            X509CertificateCollection clientCertificates;
+            settings.TryGet(SettingsKeys.ClientCertificates, out clientCertificates);
+            connectionFactory = new ConnectionFactory(connectionConfiguration, clientCertificates);
 
             routingTopology = CreateRoutingTopology();
 


### PR DESCRIPTION
This lets us pass in a collection of client certificates for TLS client authentication instead of using the CertPath and CertPassphrase in the connection string.

Closes #252