### PR TITLE
[WIP] Disable auto-recovery

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ/Connection/ConnectionFactory.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Connection/ConnectionFactory.cs
@@ -31,7 +31,6 @@
                 UserName = connectionConfiguration.UserName,
                 Password = connectionConfiguration.Password,
                 RequestedHeartbeat = connectionConfiguration.RequestedHeartbeat,
-                AutomaticRecoveryEnabled = true,
                 NetworkRecoveryInterval = connectionConfiguration.RetryDelay,
                 UseBackgroundThreadsForIO = true
             };


### PR DESCRIPTION
## Overview
This PR is a proposal of solution to solve #484. I disables auto-recovery.

## Rationale
With my current understanding of the code base we use the auto-recoverability only during sends in the `MessagePump` when dealing with poison messages or in `MessageDispatcher`. The only scenario that comes to my mind when we take advantage of this feature is when channels stored in the `ChannelFactory` pool get closed and than recovered both happening when those are not used. Otherwise those channels would be removed from the pool either when picked from or returned to the pool. 

As a result I propose to turn auto-recoverability off. We might get some penalty in terms of performance (which I doubt is the case) however the code will become easier to understand and reason about. 