### PR TITLE
seal RabbitMQTransportInfrastructure

### DIFF
--- a/src/NServiceBus.RabbitMQ/RabbitMQTransportInfrastructure.cs
+++ b/src/NServiceBus.RabbitMQ/RabbitMQTransportInfrastructure.cs
@@ -12,7 +12,7 @@
     using Settings;
 
     [SkipWeaving]
-    class RabbitMQTransportInfrastructure : TransportInfrastructure, IDisposable
+    sealed class RabbitMQTransportInfrastructure : TransportInfrastructure, IDisposable
     {
         readonly SettingsHolder settings;
         readonly ConnectionFactory connectionFactory;


### PR DESCRIPTION
 - while the class only has a Dispose() method, it's not inheritable