### PR TITLE
Remove x-first-death headers from incoming messages

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ/DelayedDelivery/DelayInfrastructure.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/DelayedDelivery/DelayInfrastructure.cs
@@ -16,7 +16,10 @@
 
         public const int MaxDelayInSeconds = (1 << maxNumberOfBitsToUse) - 1;
         public const string DelayHeader = "NServiceBus.Transport.RabbitMQ.DelayInSeconds";
-        public const string DeadLetteredMessageHeader = "x-death";
+        public const string XDeathHeader = "x-death";
+        public const string XFirstDeathExchangeHeader = "x-first-death-exchange";
+        public const string XFirstDeathQueueHeader = "x-first-death-queue";
+        public const string XFirstDeathReasonHeader = "x-first-death-reason";
         public const string DeliveryExchange = "nsb.delay-delivery";
 
         public static string LevelName(int level) => $"nsb.delay-level-{level:D2}";

--- a/src/NServiceBus.Transport.RabbitMQ/Receiving/MessageConverter.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Receiving/MessageConverter.cs
@@ -39,7 +39,10 @@
             {
                 //These headers need to be removed so that they won't be copied to an outgoing message if this message gets forwarded
                 messageHeaders.Remove(DelayInfrastructure.DelayHeader);
-                messageHeaders.Remove(DelayInfrastructure.DeadLetteredMessageHeader);
+                messageHeaders.Remove(DelayInfrastructure.XDeathHeader);
+                messageHeaders.Remove(DelayInfrastructure.XFirstDeathExchangeHeader);
+                messageHeaders.Remove(DelayInfrastructure.XFirstDeathQueueHeader);
+                messageHeaders.Remove(DelayInfrastructure.XFirstDeathReasonHeader);
                 messageHeaders.Remove(BasicPropertiesExtensions.ConfirmationIdHeader);
             }
 


### PR DESCRIPTION
Brings changes for #458 into the `release-5.0` branch.
  