### PR TITLE
[WIP] Changing ConventionalRoutingTopology to not create unnecessary exchange

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ/Routing/ConventionalRoutingTopology.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Routing/ConventionalRoutingTopology.cs
@@ -105,7 +105,7 @@
             CreateExchange(channel, ExchangeName(typeToProcess));
             var baseType = typeToProcess.BaseType;
 
-            while (baseType != null)
+            while (baseType != null && baseType != typeof(Object))
             {
                 CreateExchange(channel, ExchangeName(baseType));
                 channel.ExchangeBind(ExchangeName(baseType), ExchangeName(typeToProcess), string.Empty);


### PR DESCRIPTION
Changing ConventionalRoutingTopology to not create an exchange for System:Object