### PR TITLE
Disable timeout manager by default

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/ConfigureEndpointRabbitMQTransport.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/ConfigureEndpointRabbitMQTransport.cs
@@ -27,7 +27,6 @@ class ConfigureEndpointRabbitMQTransport : IConfigureEndpointTestExecution
 
         var transport = configuration.UseTransport<RabbitMQTransport>();
         transport.ConnectionString(connectionStringBuilder.ConnectionString);
-        transport.DelayedDelivery().DisableTimeoutManager();
         transport.UseConventionalRoutingTopology();
 
         queueBindings = configuration.GetSettings().Get<QueueBindings>();

--- a/src/NServiceBus.Transport.RabbitMQ.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -39,7 +39,10 @@ namespace NServiceBus.Transport.RabbitMQ
     
     public class DelayedDeliverySettings : NServiceBus.Configuration.AdvancedExtensibility.ExposeSettings
     {
+        [System.ObsoleteAttribute("The timeout manager is now disabled by default. The member currently throws a Not" +
+            "ImplementedException. Will be removed in version 6.0.0.", true)]
         public NServiceBus.Transport.RabbitMQ.DelayedDeliverySettings DisableTimeoutManager() { }
+        public NServiceBus.Transport.RabbitMQ.DelayedDeliverySettings EnableTimeoutManager() { }
     }
     public interface IRoutingTopology
     {

--- a/src/NServiceBus.Transport.RabbitMQ/Configuration/DelayedDeliverySettings.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Configuration/DelayedDeliverySettings.cs
@@ -22,5 +22,18 @@
 
             return this;
         }
+
+        /// <summary>
+        /// Enables the timeout manager for this endpoint.
+        /// <para>
+        /// If the timeout manager is enabled, any preexisting timeouts stored in the persistence for this endpoint will be delivered.
+        /// </para>
+        /// </summary>
+        public DelayedDeliverySettings EnableTimeoutManager()
+        {
+            this.GetSettings().Set(SettingsKeys.EnableTimeoutManager, true);
+
+            return this;
+        }
     }
 }

--- a/src/NServiceBus.Transport.RabbitMQ/Configuration/DelayedDeliverySettings.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Configuration/DelayedDeliverySettings.cs
@@ -6,22 +6,9 @@
     /// <summary>
     /// The delayed delivery settings.
     /// </summary>
-    public class DelayedDeliverySettings : ExposeSettings
+    public partial class DelayedDeliverySettings : ExposeSettings
     {
         internal DelayedDeliverySettings(SettingsHolder settings) : base(settings) { }
-
-        /// <summary>
-        /// Disables the timeout manager for this endpoint.
-        /// <para>
-        /// The timeout manager can be disabled once all preexisting timeouts stored in the persistence for this endpoint have expired.
-        /// </para>
-        /// </summary>
-        public DelayedDeliverySettings DisableTimeoutManager()
-        {
-            this.GetSettings().Set(SettingsKeys.DisableTimeoutManager, true);
-
-            return this;
-        }
 
         /// <summary>
         /// Enables the timeout manager for this endpoint.

--- a/src/NServiceBus.Transport.RabbitMQ/Configuration/SettingsKeys.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Configuration/SettingsKeys.cs
@@ -11,6 +11,7 @@
         public const string DisableRemoteCertificateValidation = "RabbitMQ.DisableRemoteCertificateValidation";
         public const string UseExternalAuthMechanism = "RabbitMQ.UseExternalAuthMechanism";
         public const string DisableTimeoutManager = "RabbitMQ.DisableTimeoutManager";
+        public const string EnableTimeoutManager = "RabbitMQ.EnableTimeoutManager";
         public const string UseDurableExchangesAndQueues = "RabbitMQ.UseDurableExchangesAndQueues";
     }
 }

