### PR TITLE
Native delayed message delivery

### DIFF
--- a/src/NServiceBus.RabbitMQ.AcceptanceTests/ConfigureEndpointRabbitMQTransport.cs
+++ b/src/NServiceBus.RabbitMQ.AcceptanceTests/ConfigureEndpointRabbitMQTransport.cs
@@ -15,7 +15,7 @@ using RabbitMQ.Client;
 
 class ConfigureScenariosForRabbitMQTransport : IConfigureSupportedScenariosForTestExecution
 {
-    public IEnumerable<Type> UnsupportedScenarioDescriptorTypes => new[] { typeof(AllDtcTransports), typeof(AllNativeMultiQueueTransactionTransports), typeof(AllTransportsWithMessageDrivenPubSub) };
+    public IEnumerable<Type> UnsupportedScenarioDescriptorTypes => new[] { typeof(AllDtcTransports), typeof(AllNativeMultiQueueTransactionTransports), typeof(AllTransportsWithMessageDrivenPubSub), typeof(AllTransportsWithoutNativeDeferral) };
 }
 
 class ConfigureEndpointRabbitMQTransport : IConfigureEndpointTestExecution

--- a/src/NServiceBus.RabbitMQ.AcceptanceTests/DelayedDelivery/When_deferring_a_message_longer_than_allowed_maximum.cs
+++ b/src/NServiceBus.RabbitMQ.AcceptanceTests/DelayedDelivery/When_deferring_a_message_longer_than_allowed_maximum.cs
@@ -1,0 +1,50 @@
+﻿namespace NServiceBus.Transport.RabbitMQ.AcceptanceTests.DelayedDelivery
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using Features;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_deferring_a_message_longer_than_allowed_maximum : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_throw()
+        {
+            var delay = TimeSpan.FromDays(365 * 1000);
+
+            var exception = Assert.ThrowsAsync<Exception>(() => Scenario.Define<ScenarioContext>()
+                .WithEndpoint<Endpoint>(b => b.When((session, c) =>
+                {
+                    var options = new SendOptions();
+
+                    options.DelayDeliveryWith(delay);
+                    options.RouteToThisEndpoint();
+
+                    return session.Send(new MyMessage(), options);
+                }))
+                .Done(context => !context.FailedMessages.IsEmpty)
+                .Run());
+
+            Assert.That(exception, Is.Not.Null);
+            Assert.IsTrue(exception.Message.StartsWith("Message cannot be sent with"));
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(config => config.EnableFeature<TimeoutManager>());
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Task Handle(MyMessage message, IMessageHandlerContext context) => TaskEx.CompletedTask;
+            }
+        }
+
+        public class MyMessage : IMessage { }
+    }
+}

--- a/src/NServiceBus.RabbitMQ.AcceptanceTests/NServiceBus.RabbitMQ.AcceptanceTests.csproj
+++ b/src/NServiceBus.RabbitMQ.AcceptanceTests/NServiceBus.RabbitMQ.AcceptanceTests.csproj
@@ -323,6 +323,7 @@
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.1.1\Tx\When_sending_within_an_ambient_transaction.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.1.1\UnicastRoutingExtensions.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.1.1\Versioning\When_multiple_versions_of_a_message_is_published.cs" />
+    <Compile Include="DelayedDelivery\When_deferring_a_message_longer_than_allowed_maximum.cs" />
     <Compile Include="When_using_a_custom_message_id_strategy_that_returns_an_invalid_message_id.cs" />
     <Compile Include="ConfigureEndpointRabbitMQTransport.cs" />
     <Compile Include="TaskEx.cs" />

