### PR TITLE
Hotfix 4.3.2 - additional changes

### DIFF
--- a/src/NServiceBus.RabbitMQ.Tests/DelayedDelivery/When_routing_topology_does_not_support_delayed_delivery.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/DelayedDelivery/When_routing_topology_does_not_support_delayed_delivery.cs
@@ -7,6 +7,9 @@
     [TestFixture]
     class When_routing_topology_does_not_support_delayed_delivery
     {
+        const string CoreSendOnlyEndpointKey = "Endpoint.SendOnly";
+        const string CoreExternalTimeoutManagerAddressKey = "NServiceBus.ExternalTimeoutManagerAddress";
+
         SettingsHolder settings;
 
         [SetUp]
@@ -59,7 +62,7 @@
         public void Should_allow_startup_if_timeout_manager_feature_is_deactivated_by_send_only()
         {
             settings.Set(typeof(TimeoutManager).FullName, FeatureState.Deactivated);
-            settings.Set("Endpoint.SendOnly", true);
+            settings.Set(CoreSendOnlyEndpointKey, true);
 
             var result = DelayInfrastructure.CheckForInvalidSettings(settings);
 
@@ -69,7 +72,7 @@
         [Test]
         public void Should_allow_startup_if_external_timeout_manager_address_is_configured()
         {
-            settings.Set("NServiceBus.ExternalTimeoutManagerAddress", "endpoint");
+            settings.Set(CoreExternalTimeoutManagerAddressKey, "endpoint");
 
             var result = DelayInfrastructure.CheckForInvalidSettings(settings);
 

--- a/src/NServiceBus.RabbitMQ.Tests/DelayedDelivery/When_routing_topology_does_not_support_delayed_delivery.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/DelayedDelivery/When_routing_topology_does_not_support_delayed_delivery.cs
@@ -1,0 +1,79 @@
+﻿namespace NServiceBus.Transport.RabbitMQ.Tests.DelayedDelivery
+{
+    using Features;
+    using NUnit.Framework;
+    using Settings;
+
+    [TestFixture]
+    class When_routing_topology_does_not_support_delayed_delivery
+    {
+        SettingsHolder settings;
+
+        [SetUp]
+        public void Setup()
+        {
+            settings = new SettingsHolder();
+            settings.Set(SettingsKeys.RoutingTopologySupportsDelayedDelivery, false);
+        }
+
+        [Test]
+        public void Should_allow_startup_if_DisableTimeoutManager_setting_is_not_set()
+        {
+            var result = DelayInfrastructure.CheckForInvalidSettings(settings);
+
+            Assert.True(result.Succeeded);
+        }
+
+        [Test]
+        public void Should_prevent_startup_if_DisableTimeoutManager_setting_is_set()
+        {
+            settings.Set(SettingsKeys.DisableTimeoutManager, true);
+
+            var result = DelayInfrastructure.CheckForInvalidSettings(settings);
+
+            Assert.False(result.Succeeded);
+            Assert.AreEqual("Cannot disable the timeout manager when the specified routing topology does not implement ISupportDelayedDelivery.", result.ErrorMessage);
+        }
+
+        [Test]
+        public void Should_allow_startup_if_timeout_manager_feature_is_active()
+        {
+            settings.Set(typeof(TimeoutManager).FullName, FeatureState.Active);
+
+            var result = DelayInfrastructure.CheckForInvalidSettings(settings);
+
+            Assert.True(result.Succeeded);
+        }
+
+        [Test]
+        public void Should_allow_startup_if_timeout_manager_feature_is_disabled()
+        {
+            settings.Set(typeof(TimeoutManager).FullName, FeatureState.Disabled);
+
+            var result = DelayInfrastructure.CheckForInvalidSettings(settings);
+
+            Assert.True(result.Succeeded);
+        }
+
+        [Test]
+        public void Should_allow_startup_if_timeout_manager_feature_is_deactivated_by_send_only()
+        {
+            settings.Set(typeof(TimeoutManager).FullName, FeatureState.Deactivated);
+            settings.Set("Endpoint.SendOnly", true);
+
+            var result = DelayInfrastructure.CheckForInvalidSettings(settings);
+
+            Assert.True(result.Succeeded);
+        }
+
+        [Test]
+        public void Should_allow_startup_if_external_timeout_manager_address_is_configured()
+        {
+            settings.Set("NServiceBus.ExternalTimeoutManagerAddress", "endpoint");
+
+            var result = DelayInfrastructure.CheckForInvalidSettings(settings);
+
+            Assert.True(result.Succeeded);
+        }
+    }
+}

--- a/src/NServiceBus.RabbitMQ.Tests/DelayedDelivery/When_routing_topology_does_not_support_delayed_delivery.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/DelayedDelivery/When_routing_topology_does_not_support_delayed_delivery.cs
@@ -7,8 +7,8 @@
     [TestFixture]
     class When_routing_topology_does_not_support_delayed_delivery
     {
-        const string CoreSendOnlyEndpointKey = "Endpoint.SendOnly";
-        const string CoreExternalTimeoutManagerAddressKey = "NServiceBus.ExternalTimeoutManagerAddress";
+        const string coreSendOnlyEndpointKey = "Endpoint.SendOnly";
+        const string coreExternalTimeoutManagerAddressKey = "NServiceBus.ExternalTimeoutManagerAddress";
 
         SettingsHolder settings;
 
@@ -62,7 +62,7 @@
         public void Should_allow_startup_if_timeout_manager_feature_is_deactivated_by_send_only()
         {
             settings.Set(typeof(TimeoutManager).FullName, FeatureState.Deactivated);
-            settings.Set(CoreSendOnlyEndpointKey, true);
+            settings.Set(coreSendOnlyEndpointKey, true);
 
             var result = DelayInfrastructure.CheckForInvalidSettings(settings);
 
@@ -72,7 +72,7 @@
         [Test]
         public void Should_allow_startup_if_external_timeout_manager_address_is_configured()
         {
-            settings.Set(CoreExternalTimeoutManagerAddressKey, "endpoint");
+            settings.Set(coreExternalTimeoutManagerAddressKey, "endpoint");
 
             var result = DelayInfrastructure.CheckForInvalidSettings(settings);
 

--- a/src/NServiceBus.RabbitMQ.Tests/DelayedDelivery/When_routing_topology_supports_delayed_delivery.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/DelayedDelivery/When_routing_topology_supports_delayed_delivery.cs
@@ -1,0 +1,108 @@
+﻿namespace NServiceBus.Transport.RabbitMQ.Tests.DelayedDelivery
+{
+    using Features;
+    using NUnit.Framework;
+    using Settings;
+
+    [TestFixture]
+    class When_routing_topology_supports_delayed_delivery
+    {
+        SettingsHolder settings;
+
+        [SetUp]
+        public void Setup()
+        {
+            settings = new SettingsHolder();
+            settings.Set(SettingsKeys.RoutingTopologySupportsDelayedDelivery, true);
+        }
+
+        [Test]
+        public void Should_allow_startup_if_DisableTimeoutManager_setting_is_not_set()
+        {
+            settings.Set(typeof(TimeoutManager).FullName, FeatureState.Active);
+
+            var result = DelayInfrastructure.CheckForInvalidSettings(settings);
+
+            Assert.True(result.Succeeded);
+        }
+
+        [Test]
+        public void Should_allow_startup_if_DisableTimeoutManager_setting_is_set()
+        {
+            settings.Set(SettingsKeys.DisableTimeoutManager, true);
+
+            var result = DelayInfrastructure.CheckForInvalidSettings(settings);
+
+            Assert.True(result.Succeeded);
+        }
+
+        [Test]
+        public void Should_allow_startup_if_timeout_manager_feature_is_active()
+        {
+            settings.Set(typeof(TimeoutManager).FullName, FeatureState.Active);
+
+            var result = DelayInfrastructure.CheckForInvalidSettings(settings);
+
+            Assert.True(result.Succeeded);
+        }
+
+        [Test]
+        public void Should_prevent_startup_if_timeout_manager_feature_is_disabled_and_DisableTimeoutManager_setting_is_not_set()
+        {
+            settings.Set(typeof(TimeoutManager).FullName, FeatureState.Disabled);
+
+            var result = DelayInfrastructure.CheckForInvalidSettings(settings);
+
+            Assert.False(result.Succeeded);
+            Assert.AreEqual("The timeout manager is not active, but the transport has not been properly configured for this. " +
+                        "Use 'EndpointConfiguration.UseTransport<RabbitMQTransport>().DelayedDelivery().DisableTimeoutManager()' to ensure delayed messages can be sent properly.", result.ErrorMessage);
+        }
+
+        [Test]
+        public void Should_allow_startup_if_timeout_manager_feature_is_disabled_and_DisableTimeoutManager_setting_is_set()
+        {
+            settings.Set(SettingsKeys.DisableTimeoutManager, true);
+            settings.Set(typeof(TimeoutManager).FullName, FeatureState.Disabled);
+
+            var result = DelayInfrastructure.CheckForInvalidSettings(settings);
+
+            Assert.True(result.Succeeded);
+        }
+
+        [Test]
+        public void Should_prevent_startup_if_timeout_manager_feature_is_deactivated_by_send_only_and_DisableTimeoutManager_setting_is_not_set()
+        {
+            settings.Set(typeof(TimeoutManager).FullName, FeatureState.Deactivated);
+            settings.Set("Endpoint.SendOnly", true);
+
+            var result = DelayInfrastructure.CheckForInvalidSettings(settings);
+
+            Assert.False(result.Succeeded);
+            Assert.AreEqual("The timeout manager is not active, but the transport has not been properly configured for this. " +
+                     "Use 'EndpointConfiguration.UseTransport<RabbitMQTransport>().DelayedDelivery().DisableTimeoutManager()' to ensure delayed messages can be sent properly.", result.ErrorMessage);
+        }
+
+        [Test]
+        public void Should_allow_startup_if_timeout_manager_feature_is_deactivated_by_send_only_and_DisableTimeoutManager_setting_set()
+        {
+            settings.Set(SettingsKeys.DisableTimeoutManager, true);
+            settings.Set(typeof(TimeoutManager).FullName, FeatureState.Deactivated);
+            settings.Set("Endpoint.SendOnly", true);
+
+            var result = DelayInfrastructure.CheckForInvalidSettings(settings);
+
+            Assert.True(result.Succeeded);
+        }
+
+        [Test]
+        public void Should_prevent_startup_if_external_timeout_manager_address_is_configured()
+        {
+            settings.Set("NServiceBus.ExternalTimeoutManagerAddress", "endpoint");
+
+            var result = DelayInfrastructure.CheckForInvalidSettings(settings);
+
+            Assert.False(result.Succeeded);
+            Assert.AreEqual("An external timeout manager address cannot be configured because the timeout manager is not being used for delayed delivery.", result.ErrorMessage);
+        }
+    }
+}

--- a/src/NServiceBus.RabbitMQ.Tests/DelayedDelivery/When_routing_topology_supports_delayed_delivery.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/DelayedDelivery/When_routing_topology_supports_delayed_delivery.cs
@@ -7,6 +7,9 @@
     [TestFixture]
     class When_routing_topology_supports_delayed_delivery
     {
+        const string CoreSendOnlyEndpointKey = "Endpoint.SendOnly";
+        const string CoreExternalTimeoutManagerAddressKey = "NServiceBus.ExternalTimeoutManagerAddress";
+
         SettingsHolder settings;
 
         [SetUp]
@@ -73,7 +76,7 @@
         public void Should_prevent_startup_if_timeout_manager_feature_is_deactivated_by_send_only_and_DisableTimeoutManager_setting_is_not_set()
         {
             settings.Set(typeof(TimeoutManager).FullName, FeatureState.Deactivated);
-            settings.Set("Endpoint.SendOnly", true);
+            settings.Set(CoreSendOnlyEndpointKey, true);
 
             var result = DelayInfrastructure.CheckForInvalidSettings(settings);
 
@@ -87,7 +90,7 @@
         {
             settings.Set(SettingsKeys.DisableTimeoutManager, true);
             settings.Set(typeof(TimeoutManager).FullName, FeatureState.Deactivated);
-            settings.Set("Endpoint.SendOnly", true);
+            settings.Set(CoreSendOnlyEndpointKey, true);
 
             var result = DelayInfrastructure.CheckForInvalidSettings(settings);
 
@@ -97,7 +100,7 @@
         [Test]
         public void Should_prevent_startup_if_external_timeout_manager_address_is_configured()
         {
-            settings.Set("NServiceBus.ExternalTimeoutManagerAddress", "endpoint");
+            settings.Set(CoreExternalTimeoutManagerAddressKey, "endpoint");
 
             var result = DelayInfrastructure.CheckForInvalidSettings(settings);
 

--- a/src/NServiceBus.RabbitMQ.Tests/DelayedDelivery/When_routing_topology_supports_delayed_delivery.cs
+++ b/src/NServiceBus.RabbitMQ.Tests/DelayedDelivery/When_routing_topology_supports_delayed_delivery.cs
@@ -7,8 +7,8 @@
     [TestFixture]
     class When_routing_topology_supports_delayed_delivery
     {
-        const string CoreSendOnlyEndpointKey = "Endpoint.SendOnly";
-        const string CoreExternalTimeoutManagerAddressKey = "NServiceBus.ExternalTimeoutManagerAddress";
+        const string coreSendOnlyEndpointKey = "Endpoint.SendOnly";
+        const string coreExternalTimeoutManagerAddressKey = "NServiceBus.ExternalTimeoutManagerAddress";
 
         SettingsHolder settings;
 
@@ -76,7 +76,7 @@
         public void Should_prevent_startup_if_timeout_manager_feature_is_deactivated_by_send_only_and_DisableTimeoutManager_setting_is_not_set()
         {
             settings.Set(typeof(TimeoutManager).FullName, FeatureState.Deactivated);
-            settings.Set(CoreSendOnlyEndpointKey, true);
+            settings.Set(coreSendOnlyEndpointKey, true);
 
             var result = DelayInfrastructure.CheckForInvalidSettings(settings);
 
@@ -86,11 +86,11 @@
         }
 
         [Test]
-        public void Should_allow_startup_if_timeout_manager_feature_is_deactivated_by_send_only_and_DisableTimeoutManager_setting_set()
+        public void Should_allow_startup_if_timeout_manager_feature_is_deactivated_by_send_only_and_DisableTimeoutManager_setting_is_set()
         {
             settings.Set(SettingsKeys.DisableTimeoutManager, true);
             settings.Set(typeof(TimeoutManager).FullName, FeatureState.Deactivated);
-            settings.Set(CoreSendOnlyEndpointKey, true);
+            settings.Set(coreSendOnlyEndpointKey, true);
 
             var result = DelayInfrastructure.CheckForInvalidSettings(settings);
 
@@ -100,7 +100,7 @@
         [Test]
         public void Should_prevent_startup_if_external_timeout_manager_address_is_configured()
         {
-            settings.Set(CoreExternalTimeoutManagerAddressKey, "endpoint");
+            settings.Set(coreExternalTimeoutManagerAddressKey, "endpoint");
 
             var result = DelayInfrastructure.CheckForInvalidSettings(settings);
 

--- a/src/NServiceBus.RabbitMQ.Tests/NServiceBus.RabbitMQ.Tests.csproj
+++ b/src/NServiceBus.RabbitMQ.Tests/NServiceBus.RabbitMQ.Tests.csproj
@@ -97,6 +97,8 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DelayedDelivery\When_routing_topology_does_not_support_delayed_delivery.cs" />
+    <Compile Include="DelayedDelivery\When_routing_topology_supports_delayed_delivery.cs" />
     <Compile Include="DelayedDelivery\When_calculating_a_routing_key.cs" />
     <Compile Include="APIApprovals.cs" />
     <Compile Include="ApprovalTestConfig.cs" />

--- a/src/NServiceBus.RabbitMQ/Connection/ConfirmsAwareChannel.cs
+++ b/src/NServiceBus.RabbitMQ/Connection/ConfirmsAwareChannel.cs
@@ -39,6 +39,8 @@ namespace NServiceBus.Transport.RabbitMQ
 
         public bool IsClosed => channel.IsClosed;
 
+        public bool SupportsDelayedDelivery => delayTopology != null;
+
         public Task SendMessage(string address, OutgoingMessage message, IBasicProperties properties)
         {
             Task task;
@@ -54,7 +56,7 @@ namespace NServiceBus.Transport.RabbitMQ
             }
 
             object delayValue;
-            if (properties.Headers.TryGetValue(DelayInfrastructure.DelayHeader, out delayValue) && delayTopology != null)
+            if (properties.Headers.TryGetValue(DelayInfrastructure.DelayHeader, out delayValue) && SupportsDelayedDelivery)
             {
                 int startingDelayLevel;
                 var routingKey = DelayInfrastructure.CalculateRoutingKey((int)delayValue, address, out startingDelayLevel);

--- a/src/NServiceBus.RabbitMQ/DelayedDelivery/DelayInfrastructure.cs
+++ b/src/NServiceBus.RabbitMQ/DelayedDelivery/DelayInfrastructure.cs
@@ -12,7 +12,7 @@
     {
         const int maxNumberOfBitsToUse = 28;
         const int maxLevel = maxNumberOfBitsToUse - 1;
-        const string CoreExternalTimeoutManagerAddressKey = "NServiceBus.ExternalTimeoutManagerAddress";
+        const string coreExternalTimeoutManagerAddressKey = "NServiceBus.ExternalTimeoutManagerAddress";
 
         public const int MaxDelayInSeconds = (1 << maxNumberOfBitsToUse) - 1;
         public const string DelayHeader = "NServiceBus.Transport.RabbitMQ.DelayInSeconds";
@@ -79,11 +79,11 @@
         public static StartupCheckResult CheckForInvalidSettings(SettingsHolder settings)
         {
             var routingTopologySupportsDelayedDelivery = settings.GetOrDefault<bool>(SettingsKeys.RoutingTopologySupportsDelayedDelivery);
-            var TimeoutManagerDisabled = settings.GetOrDefault<bool>(SettingsKeys.DisableTimeoutManager);
-            var externalTimeoutManagerAddress = settings.GetOrDefault<string>(CoreExternalTimeoutManagerAddressKey) != null;
+            var timeoutManagerDisabled = settings.GetOrDefault<bool>(SettingsKeys.DisableTimeoutManager);
+            var externalTimeoutManagerAddress = settings.GetOrDefault<string>(coreExternalTimeoutManagerAddressKey) != null;
             var timeoutManagerFeatureActive = settings.GetOrDefault<FeatureState>(typeof(TimeoutManager).FullName) == FeatureState.Active;
 
-            if (!routingTopologySupportsDelayedDelivery && TimeoutManagerDisabled)
+            if (!routingTopologySupportsDelayedDelivery && timeoutManagerDisabled)
             {
                 return StartupCheckResult.Failed($"Cannot disable the timeout manager when the specified routing topology does not implement {nameof(ISupportDelayedDelivery)}.");
             }
@@ -95,7 +95,7 @@
                     return StartupCheckResult.Failed("An external timeout manager address cannot be configured because the timeout manager is not being used for delayed delivery.");
                 }
 
-                if (!TimeoutManagerDisabled && !timeoutManagerFeatureActive)
+                if (!timeoutManagerDisabled && !timeoutManagerFeatureActive)
                 {
                     return StartupCheckResult.Failed("The timeout manager is not active, but the transport has not been properly configured for this. " +
                         "Use 'EndpointConfiguration.UseTransport<RabbitMQTransport>().DelayedDelivery().DisableTimeoutManager()' to ensure delayed messages can be sent properly.");

--- a/src/NServiceBus.RabbitMQ/DelayedDelivery/DelayInfrastructure.cs
+++ b/src/NServiceBus.RabbitMQ/DelayedDelivery/DelayInfrastructure.cs
@@ -12,6 +12,7 @@
     {
         const int maxNumberOfBitsToUse = 28;
         const int maxLevel = maxNumberOfBitsToUse - 1;
+        const string CoreExternalTimeoutManagerAddressKey = "NServiceBus.ExternalTimeoutManagerAddress";
 
         public const int MaxDelayInSeconds = (1 << maxNumberOfBitsToUse) - 1;
         public const string DelayHeader = "NServiceBus.Transport.RabbitMQ.DelayInSeconds";
@@ -79,7 +80,7 @@
         {
             var routingTopologySupportsDelayedDelivery = settings.GetOrDefault<bool>(SettingsKeys.RoutingTopologySupportsDelayedDelivery);
             var TimeoutManagerDisabled = settings.GetOrDefault<bool>(SettingsKeys.DisableTimeoutManager);
-            var externalTimeoutManagerAddress = settings.GetOrDefault<string>("NServiceBus.ExternalTimeoutManagerAddress") != null;
+            var externalTimeoutManagerAddress = settings.GetOrDefault<string>(CoreExternalTimeoutManagerAddressKey) != null;
             var timeoutManagerFeatureActive = settings.GetOrDefault<FeatureState>(typeof(TimeoutManager).FullName) == FeatureState.Active;
 
             if (!routingTopologySupportsDelayedDelivery && TimeoutManagerDisabled)

--- a/src/NServiceBus.RabbitMQ/RabbitMQTransportInfrastructure.cs
+++ b/src/NServiceBus.RabbitMQ/RabbitMQTransportInfrastructure.cs
@@ -16,8 +16,8 @@
     [SkipWeaving]
     sealed class RabbitMQTransportInfrastructure : TransportInfrastructure, IDisposable
     {
-        const string CoreSendOnlyEndpointKey = "Endpoint.SendOnly";
-        const string CoreHostInformationDisplayNameKey = "NServiceBus.HostInformation.DisplayName";
+        const string coreSendOnlyEndpointKey = "Endpoint.SendOnly";
+        const string coreHostInformationDisplayNameKey = "NServiceBus.HostInformation.DisplayName";
 
         readonly SettingsHolder settings;
         readonly ConnectionFactory connectionFactory;
@@ -42,7 +42,7 @@
             if (routingTopologySupportsDelayedDelivery)
             {
                 var timeoutManagerFeatureDisabled = settings.GetOrDefault<FeatureState>(typeof(TimeoutManager).FullName) == FeatureState.Disabled;
-                var sendOnlyEndpoint = settings.GetOrDefault<bool>(CoreSendOnlyEndpointKey);
+                var sendOnlyEndpoint = settings.GetOrDefault<bool>(coreSendOnlyEndpointKey);
 
                 if (timeoutManagerFeatureDisabled || sendOnlyEndpoint)
                 {
@@ -156,7 +156,7 @@
             }
 
             string hostDisplayName;
-            if (!settings.TryGet(CoreHostInformationDisplayNameKey, out hostDisplayName))
+            if (!settings.TryGet(coreHostInformationDisplayNameKey, out hostDisplayName))
             {
                 hostDisplayName = Support.RuntimeEnvironment.MachineName;
             }

--- a/src/NServiceBus.RabbitMQ/RabbitMQTransportInfrastructure.cs
+++ b/src/NServiceBus.RabbitMQ/RabbitMQTransportInfrastructure.cs
@@ -16,6 +16,9 @@
     [SkipWeaving]
     sealed class RabbitMQTransportInfrastructure : TransportInfrastructure, IDisposable
     {
+        const string CoreSendOnlyEndpointKey = "Endpoint.SendOnly";
+        const string CoreHostInformationDisplayNameKey = "NServiceBus.HostInformation.DisplayName";
+
         readonly SettingsHolder settings;
         readonly ConnectionFactory connectionFactory;
         readonly ChannelProvider channelProvider;
@@ -39,7 +42,7 @@
             if (routingTopologySupportsDelayedDelivery)
             {
                 var timeoutManagerFeatureDisabled = settings.GetOrDefault<FeatureState>(typeof(TimeoutManager).FullName) == FeatureState.Disabled;
-                var sendOnlyEndpoint = settings.GetOrDefault<bool>("Endpoint.SendOnly");
+                var sendOnlyEndpoint = settings.GetOrDefault<bool>(CoreSendOnlyEndpointKey);
 
                 if (timeoutManagerFeatureDisabled || sendOnlyEndpoint)
                 {
@@ -153,7 +156,7 @@
             }
 
             string hostDisplayName;
-            if (!settings.TryGet("NServiceBus.HostInformation.DisplayName", out hostDisplayName))
+            if (!settings.TryGet(CoreHostInformationDisplayNameKey, out hostDisplayName))
             {
                 hostDisplayName = Support.RuntimeEnvironment.MachineName;
             }

--- a/src/NServiceBus.RabbitMQ/Sending/BasicPropertiesExtensions.cs
+++ b/src/NServiceBus.RabbitMQ/Sending/BasicPropertiesExtensions.cs
@@ -12,7 +12,7 @@
 
     static class BasicPropertiesExtensions
     {
-        public static void Fill(this IBasicProperties properties, OutgoingMessage message, List<DeliveryConstraint> deliveryConstraints, out string destination)
+        public static void Fill(this IBasicProperties properties, OutgoingMessage message, List<DeliveryConstraint> deliveryConstraints, bool routingTopologySupportsDelayedDelivery, out string destination)
         {
             if (message.MessageId != null)
             {
@@ -24,7 +24,7 @@
             var messageHeaders = message.Headers ?? new Dictionary<string, string>();
 
             long delay;
-            var delayed = CalculateDelay(deliveryConstraints, messageHeaders, out delay, out destination);
+            var delayed = CalculateDelay(deliveryConstraints, messageHeaders, routingTopologySupportsDelayedDelivery, out delay, out destination);
 
             properties.Headers = messageHeaders.ToDictionary(p => p.Key, p => (object)p.Value);
 
@@ -83,7 +83,7 @@
             }
         }
 
-        static bool CalculateDelay(List<DeliveryConstraint> deliveryConstraints, Dictionary<string, string> messageHeaders, out long delay, out string destination)
+        static bool CalculateDelay(List<DeliveryConstraint> deliveryConstraints, Dictionary<string, string> messageHeaders, bool routingTopologySupportsDelayedDelivery, out long delay, out string destination)
         {
             destination = null;
 
@@ -113,7 +113,7 @@
                     throw new Exception($"Message cannot be sent with {nameof(DelayDeliveryWith)} value '{delayDeliveryWith.Delay}' because it exceeds the maximum delay value '{TimeSpan.FromSeconds(DelayInfrastructure.MaxDelayInSeconds)}'.");
                 }
             }
-            else if (messageHeaders.TryGetValue(TimeoutManagerHeaders.Expire, out var expire))
+            else if (routingTopologySupportsDelayedDelivery && messageHeaders.TryGetValue(TimeoutManagerHeaders.Expire, out var expire))
             {
                 delayed = true;
                 var expiration = DateTimeExtensions.ToUtcDateTime(expire);

--- a/src/NServiceBus.RabbitMQ/Sending/MessageDispatcher.cs
+++ b/src/NServiceBus.RabbitMQ/Sending/MessageDispatcher.cs
@@ -47,7 +47,7 @@
             var message = transportOperation.Message;
 
             var properties = channel.CreateBasicProperties();
-            properties.Fill(message, transportOperation.DeliveryConstraints, out var destination);
+            properties.Fill(message, transportOperation.DeliveryConstraints, channel.SupportsDelayedDelivery, out var destination);
 
             return channel.SendMessage(destination ?? transportOperation.Destination, message, properties);
         }
@@ -57,7 +57,7 @@
             var message = transportOperation.Message;
 
             var properties = channel.CreateBasicProperties();
-            properties.Fill(message, transportOperation.DeliveryConstraints, out _);
+            properties.Fill(message, transportOperation.DeliveryConstraints, channel.SupportsDelayedDelivery, out _);
 
             return channel.PublishMessage(transportOperation.MessageType, message, properties);
         }


### PR DESCRIPTION
Here are the revisions. If the routing topology doesn't support delayed delivery, then delayed retried will continue to work.

The invalid settings have been improved by scoping them based on wether the routing topology supports delayed delivery or not, and some settings actually mean we can go ahead and set `DisableTimeoutManager` to avoid an error condition.

I would still like to add some tests around all of this where possible, so I've marked the PR WIP for now.

Connects to #374 
Connects to #375
