### PR TITLE
Hotfix 4.3.2

### DIFF
--- a/src/NServiceBus.RabbitMQ.AcceptanceTests/ConfigureEndpointRabbitMQTransport.cs
+++ b/src/NServiceBus.RabbitMQ.AcceptanceTests/ConfigureEndpointRabbitMQTransport.cs
@@ -33,7 +33,9 @@ class ConfigureEndpointRabbitMQTransport : IConfigureEndpointTestExecution
 
         connectionStringBuilder = new DbConnectionStringBuilder { ConnectionString = connectionString };
 
-        configuration.UseTransport<RabbitMQTransport>().ConnectionString(connectionStringBuilder.ConnectionString);
+        var transport = configuration.UseTransport<RabbitMQTransport>();
+        transport.ConnectionString(connectionStringBuilder.ConnectionString);
+        transport.DelayedDelivery().DisableTimeoutManager();
 
         return TaskEx.CompletedTask;
     }

--- a/src/NServiceBus.RabbitMQ.sln
+++ b/src/NServiceBus.RabbitMQ.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26430.4
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus.RabbitMQ", "NServiceBus.RabbitMQ\NServiceBus.RabbitMQ.csproj", "{BA731749-22C7-4025-8A4D-465AE8E02E61}"
 EndProject

--- a/src/NServiceBus.RabbitMQ.sln.DotSettings
+++ b/src/NServiceBus.RabbitMQ.sln.DotSettings
@@ -1,6 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 
-	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp60</s:String>
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp70</s:String>
 	<s:Boolean x:Key="/Default/CodeEditing/Intellisense/CodeCompletion/AutoCompleteBasicCompletion/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeEditing/Intellisense/CodeCompletion/IntelliSenseCompletingCharacters/IntelliSenseCompletingCharactersSettingCSharp/UpgradedFromVSSettings/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeEditing/Intellisense/LookupWindow/ShowSummary/@EntryValue">True</s:Boolean>

--- a/src/NServiceBus.RabbitMQ/Sending/MessageDispatcher.cs
+++ b/src/NServiceBus.RabbitMQ/Sending/MessageDispatcher.cs
@@ -47,9 +47,9 @@
             var message = transportOperation.Message;
 
             var properties = channel.CreateBasicProperties();
-            properties.Fill(message, transportOperation.DeliveryConstraints);
+            properties.Fill(message, transportOperation.DeliveryConstraints, out var destination);
 
-            return channel.SendMessage(transportOperation.Destination, message, properties);
+            return channel.SendMessage(destination ?? transportOperation.Destination, message, properties);
         }
 
         Task PublishMessage(MulticastTransportOperation transportOperation, ConfirmsAwareChannel channel)
@@ -57,7 +57,7 @@
             var message = transportOperation.Message;
 
             var properties = channel.CreateBasicProperties();
-            properties.Fill(message, transportOperation.DeliveryConstraints);
+            properties.Fill(message, transportOperation.DeliveryConstraints, out _);
 
             return channel.PublishMessage(transportOperation.MessageType, message, properties);
         }


### PR DESCRIPTION
The first commit adds a check to `CalculateDelay` to look for timeout manager headers, which will be present on the message if the timeout manager is enabled and the message is a delayed retry. The destination in the header is passed back to the `MessageDispatcher` so it can be used instead if it's found.

The second commit improves the `DelayInfrastructure.CheckForInvalidSettings` to verify that the timeout manager is actually active when we expect to be, and points to `DisableTimeoutManager` if it isn't. There is also some cleanup in `RabbitMQTransportInfrastructure` since `CheckForInvalidSettings` now gets passed the `SettingsHolder` directly.

We could try and identify more specifically the reason when the timeout manager isn't active, but I didn't see that providing a lot of additional value.

Fixes #374 
Fixes #375