--- a/src/NServiceBus.RabbitMQ.Tests/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.RabbitMQ.Tests/APIApprovals.Approve.approved.txt
@@ -15,6 +15,7 @@ namespace NServiceBus
             "mentedException. Will be removed in version 5.0.0.", true)]
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> CallbackReceiverMaxConcurrency(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions, int maxConcurrency) { }
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> CustomMessageIdStrategy(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions, System.Func<RabbitMQ.Client.Events.BasicDeliverEventArgs, string> customIdStrategy) { }
+        public static NServiceBus.Transport.RabbitMQ.DelayedDeliverySettings DelayedDelivery(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions) { }
         [System.ObsoleteAttribute("Replaced by NServiceBus.Callbacks package. The member currently throws a NotImple" +
             "mentedException. Will be removed in version 5.0.0.", true)]
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> DisableCallbackReceiver(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions) { }
@@ -38,6 +39,11 @@ namespace NServiceBus
 }
 namespace NServiceBus.Transport.RabbitMQ
 {
+    public class DelayedDeliverySettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
+    {
+        public NServiceBus.Transport.RabbitMQ.DelayedDeliverySettings AllEndpointsSupportDelayedDelivery() { }
+        public NServiceBus.Transport.RabbitMQ.DelayedDeliverySettings DisableTimeoutManager() { }
+    }
     public interface IDeclareQueues
     {
         void DeclareAndInitialize(RabbitMQ.Client.IModel channel, System.Collections.Generic.IEnumerable<string> receivingAddresses, System.Collections.Generic.IEnumerable<string> sendingAddresses);
@@ -50,6 +56,10 @@ namespace NServiceBus.Transport.RabbitMQ
         void Send(RabbitMQ.Client.IModel channel, string address, NServiceBus.Transport.OutgoingMessage message, RabbitMQ.Client.IBasicProperties properties);
         void SetupSubscription(RabbitMQ.Client.IModel channel, System.Type type, string subscriberName);
         void TeardownSubscription(RabbitMQ.Client.IModel channel, System.Type type, string subscriberName);
+    }
+    public interface ISupportDelayedDelivery
+    {
+        void BindToDelayInfrastructure(RabbitMQ.Client.IModel channel, string address, string deliveryExchange, string routingKey);
     }
 }
 namespace NServiceBus.Transports.RabbitMQ

--- a/src/NServiceBus.RabbitMQ.Tests/DelayedDelivery/When_calculating_a_routing_key.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/DelayedDelivery/When_calculating_a_routing_key.cs
@@ -1,0 +1,30 @@
+﻿namespace NServiceBus.Transport.RabbitMQ.Tests.DelayedDelivery
+{
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class When_calculating_a_routing_key
+    {
+        [TestCase(0, "some-address", "0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.some-address", 0)]
+        [TestCase(10, "some-address", "0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1.0.1.0.some-address", 3)]
+        [TestCase(DelayInfrastructure.MaxDelayInSeconds, "some-address", "1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.some-address", 27)]
+        public void Should_return_correct_routing_key_based_on_delay(int delayInSeconds, string address, string expectedRoutingKey, int expectedStartingDelayLevel)
+        {
+            int startingDelayLevel;
+            var result = DelayInfrastructure.CalculateRoutingKey(delayInSeconds, address, out startingDelayLevel);
+
+            Assert.That(result, Is.EqualTo(expectedRoutingKey));
+            Assert.That(startingDelayLevel, Is.EqualTo(expectedStartingDelayLevel));
+        }
+
+        [Test]
+        public void Should_return_routing_key_with_delay_zero_seconds_for_negative_delay()
+        {
+            int startingDelayLevel;
+            var result = DelayInfrastructure.CalculateRoutingKey(-123, "some-address", out startingDelayLevel);
+
+            Assert.That(result, Is.EqualTo("0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.some-address"));
+            Assert.That(startingDelayLevel, Is.EqualTo(0));
+        }
+    }
+}

--- a/src/NServiceBus.RabbitMQ.Tests/NServiceBus.RabbitMQ.Tests.csproj
+++ b/src/NServiceBus.RabbitMQ.Tests/NServiceBus.RabbitMQ.Tests.csproj
@@ -97,6 +97,7 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DelayedDelivery\When_calculating_a_routing_key.cs" />
     <Compile Include="APIApprovals.cs" />
     <Compile Include="ApprovalTestConfig.cs" />
     <Compile Include="App_Packages\PublicApiGenerator.6.0.0\ApiGenerator.cs" />

--- a/src/NServiceBus.RabbitMQ.Tests/RabbitMqContext.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/RabbitMqContext.cs
@@ -28,7 +28,7 @@
             var config = ConnectionConfiguration.Create(connectionString, ReceiverQueue);
 
             connectionFactory = new ConnectionFactory(config, null);
