### PR TITLE
Change how PreventRoutingMessagesToTimeoutManager is enabled

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ/DelayedDelivery/PreventRoutingMessagesToTimeoutManager.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/DelayedDelivery/PreventRoutingMessagesToTimeoutManager.cs
@@ -6,8 +6,6 @@
     {
         public PreventRoutingMessagesToTimeoutManager()
         {
-            EnableByDefault();
-
             Prerequisite(context => !context.Settings.HasSetting(SettingsKeys.DisableTimeoutManager), "The timeout manager is disabled.");
         }
 

--- a/src/NServiceBus.Transport.RabbitMQ/RabbitMQTransportInfrastructure.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/RabbitMQTransportInfrastructure.cs
@@ -35,6 +35,8 @@
 
             routingTopology = CreateRoutingTopology();
 
+            settings.EnableFeatureByDefault<PreventRoutingMessagesToTimeoutManager>();
+
             var timeoutManagerFeatureDisabled = settings.GetOrDefault<FeatureState>(typeof(TimeoutManager).FullName) == FeatureState.Disabled;
             var sendOnlyEndpoint = settings.GetOrDefault<bool>(coreSendOnlyEndpointKey);
 


### PR DESCRIPTION
This ensures that the `PreventRoutingMessagesToTimeoutManager` feature is enabled only when the RabbitMQ transport is being used by removing the `EnableByDefault` call inside the feature.


Fixes #471