### PR TITLE
isolate build packages and add versioning for local nuget.exe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ _NCrunch_NServiceBus/*
 logs
 run-git.cmd
 src/Chocolatey/Build/*
-src/.nuget/NuGet.exe
+NuGet.exe
 *.sln.inspections.xml
 
 installer/[F|f]iles

--- a/build.cmd
+++ b/build.cmd
@@ -5,8 +5,9 @@
 cd %~dp0
 setlocal
 
-:: determine cache dir
+:: determine dirs
 set NUGET_CACHE_DIR=%LocalAppData%\.nuget\v3.4.4
+set NUGET_LOCAL_DIR=src\.nuget\v3.4.4
 
 :: download nuget to cache dir
 set NUGET_URL=https://dist.nuget.org/win-x86-commandline/v3.4.4/NuGet.exe
@@ -17,12 +18,13 @@ if not exist %NUGET_CACHE_DIR%\NuGet.exe (
 )
 
 :: copy nuget locally
-if not exist src\.nuget\NuGet.exe (
-  copy %NUGET_CACHE_DIR%\NuGet.exe src\.nuget\NuGet.exe > nul
+if not exist %NUGET_LOCAL_DIR% md %NUGET_LOCAL_DIR%
+if not exist %NUGET_LOCAL_DIR%\NuGet.exe (
+  copy %NUGET_CACHE_DIR%\NuGet.exe %NUGET_LOCAL_DIR%\NuGet.exe > nul
 )
 
 :: restore packages
-src\.nuget\NuGet.exe restore .\src\NServiceBus.RabbitMQ.sln -MSBuildVersion 14
+%NUGET_LOCAL_DIR%\NuGet.exe restore .\packages.config -PackagesDirectory ./src/packages -MSBuildVersion 14 -Verbosity quiet
 
 :: run script
 "%ProgramFiles(x86)%\MSBuild\14.0\Bin\csi.exe" build.csx %*

--- a/build.csx
+++ b/build.csx
@@ -15,6 +15,7 @@ using static SimpleTargets;
 var resharperCltUrl = new Uri("https://download.jetbrains.com/resharper/JetBrains.ReSharper.CommandLineTools.2016.3.20161215.134936.zip");
 var resharperCltPath = $"{Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)}/.resharper/{resharperCltUrl.Segments.Last()}";
 var inspectCodePath = $"./.resharper/{Path.GetFileNameWithoutExtension(resharperCltUrl.Segments.Last())}/inspectcode.exe";
+var nuget = "src/.nuget/v3.4.4/NuGet.exe";
 var msBuild = $"{Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86)}/MSBuild/14.0/Bin/msbuild.exe";
 var solution = "./src/NServiceBus.RabbitMQ.sln";
 var dotSettings = "./src/NServiceBus.RabbitMQ.sln.DotSettings";
@@ -28,7 +29,9 @@ var targets = new TargetDictionary();
 
 targets.Add("default", DependsOn("build", "inspect", "unit-test", "acceptance-test", "transport-test"));
 
-targets.Add("build", () => Cmd(msBuild, $"{solution} /p:Configuration=Release /nologo /m /v:m /nr:false"));
+targets.Add("restore", () => Cmd(nuget, $"restore {solution}"));
+
+targets.Add("build", DependsOn("restore"), () => Cmd(msBuild, $"{solution} /p:Configuration=Release /nologo /m /v:m /nr:false"));
 
 targets.Add(
     "download-resharper-clt",

--- a/packages.config
+++ b/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit.ConsoleRunner" version="3.5.0" />
+  <package id="simple-targets-csx" version="5.0.0" />
+</packages>

--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -3,6 +3,4 @@
   <package id="ConsoleTweet" version="0.1.0" />
   <package id="GitHubReleaseNotes" version="0.1.1" />
   <package id="NuGet.CommandLine" version="2.8.3" />
-  <package id="NUnit.ConsoleRunner" version="3.5.0" />
-  <package id="simple-targets-csx" version="5.0.0" />
 </packages>


### PR DESCRIPTION
Some ideas around how to clean up/improve the build command. Looking for opinion on this.

Switching to `-Verbosity quiet` when restoring the build packages gets rid of the annoying 

> All packages listed in packages.config are already installed.

...every time the build command is run, even when running something like `.\build.cmd -?`

However, I think it's better to have the regular NuGet.exe output when restoring the solution packages, and isolating the build packages from the solution packages allows us to do this.

Local versioning of NuGet.exe is something we've discussed before, and could be split into a separate PR  (probably ought to be a separate commit).