### PR TITLE
Hotfix 4.3.1

### DIFF
--- a/src/NServiceBus.RabbitMQ.Tests/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.RabbitMQ.Tests/APIApprovals.Approve.approved.txt
@@ -41,6 +41,8 @@ namespace NServiceBus.Transport.RabbitMQ
 {
     public class DelayedDeliverySettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
     {
+        [System.ObsoleteAttribute("Will be treated as an error from version 5.0.0. Will be removed in version 5.0.0." +
+            "", false)]
         public NServiceBus.Transport.RabbitMQ.DelayedDeliverySettings AllEndpointsSupportDelayedDelivery() { }
         public NServiceBus.Transport.RabbitMQ.DelayedDeliverySettings DisableTimeoutManager() { }
     }

--- a/src/NServiceBus.RabbitMQ.Tests/RabbitMqContext.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/RabbitMqContext.cs
@@ -28,7 +28,7 @@
             var config = ConnectionConfiguration.Create(connectionString, ReceiverQueue);
 
             connectionFactory = new ConnectionFactory(config, null);
-            channelProvider = new ChannelProvider(connectionFactory, routingTopology, true, false);
+            channelProvider = new ChannelProvider(connectionFactory, routingTopology, true);
 
             messageDispatcher = new MessageDispatcher(channelProvider);
 

--- a/src/NServiceBus.RabbitMQ/Configuration/DelayedDeliverySettings.cs
+++ b/src/NServiceBus.RabbitMQ/Configuration/DelayedDeliverySettings.cs
@@ -6,7 +6,7 @@
     /// <summary>
     /// The delayed delivery settings.
     /// </summary>
-    public class DelayedDeliverySettings : ExposeSettings
+    public partial class DelayedDeliverySettings : ExposeSettings
     {
         internal DelayedDeliverySettings(SettingsHolder settings) : base(settings) { }
 
@@ -20,14 +20,6 @@
         {
             this.GetSettings().Set(SettingsKeys.DisableTimeoutManager, true);
 
-            return this;
-        }
-
-        /// <summary>
-        /// Tells the endpoint that all other endpoints can manage their own bindings to the delay infrastructure.
-        /// </summary>
-        public DelayedDeliverySettings AllEndpointsSupportDelayedDelivery()
-        {
             return this;
         }
     }

--- a/src/NServiceBus.RabbitMQ/Configuration/DelayedDeliverySettings.cs
+++ b/src/NServiceBus.RabbitMQ/Configuration/DelayedDeliverySettings.cs
@@ -28,8 +28,6 @@
         /// </summary>
         public DelayedDeliverySettings AllEndpointsSupportDelayedDelivery()
         {
-            this.GetSettings().Set(SettingsKeys.AllEndpointsSupportDelayedDelivery, true);
-
             return this;
         }
     }

--- a/src/NServiceBus.RabbitMQ/Configuration/SettingsKeys.cs
+++ b/src/NServiceBus.RabbitMQ/Configuration/SettingsKeys.cs
@@ -9,7 +9,6 @@
         public const string PrefetchCount = "RabbitMQ.PrefetchCount";
         public const string ClientCertificates = "RabbitMQ.ClientCertificates";
         public const string DisableTimeoutManager = "RabbitMQ.DisableTimeoutManager";
-        public const string AllEndpointsSupportDelayedDelivery = "RabbitMQ.AllEndpointsSupportDelayedDelivery";
         public const string RoutingTopologySupportsDelayedDelivery = "RabbitMQ.RoutingTopologySupportsDelayedDelivery";
     }
 }

--- a/src/NServiceBus.RabbitMQ/Connection/ChannelProvider.cs
+++ b/src/NServiceBus.RabbitMQ/Connection/ChannelProvider.cs
@@ -6,13 +6,12 @@ namespace NServiceBus.Transport.RabbitMQ
 
     class ChannelProvider : IChannelProvider, IDisposable
     {
-        public ChannelProvider(ConnectionFactory connectionFactory, IRoutingTopology routingTopology, bool usePublisherConfirms, bool allEndpointsSupportDelayedDelivery)
+        public ChannelProvider(ConnectionFactory connectionFactory, IRoutingTopology routingTopology, bool usePublisherConfirms)
         {
             connection = new Lazy<IConnection>(() => connectionFactory.CreatePublishConnection());
 
             this.routingTopology = routingTopology;
             this.usePublisherConfirms = usePublisherConfirms;
-            this.allEndpointsSupportDelayedDelivery = allEndpointsSupportDelayedDelivery;
 
             channels = new ConcurrentQueue<ConfirmsAwareChannel>();
         }
@@ -25,7 +24,7 @@ namespace NServiceBus.Transport.RabbitMQ
             {
                 channel?.Dispose();
 
-                channel = new ConfirmsAwareChannel(connection.Value, routingTopology, usePublisherConfirms, allEndpointsSupportDelayedDelivery);
+                channel = new ConfirmsAwareChannel(connection.Value, routingTopology, usePublisherConfirms);
             }
 
             return channel;
@@ -64,7 +63,6 @@ namespace NServiceBus.Transport.RabbitMQ
         readonly Lazy<IConnection> connection;
         readonly IRoutingTopology routingTopology;
         readonly bool usePublisherConfirms;
-        readonly bool allEndpointsSupportDelayedDelivery;
         readonly ConcurrentQueue<ConfirmsAwareChannel> channels;
     }
 }

--- a/src/NServiceBus.RabbitMQ/RabbitMQTransportInfrastructure.cs
+++ b/src/NServiceBus.RabbitMQ/RabbitMQTransportInfrastructure.cs
@@ -45,10 +45,7 @@
 
             settings.TryGet(SettingsKeys.DisableTimeoutManager, out disableTimeoutManager);
 
-            bool allEndpointsSupportDelayedDelivery;
-            settings.TryGet(SettingsKeys.AllEndpointsSupportDelayedDelivery, out allEndpointsSupportDelayedDelivery);
-
-            channelProvider = new ChannelProvider(connectionFactory, routingTopology, usePublisherConfirms, allEndpointsSupportDelayedDelivery);
+            channelProvider = new ChannelProvider(connectionFactory, routingTopology, usePublisherConfirms);
 
             RequireOutboxConsent = false;
         }

--- a/src/NServiceBus.RabbitMQ/obsoletes.cs
+++ b/src/NServiceBus.RabbitMQ/obsoletes.cs
@@ -26,6 +26,18 @@ namespace NServiceBus
     }
 }
 
+namespace NServiceBus.Transport.RabbitMQ
+{
+    public partial class DelayedDeliverySettings
+    {
+        [ObsoleteEx(RemoveInVersion = "5.0", TreatAsErrorFromVersion = "5.0")]
+        public DelayedDeliverySettings AllEndpointsSupportDelayedDelivery()
+        {
+            return this;
+        }
+    }
+}
+
 namespace NServiceBus.Transports.RabbitMQ
 {
     [ObsoleteEx(RemoveInVersion = "5.0", TreatAsErrorFromVersion = "4.0")]


### PR DESCRIPTION
This removes the `allEndpointsSupportDelayedDelivery` implementation, meaning that `BindToDelayInfrastructure` now gets called before every delayed message send, generating an error if the destination doesn't yet exist in the broker.

The public API has been obsoleted as well. I've gone with a warning, to be removed in 5.0. I suppose we could keep it around as an error in 5.0, and remove in 6.0?



Connects to #367 