### PR TITLE
Update to beta30

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -2,6 +2,6 @@ assembly-versioning-scheme: Major
 next-version: 5.0
 branches:
   develop:
-    tag: beta
+    tag: beta30
   release:
     tag: rc


### PR DESCRIPTION
Since tagging develop seems to have reset the commit count, develop it currently versioned as 5.0.0-beta0007, which is lower than the already tagged/released beta0029.

An approach to solve this is to stop relying on the commit count to be our version at all, and add the next beta version to the tag directly.

With this change, we end up with a package named something like `NServiceBus.RabbitMQ.5.0.0-beta02-0007.nupkg`, which means we get something that will properly sort higher in prerelease form, and then we can tag it as needed to get something that works with the already released beta0029.