-            channelProvider = new ChannelProvider(connectionFactory, routingTopology, true);
+            channelProvider = new ChannelProvider(connectionFactory, routingTopology, true, false);
 
             messageDispatcher = new MessageDispatcher(channelProvider);
 

--- a/src/NServiceBus.RabbitMQ.Tests/Support/ConventionalRoutingTopologyExtensions.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/Support/ConventionalRoutingTopologyExtensions.cs
@@ -20,6 +20,9 @@ namespace NServiceBus.Transport.RabbitMQ.Tests.Support
                     channel.ExchangeDelete(address, false);
                 }
 
+                DelayInfrastructure.TearDown(channel);
+                DelayInfrastructure.Build(channel);
+
                 routingTopology.DeclareAndInitialize(channel, receivingAddresses, sendingAddresses);
             }
         }

--- a/src/NServiceBus.RabbitMQ/Administration/QueueCreator.cs
+++ b/src/NServiceBus.RabbitMQ/Administration/QueueCreator.cs
@@ -21,6 +21,8 @@
             using (var connection = connectionFactory.CreateAdministrationConnection())
             using (var channel = connection.CreateModel())
             {
+                DelayInfrastructure.Build(channel);
+
                 var queueDeclaringTopology = routingTopology as IDeclareQueues;
 
                 if (queueDeclaringTopology != null)
@@ -37,6 +39,16 @@
                     foreach (var sendingAddress in queueBindings.SendingAddresses)
                     {
                         CreateQueueIfNecessary(channel, sendingAddress);
+                    }
+                }
+
+                var delayTopology = routingTopology as ISupportDelayedDelivery;
+
+                if (delayTopology != null)
+                {
+                    foreach (var receivingAddress in queueBindings.ReceivingAddresses)
+                    {
+                        delayTopology.BindToDelayInfrastructure(channel, receivingAddress, DelayInfrastructure.DeliveryExchange, DelayInfrastructure.BindingKey(receivingAddress));
                     }
                 }
             }

--- a/src/NServiceBus.RabbitMQ/Configuration/DelayedDeliverySettings.cs
+++ b/src/NServiceBus.RabbitMQ/Configuration/DelayedDeliverySettings.cs
@@ -1,0 +1,36 @@
+﻿namespace NServiceBus.Transport.RabbitMQ
+{
+    using Configuration.AdvanceExtensibility;
+    using Settings;
+
+    /// <summary>
+    /// The delayed delivery settings.
+    /// </summary>
+    public class DelayedDeliverySettings : ExposeSettings
+    {
+        internal DelayedDeliverySettings(SettingsHolder settings) : base(settings) { }
+
+        /// <summary>
+        /// Disables the timeout manager for this endpoint.
+        /// <para>
+        /// The timeout manager can be disabled once all preexisting timeouts stored in the persistence for this endpoint have expired.
+        /// </para>
+        /// </summary>
+        public DelayedDeliverySettings DisableTimeoutManager()
+        {
+            this.GetSettings().Set(SettingsKeys.DisableTimeoutManager, true);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Tells the endpoint that all other endpoints can manage their own bindings to the delay infrastructure.
+        /// </summary>
+        public DelayedDeliverySettings AllEndpointsSupportDelayedDelivery()
+        {
+            this.GetSettings().Set(SettingsKeys.AllEndpointsSupportDelayedDelivery, true);
+
+            return this;
+        }
+    }
+}

--- a/src/NServiceBus.RabbitMQ/Configuration/RabbitMQTransportSettingsExtensions.cs
+++ b/src/NServiceBus.RabbitMQ/Configuration/RabbitMQTransportSettingsExtensions.cs
@@ -128,5 +128,12 @@
             transportExtensions.GetSettings().Set(SettingsKeys.ClientCertificates, clientCertificates);
             return transportExtensions;
         }
+
+        /// <summary>
+        /// Gets the delayed delivery settings.
+        /// </summary>
+        /// <param name="transportExtensions"></param>
+        /// <returns></returns>
+        public static DelayedDeliverySettings DelayedDelivery(this TransportExtensions<RabbitMQTransport> transportExtensions) => new DelayedDeliverySettings(transportExtensions.GetSettings());
     }
 }

