### PR TITLE
[WIP] Duplicate NextSequenceNo Repro

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/When_publishing_message_implementing_interface_in_direct_topology.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/When_publishing_message_implementing_interface_in_direct_topology.cs
@@ -1,5 +1,7 @@
 ﻿namespace NServiceBus.Transport.RabbitMQ.AcceptanceTests
 {
+    using System;
+    using System.Collections.Concurrent;
     using System.Linq;
     using System.Threading.Tasks;
     using AcceptanceTesting;
@@ -16,7 +18,18 @@
         {
             var context = await Scenario.Define<MyContext>()
                 .WithEndpoint<Publisher>(b =>
-                        b.When(c => c.Subscriber1Subscribed, session => session.Publish(new MyRequest())))
+                        b.When(c => c.Subscriber1Subscribed, async session =>
+                        {
+                            try
+                            {
+                                await session.Publish(new MyRequest());
+                            }
+                            catch (Exception e)
+                            {
+                                Console.WriteLine(e);
+                            }
+                            await session.Publish(new MyRequest());
+                        }))
                 .WithEndpoint<Receiver>(b => b.When(async (session, c) =>
                 {
                     await session.Subscribe<IMyRequest>();

--- a/src/NServiceBus.Transport.RabbitMQ/Sending/MessageDispatcher.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Sending/MessageDispatcher.cs
@@ -1,6 +1,8 @@
 ﻿namespace NServiceBus.Transport.RabbitMQ
 {
+    using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using Extensibility;
 
@@ -38,6 +40,11 @@
             }
             finally
             {
+                while (channel.IsOpen == false)
+                {
+                    Thread.Sleep(TimeSpan.FromSeconds(2));
+                }
+
                 channelProvider.ReturnPublishChannel(channel);
             }
         }


### PR DESCRIPTION
## Overview
After pairing with @WojcikMike we were able to crate a relatively simple test to reproduce #484. To make it fail do:
 * Set breakpoint in `GetConfirmationTask` method in the first [while loop](https://github.com/Particular/NServiceBus.RabbitMQ/blob/seqno-duplication-repro/src/NServiceBus.Transport.RabbitMQ/Connection/ConfirmsAwareChannel.cs#L116)
 * Debug the test 
 * When breakpoint is hit restart RabbitMQ service
 * Continue with debugging.

## What is going on
This scenario that shows a race condition in `ConfirmAwareChannel` that makes it possible for channel to be open (after auto-recovery), have non-empty `messages` collection with an item that will be never removed and is grater than `NextSequeneceNo` of underlying channel. 