--- a/src/NServiceBus.Transport.RabbitMQ/Configuration/SettingsKeys.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Configuration/SettingsKeys.cs
@@ -10,7 +10,6 @@
         public const string ClientCertificates = "RabbitMQ.ClientCertificates";
         public const string DisableRemoteCertificateValidation = "RabbitMQ.DisableRemoteCertificateValidation";
         public const string UseExternalAuthMechanism = "RabbitMQ.UseExternalAuthMechanism";
-        public const string DisableTimeoutManager = "RabbitMQ.DisableTimeoutManager";
         public const string EnableTimeoutManager = "RabbitMQ.EnableTimeoutManager";
         public const string UseDurableExchangesAndQueues = "RabbitMQ.UseDurableExchangesAndQueues";
     }

--- a/src/NServiceBus.Transport.RabbitMQ/DelayedDelivery/PreventRoutingMessagesToTimeoutManager.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/DelayedDelivery/PreventRoutingMessagesToTimeoutManager.cs
@@ -8,7 +8,7 @@
         {
             EnableByDefault();
 
-            Prerequisite(context => !context.Settings.HasSetting(SettingsKeys.DisableTimeoutManager), "The timeout manager is disabled.");
+            Prerequisite(context => context.Settings.HasSetting(SettingsKeys.EnableTimeoutManager), "The timeout manager is disabled.");
         }
 
         protected override void Setup(FeatureConfigurationContext context) =>

--- a/src/NServiceBus.Transport.RabbitMQ/RabbitMQTransportInfrastructure.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/RabbitMQTransportInfrastructure.cs
@@ -6,7 +6,6 @@
     using System.Text;
     using System.Threading.Tasks;
     using DelayedDelivery;
-    using Features;
     using global::RabbitMQ.Client.Events;
     using Performance.TimeToBeReceived;
     using Routing;
@@ -35,14 +34,6 @@
 
             routingTopology = CreateRoutingTopology();
 
-            var timeoutManagerFeatureDisabled = settings.GetOrDefault<FeatureState>(typeof(TimeoutManager).FullName) == FeatureState.Disabled;
-            var sendOnlyEndpoint = settings.GetOrDefault<bool>(coreSendOnlyEndpointKey);
-
-            if (timeoutManagerFeatureDisabled || sendOnlyEndpoint)
-            {
-                settings.Set(SettingsKeys.DisableTimeoutManager, true);
-            }
-
             if (!settings.TryGet(SettingsKeys.UsePublisherConfirms, out bool usePublisherConfirms))
             {
                 usePublisherConfirms = true;
@@ -61,7 +52,7 @@
                     typeof(NonDurableDelivery)
                 };
 
-                if (settings.HasSetting(SettingsKeys.DisableTimeoutManager))
+                if (!settings.HasSetting(SettingsKeys.EnableTimeoutManager))
                 {
                     constraints.Add(typeof(DoNotDeliverBefore));
                     constraints.Add(typeof(DelayDeliveryWith));

--- a/src/NServiceBus.Transport.RabbitMQ/obsoletes.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/obsoletes.cs
@@ -15,4 +15,18 @@ namespace NServiceBus
     }
 }
 
+namespace NServiceBus.Transport.RabbitMQ
+{
+    using System;
+
+    public partial class DelayedDeliverySettings
+    {
+        [ObsoleteEx(RemoveInVersion = "6.0", TreatAsErrorFromVersion = "5.0", Message = "The timeout manager is now disabled by default.")]
+        public DelayedDeliverySettings DisableTimeoutManager()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}
+
 #pragma warning restore 1591


### PR DESCRIPTION
This PR obsoletes the `DisableTimeoutManager` API and adds a new `EnableTimeoutManger` API instead to opt-in to turning the timeout manager on for backwards compatibility.

@Particular/rabbitmq-transport-maintainers There are several things that I think should be looked at to see what we think about:
- The name of the new API
- The xml comments content of the new API
- The wording of the new error message in `DelayInfrastructure.CheckForInvalidSettings`


Closes #349 