### PR TITLE
address inspectcode warnings

### DIFF
--- a/src/NServiceBus.RabbitMQ.AcceptanceTests/ConfigureEndpointRabbitMQTransport.cs
+++ b/src/NServiceBus.RabbitMQ.AcceptanceTests/ConfigureEndpointRabbitMQTransport.cs
@@ -130,6 +130,11 @@ class ConfigureEndpointRabbitMQTransport : IConfigureEndpointTestExecution
 
     class Queue
     {
-        public string Name { get; set; }
+        public Queue(string name)
+        {
+            Name = name;
+        }
+
+        public string Name { get; }
     }
 }

--- a/src/NServiceBus.RabbitMQ.Tests/ConnectionString/ConnectionConfigurationTests.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/ConnectionString/ConnectionConfigurationTests.cs
@@ -7,10 +7,6 @@
     [TestFixture]
     public class ConnectionConfigurationTests
     {
-        const string connectionString =
-            "virtualHost=Copa;username=Copa;host=192.168.1.1:1234;password=abc_xyz;port=12345;requestedHeartbeat=3;" +
-            "retryDelay=01:02:03;useTls=true;certPath=/path/to/client/keycert.p12;certPassPhrase=abc123";
-
         const string endpointName = "endpoint";
 
         ConnectionConfiguration defaults = ConnectionConfiguration.Create("host=localhost", "endpoint");
@@ -18,6 +14,10 @@
         [Test]
         public void Should_correctly_parse_full_connection_string()
         {
+            var connectionString =
+               "virtualHost=Copa;username=Copa;host=192.168.1.1:1234;password=abc_xyz;port=12345;requestedHeartbeat=3;" +
+               "retryDelay=01:02:03;useTls=true;certPath=/path/to/client/keycert.p12;certPassPhrase=abc123";
+
             var connectionConfiguration = ConnectionConfiguration.Create(connectionString, endpointName);
 
             Assert.AreEqual(connectionConfiguration.Host, "192.168.1.1");

--- a/src/NServiceBus.RabbitMQ.Tests/OutgoingMessageBuilder.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/OutgoingMessageBuilder.cs
@@ -8,9 +8,9 @@
 
     public class OutgoingMessageBuilder
     {
-        public OutgoingMessageBuilder WithBody(byte[] body)
+        public OutgoingMessageBuilder WithBody(byte[] newBody)
         {
-            this.body = body;
+            body = newBody;
             return this;
         }
 

--- a/src/NServiceBus.RabbitMQ.Tests/RabbitMqContext.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/RabbitMqContext.cs
@@ -36,7 +36,7 @@
 
             messagePump = new MessagePump(connectionFactory, new MessageConverter(), "Unit test", channelProvider, purger, TimeSpan.FromMinutes(2), 3, 0);
 
-            routingTopology.Reset(connectionFactory, new[] { ReceiverQueue }.Concat(AdditionalReceiverQueues), new[] { ErrorQueue });
+            routingTopology.Reset(connectionFactory, new[] { ReceiverQueue }.Concat(AdditionalReceiverQueues).ToList(), new[] { ErrorQueue });
 
             subscriptionManager = new SubscriptionManager(connectionFactory, routingTopology, ReceiverQueue);
 

--- a/src/NServiceBus.RabbitMQ.Tests/Support/ConventionalRoutingTopologyExtensions.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/Support/ConventionalRoutingTopologyExtensions.cs
@@ -8,8 +8,8 @@ namespace NServiceBus.Transport.RabbitMQ.Tests.Support
         public static void Reset(
             this ConventionalRoutingTopology routingTopology,
             ConnectionFactory connectionFactory,
-            IEnumerable<string> receivingAddresses,
-            IEnumerable<string> sendingAddresses)
+            IList<string> receivingAddresses,
+            IList<string> sendingAddresses)
         {
             using (var connection = connectionFactory.CreateAdministrationConnection())
             using (var channel = connection.CreateModel())

--- a/src/NServiceBus.RabbitMQ.Tests/When_sending_a_message_over_rabbitmq.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/When_sending_a_message_over_rabbitmq.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Linq;
     using System.Text;
     using System.Threading.Tasks;
@@ -47,7 +48,7 @@
         {
             var timeToBeReceived = TimeSpan.FromDays(1);
 
-            return Verify(new OutgoingMessageBuilder().TimeToBeReceived(timeToBeReceived), received => Assert.AreEqual(timeToBeReceived.TotalMilliseconds.ToString(), received.BasicProperties.Expiration));
+            return Verify(new OutgoingMessageBuilder().TimeToBeReceived(timeToBeReceived), received => Assert.AreEqual(timeToBeReceived.TotalMilliseconds.ToString(CultureInfo.CurrentCulture), received.BasicProperties.Expiration));
         }
 
         [Test]
@@ -104,7 +105,7 @@
 
             var messageId = operations.MulticastTransportOperations.FirstOrDefault()?.Message.MessageId ?? operations.UnicastTransportOperations.FirstOrDefault()?.Message.MessageId;
 
-            var result = Consume(messageId, queueToReceiveOn);
+            var result = Consume(messageId);
 
             var converter = new MessageConverter();
             var convertedHeaders = converter.RetrieveHeaders(result);
@@ -119,7 +120,7 @@
 
         Task Verify(OutgoingMessageBuilder builder, Action<BasicDeliverEventArgs> assertion) => Verify(builder, (t, r) => assertion(r));
 
-        BasicDeliverEventArgs Consume(string id, string queueToReceiveOn)
+        BasicDeliverEventArgs Consume(string id)
         {
             using (var connection = connectionFactory.CreateConnection("Consume"))
             using (var channel = connection.CreateModel())

--- a/src/NServiceBus.RabbitMQ/Configuration/ConnectionConfiguration.cs
+++ b/src/NServiceBus.RabbitMQ/Configuration/ConnectionConfiguration.cs
@@ -138,11 +138,13 @@
                 invalidOptionsMessage.AppendLine("Invalid connection string. 'host' value must be supplied. e.g: \"host=myServer\"");
             }
 
-            var nsbVersion = FileVersionInfo.GetVersionInfo(typeof(Endpoint).Assembly.Location);
-            var nsbFileVersion = $"{nsbVersion.FileMajorPart}.{nsbVersion.FileMinorPart}.{nsbVersion.FileBuildPart}";
+            var nsbLocation = typeof(Endpoint).Assembly.Location;
+            var nsbVersion = nsbLocation != null ? FileVersionInfo.GetVersionInfo(nsbLocation) : null;
+            var nsbFileVersion = nsbVersion != null ? $"{nsbVersion.FileMajorPart}.{nsbVersion.FileMinorPart}.{nsbVersion.FileBuildPart}" : "(unknown)";
 
-            var rabbitMQVersion = FileVersionInfo.GetVersionInfo(typeof(ConnectionConfiguration).Assembly.Location);
-            var rabbitMQFileVersion = $"{rabbitMQVersion.FileMajorPart}.{rabbitMQVersion.FileMinorPart}.{rabbitMQVersion.FileBuildPart}";
+            var rabbitMQLocation = typeof(ConnectionConfiguration).Assembly.Location;
+            var rabbitMQVersion = rabbitMQLocation != null ? FileVersionInfo.GetVersionInfo(rabbitMQLocation) : null;
+            var rabbitMQFileVersion = rabbitMQVersion != null ? $"{rabbitMQVersion.FileMajorPart}.{rabbitMQVersion.FileMinorPart}.{rabbitMQVersion.FileBuildPart}" : "(unknown)";
 
             var applicationNameAndPath = Environment.GetCommandLineArgs()[0];
             var applicationName = Path.GetFileName(applicationNameAndPath);


### PR DESCRIPTION
After these changes, only "suggestions" and warnings for the obsoletes are left:

![image](https://cloud.githubusercontent.com/assets/677704/21288406/9abbe67a-c482-11e6-9348-ea1a19499447.png)

I guess the obsolete warnings can be removed with some special Resharper incantation in a comment but not being a Resharper user I don't know what this should be.