### PR TITLE
Channel improvements

### DIFF
--- a/src/NServiceBus.RabbitMQ/Connection/ConfirmsAwareChannel.cs
+++ b/src/NServiceBus.RabbitMQ/Connection/ConfirmsAwareChannel.cs
@@ -192,7 +192,7 @@ namespace NServiceBus.Transport.RabbitMQ
         {
             if (messages.TryRemove(key, out var tcs))
             {
-                TaskEx.StartNew(tcs, state => ((TaskCompletionSource<bool>)state).SetResult(true));
+                TaskEx.StartNew(tcs, state => ((TaskCompletionSource<bool>)state).SetResult(true)).Ignore();
             }
         }
 
@@ -200,7 +200,7 @@ namespace NServiceBus.Transport.RabbitMQ
         {
             if (messages.TryRemove(key, out var tcs))
             {
-                TaskEx.StartNew(tcs, state => ((TaskCompletionSource<bool>)state).SetException(new Exception(exceptionMessage)));
+                TaskEx.StartNew(tcs, state => ((TaskCompletionSource<bool>)state).SetException(new Exception(exceptionMessage))).Ignore();
             }
         }
 

--- a/src/NServiceBus.RabbitMQ/NServiceBus.RabbitMQ.csproj
+++ b/src/NServiceBus.RabbitMQ/NServiceBus.RabbitMQ.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="NServiceBus" Version="6.0.0" />
     <PackageReference Include="NuGetPackager" Version="0.6.1" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="4.2.2" PrivateAssets="All" />
-    <PackageReference Include="Particular.CodeRules" Version="0.1.1" PrivateAssets="All" />
+    <PackageReference Include="Particular.CodeRules" Version="0.2.0" PrivateAssets="All" />
     <PackageReference Include="RabbitMQ.Client" Version="4.1.1" />
   </ItemGroup>
 

--- a/src/NServiceBus.RabbitMQ/TaskEx.cs
+++ b/src/NServiceBus.RabbitMQ/TaskEx.cs
@@ -9,6 +9,8 @@ namespace NServiceBus.Transport.RabbitMQ
         //TODO: remove when we update to 4.6 and can use Task.CompletedTask
         public static readonly Task CompletedTask = Task.FromResult(0);
 
+        public static void Ignore(this Task task) { }
+
         public static Task StartNew(object state, Action<object> action) => StartNew(state, action, TaskScheduler.Default);
 
         public static Task StartNew(object state, Action<object> action, TaskScheduler scheduler) => Task.Factory.StartNew(action, state, CancellationToken.None, TaskCreationOptions.DenyChildAttach, scheduler);


### PR DESCRIPTION
This improves the event handler methods in `ConfirmsAwareChannel` by limiting the code inside of the new task to be just the `TaskCompletionSource.SetResult` and `TaskCompletionSource.SetException` calls.

It also updates Particular.CodeRules to 0.2.0, which includes a rule to check for "missing" awaits. The `TaskCompletionSource` calls are intentionally not waited on, so `Ignore()` has been added to satisfy the new rule.