### PR TITLE
Use RecoverySucceeded event to clear any orphaned messages

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ/Connection/ChannelProvider.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Connection/ChannelProvider.cs
@@ -30,6 +30,8 @@ namespace NServiceBus.Transport.RabbitMQ
                 channel = new ConfirmsAwareChannel(connection, routingTopology, usePublisherConfirms);
             }
 
+            channel.CleanUpAfterRecovery();
+
             return channel;
         }
 
@@ -37,6 +39,8 @@ namespace NServiceBus.Transport.RabbitMQ
         {
             if (channel.IsOpen)
             {
+                channel.CleanUpAfterRecovery();
+
                 channels.Enqueue(channel);
             }
             else

--- a/src/NServiceBus.Transport.RabbitMQ/Connection/ConfirmsAwareChannel.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Connection/ConfirmsAwareChannel.cs
@@ -187,6 +187,13 @@ namespace NServiceBus.Transport.RabbitMQ
 
         void Connection_RecoverySucceeded(object sender, EventArgs e)
         {
+            FailAllMessages();
+
+            RecoveryCleanUpNeeded = true;
+        }
+
+        void FailAllMessages()
+        {
             do
             {
                 foreach (var message in messages)
@@ -212,6 +219,15 @@ namespace NServiceBus.Transport.RabbitMQ
             }
         }
 
+        public void CleanUpAfterRecovery()
+        {
+            if (RecoveryCleanUpNeeded)
+            {
+                FailAllMessages();
+            }
+
+            RecoveryCleanUpNeeded = false;
+        }
 
         public void Dispose()
         {
@@ -219,6 +235,7 @@ namespace NServiceBus.Transport.RabbitMQ
         }
 
         IModel channel;
+        bool RecoveryCleanUpNeeded;
         readonly IRoutingTopology routingTopology;
         readonly bool usePublisherConfirms;
         readonly ConcurrentDictionary<ulong, TaskCompletionSource<bool>> messages;

--- a/src/NServiceBus.Transport.RabbitMQ/Connection/ConfirmsAwareChannel.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Connection/ConfirmsAwareChannel.cs
@@ -116,9 +116,9 @@ namespace NServiceBus.Transport.RabbitMQ
             var tcs = new TaskCompletionSource<bool>();
             var added = messages.TryAdd(channel.NextPublishSeqNo, tcs);
 
-            if (!added) //debug check, this shouldn't happen
+            if (!added)
             {
-                throw new Exception($"Failed to add {channel.NextPublishSeqNo}");
+                throw new Exception($"Cannot publish a message with sequence number '{channel.NextPublishSeqNo}' on this channel. A message was already published on this channel with the same confirmation number.");
             }
 
             return tcs.Task;


### PR DESCRIPTION
Alternative to #488.

@tmasternak I think this will also clean up anything left in the `messages` collection that was missed by `Channel_ModelShutdown`.