### PR TITLE
Run API Approval test on both TFMs

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ.Tests/APIApprovals.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/APIApprovals.cs
@@ -1,6 +1,7 @@
-﻿#if NET452
-namespace NServiceBus.Transport.RabbitMQ.Tests
+﻿namespace NServiceBus.Transport.RabbitMQ.Tests
 {
+    using System;
+    using System.Linq;
     using System.Runtime.CompilerServices;
     using NServiceBus;
     using NUnit.Framework;
@@ -13,9 +14,17 @@ namespace NServiceBus.Transport.RabbitMQ.Tests
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void Approve()
         {
-            var publicApi = ApiGenerator.GeneratePublicApi(typeof(RabbitMQTransport).Assembly);
+            var publicApi = Filter(ApiGenerator.GeneratePublicApi(typeof(RabbitMQTransport).Assembly));
             TestApprover.Verify(publicApi);
+        }
+
+        string Filter(string api)
+        {
+            var lines = api.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries)
+                .Where(line => !line.StartsWith("[assembly: System.Runtime.Versioning.TargetFrameworkAttribute"))
+                .Where(line => !string.IsNullOrWhiteSpace(line));
+            
+            return string.Join(Environment.NewLine, lines);
         }
     }
 }
-#endif

--- a/src/NServiceBus.Transport.RabbitMQ.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -1,10 +1,7 @@
 ﻿[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute(@"NServiceBus.Transport.RabbitMQ.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100dde965e6172e019ac82c2639ffe494dd2e7dd16347c34762a05732b492e110f2e4e2e1b5ef2d85c848ccfb671ee20a47c8d1376276708dc30a90ff1121b647ba3b7259a6bc383b2034938ef0e275b58b920375ac605076178123693c6c4f1331661a62eba28c249386855637780e3ff5f23a6d854700eaa6803ef48907513b92")]
 [assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETFramework,Version=v4.5.2", FrameworkDisplayName=".NET Framework 4.5.2")]
-
 namespace NServiceBus
 {
-    
     public class RabbitMQTransport : NServiceBus.Transport.TransportDefinition
     {
         public RabbitMQTransport() { }
@@ -36,7 +33,6 @@ namespace NServiceBus
 }
 namespace NServiceBus.Transport.RabbitMQ
 {
-    
     public class DelayedDeliverySettings : NServiceBus.Configuration.AdvancedExtensibility.ExposeSettings
     {
         public NServiceBus.Transport.RabbitMQ.DelayedDeliverySettings DisableTimeoutManager() { }

--- a/src/NServiceBus.Transport.RabbitMQ.Tests/ApprovalTestConfig.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/ApprovalTestConfig.cs
@@ -1,8 +1,6 @@
-﻿#if NET452
 using ApprovalTests.Reporters;
-#if DEBUG
+#if NET452
 [assembly: UseReporter(typeof(DiffReporter), typeof(AllFailingTestsClipboardReporter))]
 #else
-[assembly: UseReporter(typeof(DiffReporter))]
-#endif
+[assembly: UseReporter(typeof(QuietReporter))]
 #endif

--- a/src/NServiceBus.Transport.RabbitMQ.Tests/NServiceBus.Transport.RabbitMQ.Tests.csproj
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/NServiceBus.Transport.RabbitMQ.Tests.csproj
@@ -12,16 +12,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="ApprovalTests" Version="3.0.13" NoWarn="NU1701" />
+    <PackageReference Include="ApprovalUtilities" Version="3.0.13" NoWarn="NU1701" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NServiceBus" Version="7.0.0-beta0012" />
     <PackageReference Include="NUnit" Version="3.8.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
     <PackageReference Include="RabbitMQ.Client" Version="5.0.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
-    <PackageReference Include="ApprovalTests" Version="3.0.13" />
-    <PackageReference Include="PublicApiGenerator" Version="6.4.0" />
+    <PackageReference Include="PublicApiGenerator" Version="6.5.0" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.Transport.RabbitMQ.Tests/TestApprover.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/TestApprover.cs
@@ -1,9 +1,9 @@
-﻿#if NET452
-namespace NServiceBus.Transport.RabbitMQ.Tests
+﻿namespace NServiceBus.Transport.RabbitMQ.Tests
 {
     using System.IO;
     using ApprovalTests;
     using ApprovalTests.Namers;
+    using NUnit.Framework;
 
     static class TestApprover
     {
@@ -16,18 +16,7 @@ namespace NServiceBus.Transport.RabbitMQ.Tests
 
         class ApprovalNamer : UnitTestFrameworkNamer
         {
-            public ApprovalNamer()
-            {
-                var assemblyPath = GetType().Assembly.Location;
-                var assemblyDir = Path.GetDirectoryName(assemblyPath);
-
-                sourcePath = Path.Combine(assemblyDir, "..", "..", "..", "ApprovalFiles");
-            }
-
-            public override string SourcePath => sourcePath;
-
-            readonly string sourcePath;
+            public override string SourcePath { get; } = Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "ApprovalFiles");
         }
     }
 }
-#endif


### PR DESCRIPTION
This lets the API approvals test run against the `netstandard2.0` assembly in addition to the `net452` assembly.