### PR TITLE
reduce line length of some recently touched files

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ/RabbitMQTransportInfrastructure.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/RabbitMQTransportInfrastructure.cs
@@ -79,7 +79,8 @@
             }
         }
 
-        public override OutboundRoutingPolicy OutboundRoutingPolicy => new OutboundRoutingPolicy(OutboundRoutingType.Unicast, OutboundRoutingType.Multicast, OutboundRoutingType.Unicast);
+        public override OutboundRoutingPolicy OutboundRoutingPolicy =>
+            new OutboundRoutingPolicy(OutboundRoutingType.Unicast, OutboundRoutingType.Multicast, OutboundRoutingType.Unicast);
 
         public override TransportTransactionMode TransactionMode => TransportTransactionMode.ReceiveOnly;
 
@@ -176,7 +177,15 @@
                 prefetchCount = 0;
             }
 
-            return new MessagePump(connectionFactory, messageConverter, consumerTag, channelProvider, queuePurger, timeToWaitBeforeTriggeringCircuitBreaker, prefetchMultiplier, prefetchCount);
+            return new MessagePump(
+                connectionFactory,
+                messageConverter,
+                consumerTag,
+                channelProvider,
+                queuePurger,
+                timeToWaitBeforeTriggeringCircuitBreaker,
+                prefetchMultiplier,
+                prefetchCount);
         }
     }
 }

--- a/src/NServiceBus.Transport.RabbitMQ/Sending/BasicPropertiesExtensions.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Sending/BasicPropertiesExtensions.cs
@@ -12,7 +12,12 @@
 
     static class BasicPropertiesExtensions
     {
-        public static void Fill(this IBasicProperties properties, OutgoingMessage message, List<DeliveryConstraint> deliveryConstraints, bool routingTopologySupportsDelayedDelivery, out string destination)
+        public static void Fill(
+            this IBasicProperties properties,
+            OutgoingMessage message,
+            List<DeliveryConstraint> deliveryConstraints,
+            bool routingTopologySupportsDelayedDelivery,
+            out string destination)
         {
             if (message.MessageId != null)
             {
@@ -23,7 +28,12 @@
 
             var messageHeaders = message.Headers ?? new Dictionary<string, string>();
 
-            var delayed = CalculateDelay(deliveryConstraints, messageHeaders, routingTopologySupportsDelayedDelivery, out var delay, out destination);
+            var delayed = CalculateDelay(
+                deliveryConstraints,
+                messageHeaders,
+                routingTopologySupportsDelayedDelivery,
+                out var delay,
+                out destination);
 
             properties.Headers = messageHeaders.ToDictionary(p => p.Key, p => (object)p.Value);
 
@@ -77,7 +87,12 @@
             }
         }
 
-        static bool CalculateDelay(List<DeliveryConstraint> deliveryConstraints, Dictionary<string, string> messageHeaders, bool routingTopologySupportsDelayedDelivery, out long delay, out string destination)
+        static bool CalculateDelay(
+            List<DeliveryConstraint> deliveryConstraints,
+            Dictionary<string, string> messageHeaders,
+            bool routingTopologySupportsDelayedDelivery,
+            out long delay,
+            out string destination)
         {
             destination = null;
 


### PR DESCRIPTION
When I was reviewing a recent PR, a continuous paper cut was having to scroll left and right repeatedly to review the diff, both in GitHub and in my local diff viewer. This PR is an attempt at removing some of that pain.

In some other OSS projects, we've adopted a loose rule of limiting line length to ~120 chars for this purpose. The rule isn't strict, but we apply it were it doesn't add friction in itself.