### PR TITLE
AMQP field headers and custom primitive value headers are NULL

### DIFF
--- a/src/NServiceBus.RabbitMQ.Tests/MessageConverterTests.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/MessageConverterTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.Transport.RabbitMQ.Tests
 {
     using System;
-    using System.Collections;
     using System.Collections.Generic;
     using System.Text;
     using global::RabbitMQ.Client.Events;
@@ -212,27 +211,6 @@
 
             Assert.NotNull(headers);
             Assert.AreEqual("ni", headers["Foo"]);
-        }
-
-        [Test]
-        public void TestCanHandleStringArrayListsHeader()
-        {
-            var message = new BasicDeliverEventArgs
-            {
-                BasicProperties = new BasicProperties
-                {
-                    MessageId = "Blah",
-                    Headers = new Dictionary<string, object>
-                {
-                    {"Foo", new ArrayList{"Bing"}}
-                }
-                }
-            };
-
-            var headers = converter.RetrieveHeaders(message);
-
-            Assert.NotNull(headers);
-            Assert.AreEqual("Bing", headers["Foo"]);
         }
 
         [Test]

--- a/src/NServiceBus.RabbitMQ.Tests/MessageConverterTests.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/MessageConverterTests.cs
@@ -138,6 +138,62 @@
         }
 
         [Test]
+        public void TestCanHandleHeadersWithAllAmqpFieldValues()
+        {
+            var message = new BasicDeliverEventArgs
+            {
+                BasicProperties = new BasicProperties
+                {
+                    MessageId = "Blah",
+                    Headers = new Dictionary<string, object>
+                    {
+                        {"short", (short)42},
+                        {"int", 42},
+                        {"long", 42L},
+                        {"decimal", 42m},
+                        {"sbyte", (sbyte)42},
+                        {"double", 42d},
+                        {"single", 42f},
+                        {"bool", true }
+                    }
+                }
+            };
+
+            var headers = converter.RetrieveHeaders(message);
+
+            Assert.NotNull(headers);
+            Assert.AreEqual("42", headers["short"]);
+            Assert.AreEqual("42", headers["int"]);
+            Assert.AreEqual("42", headers["long"]);
+            Assert.AreEqual("42", headers["decimal"]);
+            Assert.AreEqual("42", headers["sbyte"]);
+            Assert.AreEqual("42", headers["double"]);
+            Assert.AreEqual("42", headers["single"]);
+            Assert.AreEqual("True", headers["bool"]);
+        }
+
+        [Test]
+        public void TestCanHandleAmqpTimestampHeader()
+        {
+            var message = new BasicDeliverEventArgs
+            {
+                BasicProperties = new BasicProperties
+                {
+                    MessageId = "Blah",
+                    Headers = new Dictionary<string, object>
+                    {
+                        {"Foo", new global::RabbitMQ.Client.AmqpTimestamp(int.MaxValue) }
+                    }
+                }
+            };
+
+            var headers = converter.RetrieveHeaders(message);
+
+            Assert.NotNull(headers);
+            Assert.AreEqual("2038-01-19 03:14:07:000000 Z", headers["Foo"]);
+        }
+
+        [Test]
         public void TestCanHandleStringHeader()
         {
             var message = new BasicDeliverEventArgs


### PR DESCRIPTION
While working on #329, I hit a point where I needed to improve how incoming header values were being handled. It didn't make sense to do that in the same branch, since it's not specific to native delays, so here is that work.

`ValueToString` should now be able to handle any possible value that could be in the `BasicProperties.Headers` collection, according to the AMQP spec and the RabbitMQ client's [implementation](https://github.com/rabbitmq/rabbitmq-dotnet-client/blob/master/projects/client/RabbitMQ.Client/src/client/impl/WireFormatting.cs#L111).

CC: @SeanFeldman 