### PR TITLE
converted RabbitMqContext.TryWaitForMessageReceipt() to expression bodied member

### DIFF
--- a/src/NServiceBus.RabbitMQ.Tests/RabbitMqContext.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/RabbitMqContext.cs
@@ -61,10 +61,7 @@
             channelProvider?.Dispose();
         }
 
-        protected bool TryWaitForMessageReceipt()
-        {
-            return TryReceiveMessage(out var message, incomingMessageTimeout);
-        }
+        protected bool TryWaitForMessageReceipt() => TryReceiveMessage(out var _, incomingMessageTimeout);
 
         protected IncomingMessage ReceiveMessage()
         {


### PR DESCRIPTION
Building on the changes in #366 