--- a/src/NServiceBus.RabbitMQ/Configuration/SettingsKeys.cs
+++ b/src/NServiceBus.RabbitMQ/Configuration/SettingsKeys.cs
@@ -8,5 +8,8 @@
         public const string PrefetchMultiplier = "RabbitMQ.PrefetchMultiplier";
         public const string PrefetchCount = "RabbitMQ.PrefetchCount";
         public const string ClientCertificates = "RabbitMQ.ClientCertificates";
+        public const string DisableTimeoutManager = "RabbitMQ.DisableTimeoutManager";
+        public const string AllEndpointsSupportDelayedDelivery = "RabbitMQ.AllEndpointsSupportDelayedDelivery";
+        public const string RoutingTopologySupportsDelayedDelivery = "RabbitMQ.RoutingTopologySupportsDelayedDelivery";
     }
 }

--- a/src/NServiceBus.RabbitMQ/Connection/ChannelProvider.cs
+++ b/src/NServiceBus.RabbitMQ/Connection/ChannelProvider.cs
@@ -6,12 +6,13 @@ namespace NServiceBus.Transport.RabbitMQ
 
     class ChannelProvider : IChannelProvider, IDisposable
     {
-        public ChannelProvider(ConnectionFactory connectionFactory, IRoutingTopology routingTopology, bool usePublisherConfirms)
+        public ChannelProvider(ConnectionFactory connectionFactory, IRoutingTopology routingTopology, bool usePublisherConfirms, bool allEndpointsSupportDelayedDelivery)
         {
             connection = new Lazy<IConnection>(() => connectionFactory.CreatePublishConnection());
 
             this.routingTopology = routingTopology;
             this.usePublisherConfirms = usePublisherConfirms;
+            this.allEndpointsSupportDelayedDelivery = allEndpointsSupportDelayedDelivery;
 
             channels = new ConcurrentQueue<ConfirmsAwareChannel>();
         }
@@ -24,7 +25,7 @@ namespace NServiceBus.Transport.RabbitMQ
             {
                 channel?.Dispose();
 
-                channel = new ConfirmsAwareChannel(connection.Value, routingTopology, usePublisherConfirms);
+                channel = new ConfirmsAwareChannel(connection.Value, routingTopology, usePublisherConfirms, allEndpointsSupportDelayedDelivery);
             }
 
             return channel;
@@ -63,6 +64,7 @@ namespace NServiceBus.Transport.RabbitMQ
         readonly Lazy<IConnection> connection;
         readonly IRoutingTopology routingTopology;
         readonly bool usePublisherConfirms;
+        readonly bool allEndpointsSupportDelayedDelivery;
         readonly ConcurrentQueue<ConfirmsAwareChannel> channels;
     }
 }

