### PR TITLE
remove outdated note about stale PR approvals

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -15,7 +15,6 @@ The maintainers [watch](https://github.com/Particular/NServiceBus.RabbitMQ/watch
   - A pull request created by a maintainer is implicitly approved by that maintainer.
   - Approval is given by submitting a review and choosing the **Approve** option
   - For some pull requests, it may be appropriate to require a third maintainer to give approval before the pull request is merged. This may be requested by either of the current approvers based on their assessment of factors such as the impact or risk of the changes.
-- There is a flaw in the GitHub pull request approval system in that a pull request may be altered (by adding more commits or force-pushing) after an approval is made, and the approval remains in place. When a pull request is altered after approval, the approval should be dismissed and the pull request must be re-approved.
 - A pull request created by a maintainer must be merged by *another* maintainer. No "self-merges".
 - The pull request must be made from a branch which is a straight line of commits from `develop`. There must be no merges in the branch history since the commit on `develop`.
   - The branch does not have to be based on the latest commit in `develop` but this is preferable, where practical.


### PR DESCRIPTION
Doesn't apply any more with the introduction of the "Dismiss stale pull request approvals when new commits are pushed" GitHub feature.