### PR TITLE
dispose of channels in ChannelProvider

### DIFF
--- a/src/NServiceBus.RabbitMQ/Connection/ChannelProvider.cs
+++ b/src/NServiceBus.RabbitMQ/Connection/ChannelProvider.cs
@@ -53,6 +53,11 @@ namespace NServiceBus.Transport.RabbitMQ
             {
                 connection.Value.Dispose();
             }
+
+            foreach (var channel in channels)
+            {
+                channel.Dispose();
+            }
         }
 
         readonly Lazy<IConnection> connection;


### PR DESCRIPTION
Thanks to @SimonCropp for pointing this out.

@Particular/rabbitmq-transport-maintainers I guess we should consider this as tech-debt, unless we can demonstrate a functional change.