### PR TITLE
Test cleanup

### DIFF
--- a/src/NServiceBus.RabbitMQ.sln
+++ b/src/NServiceBus.RabbitMQ.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26711.1
+VisualStudioVersion = 15.0.26720.2
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.Transport.RabbitMQ.TransportTests", "NServiceBus.Transport.RabbitMQ.TransportTests\NServiceBus.Transport.RabbitMQ.TransportTests.csproj", "{9D218CB8-1A64-4209-8156-81F44BB17986}"
 EndProject

--- a/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/NServiceBus.Transport.RabbitMQ.AcceptanceTests.csproj
+++ b/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/NServiceBus.Transport.RabbitMQ.AcceptanceTests.csproj
@@ -15,7 +15,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.0.0-alpharelease0005" />
     <PackageReference Include="NUnit" Version="3.7.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />

--- a/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/NServiceBus.Transport.RabbitMQ.AcceptanceTests.csproj
+++ b/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/NServiceBus.Transport.RabbitMQ.AcceptanceTests.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.0.0-alpharelease0005" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.0.0-alpharelease0026" />
     <PackageReference Include="NUnit" Version="3.7.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
   </ItemGroup>

--- a/src/NServiceBus.Transport.RabbitMQ.Tests/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/APIApprovals.Approve.approved.txt
@@ -1,8 +1,10 @@
 ﻿[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute(@"NServiceBus.Transport.RabbitMQ.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100dde965e6172e019ac82c2639ffe494dd2e7dd16347c34762a05732b492e110f2e4e2e1b5ef2d85c848ccfb671ee20a47c8d1376276708dc30a90ff1121b647ba3b7259a6bc383b2034938ef0e275b58b920375ac605076178123693c6c4f1331661a62eba28c249386855637780e3ff5f23a6d854700eaa6803ef48907513b92")]
 [assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
 [assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETFramework,Version=v4.5.2", FrameworkDisplayName=".NET Framework 4.5.2")]
+
 namespace NServiceBus
 {
+    
     public class RabbitMQTransport : NServiceBus.Transport.TransportDefinition
     {
         public RabbitMQTransport() { }
@@ -29,6 +31,7 @@ namespace NServiceBus
 }
 namespace NServiceBus.Transport.RabbitMQ
 {
+    
     public class DelayedDeliverySettings : NServiceBus.Configuration.AdvancedExtensibility.ExposeSettings
     {
         public NServiceBus.Transport.RabbitMQ.DelayedDeliverySettings DisableTimeoutManager() { }

--- a/src/NServiceBus.Transport.RabbitMQ.Tests/APIApprovals.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/APIApprovals.cs
@@ -1,6 +1,4 @@
 ﻿#if NET452
-using System;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using ApprovalTests;
 using NServiceBus;
@@ -14,20 +12,8 @@ public class APIApprovals
     [MethodImpl(MethodImplOptions.NoInlining)]
     public void Approve()
     {
-        var publicApi = Filter(ApiGenerator.GeneratePublicApi(typeof(RabbitMQTransport).Assembly));
+        var publicApi = ApiGenerator.GeneratePublicApi(typeof(RabbitMQTransport).Assembly);
         Approvals.Verify(publicApi);
     }
-
-    string Filter(string text)
-    {
-        return string.Join(Environment.NewLine, text.Split(new[]
-        {
-            Environment.NewLine
-        }, StringSplitOptions.RemoveEmptyEntries)
-            .Where(l => !l.StartsWith("[assembly: ReleaseDateAttribute("))
-            .Where(l => !string.IsNullOrWhiteSpace(l))
-            );
-    }
-
 }
 #endif

--- a/src/NServiceBus.Transport.RabbitMQ.TransportTests/NServiceBus.Transport.RabbitMQ.TransportTests.csproj
+++ b/src/NServiceBus.Transport.RabbitMQ.TransportTests/NServiceBus.Transport.RabbitMQ.TransportTests.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
-    <PackageReference Include="NServiceBus.TransportTests.Sources" Version="7.0.0-alpharelease0005" />
+    <PackageReference Include="NServiceBus.TransportTests.Sources" Version="7.0.0-alpharelease0026" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
   </ItemGroup>
 

--- a/src/NServiceBus.Transport.RabbitMQ/NServiceBus.Transport.RabbitMQ.csproj
+++ b/src/NServiceBus.Transport.RabbitMQ/NServiceBus.Transport.RabbitMQ.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Fody" Version="2.1.2" PrivateAssets="All" />
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012" PrivateAssets="All" />
     <PackageReference Include="Janitor.Fody" Version="1.4.1" PrivateAssets="All" />
-    <PackageReference Include="NServiceBus" Version="7.0.0-alpharelease0005" PrivateAssets="None" />
+    <PackageReference Include="NServiceBus" Version="7.0.0-alpharelease0026" PrivateAssets="None" />
     <PackageReference Include="Obsolete.Fody" Version="4.2.2" PrivateAssets="All" />
     <PackageReference Include="Particular.CodeRules" Version="0.2.0" PrivateAssets="All" />
     <PackageReference Include="RabbitMQ.Client" Version="[4.1.0, 4.2.0)" PrivateAssets="None" />


### PR DESCRIPTION
Two changes here. The first is that AcceptanceTests now uses `QueueBindings` to know what queues to purge, like we were already doing in TransportTests. I tweaked the TransportTests implemenation so that both are consistent.

I also removed some unneeded code from the APIApprovals test, which had the side effect of introducing some whitespace in the approval file.