### PR TITLE
require VS 2017

### DIFF
--- a/src/NServiceBus.RabbitMQ.sln
+++ b/src/NServiceBus.RabbitMQ.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26403.7
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus.RabbitMQ", "NServiceBus.RabbitMQ\NServiceBus.RabbitMQ.csproj", "{BA731749-22C7-4025-8A4D-465AE8E02E61}"
 EndProject


### PR DESCRIPTION
I think this should have been done as part of https://github.com/Particular/NServiceBus.RabbitMQ/pull/366

When I open the solution from develop, it opens in VS 2015 (I have both VS 2015 and VS 2017 on this machine) and the solution fails to compile.