--- a/src/NServiceBus.RabbitMQ/DelayedDelivery/DelayInfrastructure.cs
+++ b/src/NServiceBus.RabbitMQ/DelayedDelivery/DelayInfrastructure.cs
@@ -1,0 +1,112 @@
+﻿namespace NServiceBus.Transport.RabbitMQ
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Text;
+    using global::RabbitMQ.Client;
+
+    static class DelayInfrastructure
+    {
+        const int maxNumberOfBitsToUse = 28;
+        const int maxLevel = maxNumberOfBitsToUse - 1;
+
+        public const int MaxDelayInSeconds = (1 << maxNumberOfBitsToUse) - 1;
+        public const string DelayHeader = "NServiceBus.Transport.RabbitMQ.DelayInSeconds";
+        public const string DeadLetteredMessageHeader = "x-death";
+        public const string DeliveryExchange = "nsb.delay-delivery";
+
+        public static string LevelName(int level) => $"nsb.delay-level-{level:D2}";
+
+        public static string BindingKey(string address) => $"#.{address}";
+
+        public static void Build(IModel channel)
+        {
+            var bindingKey = "1.#";
+
+            for (var level = maxLevel; level >= 0; level--)
+            {
+                var currentLevel = LevelName(level);
+                var nextLevel = LevelName(level - 1);
+
+                channel.ExchangeDeclare(currentLevel, ExchangeType.Topic, true);
+
+                var arguments = new Dictionary<string, object>
+                {
+                    { "x-queue-mode", "lazy" },
+                    { "x-message-ttl", Convert.ToInt64(Math.Pow(2, level)) * 1000 },
+                    { "x-dead-letter-exchange", level > 0 ? nextLevel : DeliveryExchange }
+                };
+
+                channel.QueueDeclare(currentLevel, true, false, false, arguments);
+                channel.QueueBind(currentLevel, currentLevel, bindingKey);
+
+                bindingKey = "*." + bindingKey;
+            }
+
+            bindingKey = "0.#";
+
+            for (var level = maxLevel; level >= 1; level--)
+            {
+                var currentLevel = LevelName(level);
+                var nextLevel = LevelName(level - 1);
+
+                channel.ExchangeBind(nextLevel, currentLevel, bindingKey);
+
+                bindingKey = "*." + bindingKey;
+            }
+
+            channel.ExchangeDeclare(DeliveryExchange, ExchangeType.Topic, true);
+            channel.ExchangeBind(DeliveryExchange, LevelName(0), bindingKey);
+        }
+
+        public static void TearDown(IModel channel)
+        {
+            channel.ExchangeDelete(DeliveryExchange);
+
+            for (var level = maxLevel; level >= 0; level--)
+            {
+                var name = LevelName(level);
+
+                channel.QueueDelete(name);
+                channel.ExchangeDelete(name);
+            }
+        }
+
+        public static StartupCheckResult CheckForInvalidSetting(bool routingTopologySupportsDelayedDelivery, bool disableTimeoutManager)
+        {
+            if (!routingTopologySupportsDelayedDelivery && disableTimeoutManager)
+            {
+                return StartupCheckResult.Failed($"Cannot disable the timeout manager when the specified routing topology does not implement {nameof(ISupportDelayedDelivery)}.");
+            }
+
+            return StartupCheckResult.Success;
+        }
+
+        public static string CalculateRoutingKey(int delayInSeconds, string address, out int startingDelayLevel)
+        {
+            if (delayInSeconds < 0)
+            {
+                delayInSeconds = 0;
+            }
+
+            var bitArray = new BitArray(new[] { delayInSeconds });
+            var sb = new StringBuilder();
+            startingDelayLevel = 0;
+
+            for (var level = maxLevel; level >= 0; level--)
+            {
+                if (startingDelayLevel == 0 && bitArray[level])
+                {
+                    startingDelayLevel = level;
+                }
+
+                sb.Append(bitArray[level] ? "1." : "0.");
+            }
+
+            sb.Append(address);
+
+            return sb.ToString();
+        }
+    }
+}

--- a/src/NServiceBus.RabbitMQ/DelayedDelivery/PreventRoutingMessagesToTimeoutManager.cs
+++ b/src/NServiceBus.RabbitMQ/DelayedDelivery/PreventRoutingMessagesToTimeoutManager.cs
@@ -1,0 +1,24 @@
+﻿namespace NServiceBus.Transport.RabbitMQ
+{
+    using Features;
+
+    class PreventRoutingMessagesToTimeoutManager : Feature
+    {
+        public PreventRoutingMessagesToTimeoutManager()
+        {
+            EnableByDefault();
+
+            Prerequisite(context => !context.Settings.HasSetting(SettingsKeys.DisableTimeoutManager), "The timeout manager is disabled.");
+        }
+
+        protected override void Setup(FeatureConfigurationContext context)
+        {
+            var routingTopologySupportsDelayedDelivery = (bool)context.Settings.Get(SettingsKeys.RoutingTopologySupportsDelayedDelivery);
+
+            if (routingTopologySupportsDelayedDelivery)
+            {
+                context.Pipeline.Remove("RouteDeferredMessageToTimeoutManager");
+            }
+        }
+    }
+}

--- a/src/NServiceBus.RabbitMQ/NServiceBus.RabbitMQ.csproj
+++ b/src/NServiceBus.RabbitMQ/NServiceBus.RabbitMQ.csproj
@@ -73,6 +73,9 @@
     <Reference Include="System.Data" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DelayedDelivery\DelayInfrastructure.cs" />
+    <Compile Include="DelayedDelivery\PreventRoutingMessagesToTimeoutManager.cs" />
+    <Compile Include="Configuration\DelayedDeliverySettings.cs" />
     <Compile Include="Connection\ChannelProvider.cs" />
     <Compile Include="Configuration\ObsoleteAppSettings.cs" />
     <Compile Include="RabbitMQTransport.cs" />
@@ -91,6 +94,7 @@
     <Compile Include="Administration\QueuePurger.cs" />
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="Routing\IDeclareQueues.cs" />
+    <Compile Include="Routing\ISupportDelayedDelivery.cs" />
     <Compile Include="Sending\MessageDispatcher.cs" />
     <Compile Include="Administration\QueueCreator.cs" />
     <Compile Include="Administration\SubscriptionManager.cs" />

--- a/src/NServiceBus.RabbitMQ/Routing/ConventionalRoutingTopology.cs
+++ b/src/NServiceBus.RabbitMQ/Routing/ConventionalRoutingTopology.cs
@@ -21,7 +21,7 @@
     /// <item><description>we generate an exchange for each queue so that we can do direct sends to the queue. it is bound as a fanout exchange</description></item>
     /// </list>
     /// </summary>
-    class ConventionalRoutingTopology : IRoutingTopology, IDeclareQueues
+    class ConventionalRoutingTopology : IRoutingTopology, IDeclareQueues, ISupportDelayedDelivery
     {
         readonly bool useDurableExchanges;
 
@@ -79,6 +79,11 @@
                 channel.QueueDeclare(address, useDurableExchanges, false, false, null);
                 Initialize(channel, address);
             }
+        }
+
+        public void BindToDelayInfrastructure(IModel channel, string address, string deliveryExchange, string routingKey)
+        {
+            channel.ExchangeBind(address, deliveryExchange, routingKey);
         }
 
         public void Initialize(IModel channel, string mainQueue)

--- a/src/NServiceBus.RabbitMQ/Routing/DirectRoutingTopology.cs
+++ b/src/NServiceBus.RabbitMQ/Routing/DirectRoutingTopology.cs
@@ -8,7 +8,7 @@
     /// <summary>
     /// Route using a static routing convention for routing messages from publishers to subscribers using routing keys.
     /// </summary>
-    class DirectRoutingTopology : IRoutingTopology, IDeclareQueues
+    class DirectRoutingTopology : IRoutingTopology, IDeclareQueues, ISupportDelayedDelivery
     {
         public DirectRoutingTopology(Conventions conventions, bool useDurableExchanges)
         {
@@ -48,6 +48,11 @@
             {
                 channel.QueueDeclare(address, useDurableExchanges, false, false, null);
             }
+        }
+
+        public void BindToDelayInfrastructure(IModel channel, string address, string deliveryExchange, string routingKey)
+        {
+            channel.QueueBind(address, deliveryExchange, routingKey);
         }
 
         public void Initialize(IModel channel, string main)

--- a/src/NServiceBus.RabbitMQ/Routing/ISupportDelayedDelivery.cs
+++ b/src/NServiceBus.RabbitMQ/Routing/ISupportDelayedDelivery.cs
@@ -1,0 +1,20 @@
+﻿namespace NServiceBus.Transport.RabbitMQ
+{
+    using global::RabbitMQ.Client;
+
+    /// <summary>
+    /// An extension for <see cref="IRoutingTopology"/> implementations which allows
+    /// for receiving messages from the delay infrastructure.
+    /// </summary>
+    public interface ISupportDelayedDelivery
+    {
+        /// <summary>
+        /// Binds an address to the delay infrastructure's delivery exchange.
+        /// </summary>
+        /// <param name="channel">The RabbitMQ channel to operate on.</param>
+        /// <param name="address">The address that needs to be bound to the delivery exchange.</param>
+        /// <param name="deliveryExchange">The name of the delivery exchange.</param>
+        /// <param name="routingKey">The routing key required for the binding.</param>
+        void BindToDelayInfrastructure(IModel channel, string address, string deliveryExchange, string routingKey);
+    }
+}


### PR DESCRIPTION
## Things to-do before merging

- Run through the following test scenarios
  - [x] Spin up NSB v5 and NSB v6 endpoints. Send a delayed message from v6 to v5 and verify it's working
  - [x] Scenario (v6 to v6) where one endpoint disables non-native timeouts
  - [x] Scenario (v6 to v6)  where all endpoints disable non-native timeouts
  - [x] [More test scenarios](https://github.com/Particular/NServiceBus.RabbitMQ/pull/329#issuecomment-277240134)
- [x] Document native delays (PR raised: Particular/docs.particular.net/pull/2451)
