### PR TITLE
Remove ChannelProvider automatic connection recovery

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ.Tests/RabbitMqContext.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/RabbitMqContext.cs
@@ -28,7 +28,7 @@
             var config = ConnectionConfiguration.Create(connectionString, ReceiverQueue);
 
             connectionFactory = new ConnectionFactory(config, null, false, false);
-            channelProvider = new ChannelProvider(connectionFactory, routingTopology, true);
+            channelProvider = new ChannelProvider(connectionFactory, config.RetryDelay, routingTopology, true);
             channelProvider.CreateConnection();
 
             messageDispatcher = new MessageDispatcher(channelProvider);

--- a/src/NServiceBus.Transport.RabbitMQ/Connection/ChannelProvider.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Connection/ChannelProvider.cs
@@ -2,13 +2,15 @@ namespace NServiceBus.Transport.RabbitMQ
 {
     using System;
     using System.Collections.Concurrent;
+    using System.Threading.Tasks;
     using global::RabbitMQ.Client;
 
     sealed class ChannelProvider : IDisposable
     {
-        public ChannelProvider(ConnectionFactory connectionFactory, IRoutingTopology routingTopology, bool usePublisherConfirms)
+        public ChannelProvider(ConnectionFactory connectionFactory, TimeSpan retryDelay, IRoutingTopology routingTopology, bool usePublisherConfirms)
         {
             this.connectionFactory = connectionFactory;
+            this.retryDelay = retryDelay;
 
             this.routingTopology = routingTopology;
             this.usePublisherConfirms = usePublisherConfirms;
@@ -19,6 +21,35 @@ namespace NServiceBus.Transport.RabbitMQ
         public void CreateConnection()
         {
             connection = connectionFactory.CreatePublishConnection();
+            connection.ConnectionShutdown += Connection_ConnectionShutdown;
+        }
+
+        void Connection_ConnectionShutdown(object sender, ShutdownEventArgs e)
+        {
+            if (e.Initiator != ShutdownInitiator.Application)
+            {
+                Task.Run(Reconnect).Ignore();
+            }
+        }
+
+        async Task Reconnect()
+        {
+            var reconnected = false;
+
+            while (!reconnected)
+            {
+                await Task.Delay(retryDelay).ConfigureAwait(false);
+
+                try
+                {
+                    CreateConnection();
+                    reconnected = true;
+                }
+                catch
+                {
+                    reconnected = false;
+                }
+            }
         }
 
         public ConfirmsAwareChannel GetPublishChannel()
@@ -59,6 +90,7 @@ namespace NServiceBus.Transport.RabbitMQ
         }
 
         readonly ConnectionFactory connectionFactory;
+        readonly TimeSpan retryDelay;
         readonly IRoutingTopology routingTopology;
         readonly bool usePublisherConfirms;
         readonly ConcurrentQueue<ConfirmsAwareChannel> channels;

--- a/src/NServiceBus.Transport.RabbitMQ/Connection/ConfirmsAwareChannel.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Connection/ConfirmsAwareChannel.cs
@@ -115,9 +115,9 @@ namespace NServiceBus.Transport.RabbitMQ
             var tcs = new TaskCompletionSource<bool>();
             var added = messages.TryAdd(channel.NextPublishSeqNo, tcs);
 
-            if (!added) //debug check, this shouldn't happen
+            if (!added)
             {
-                throw new Exception($"Failed to add {channel.NextPublishSeqNo}");
+                throw new Exception($"Cannot publish a message with sequence number '{channel.NextPublishSeqNo}' on this channel. A message was already published on this channel with the same confirmation number.");
             }
 
             return tcs.Task;

--- a/src/NServiceBus.Transport.RabbitMQ/Connection/ConnectionFactory.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Connection/ConnectionFactory.cs
@@ -31,7 +31,6 @@
                 UserName = connectionConfiguration.UserName,
                 Password = connectionConfiguration.Password,
                 RequestedHeartbeat = connectionConfiguration.RequestedHeartbeat,
-                AutomaticRecoveryEnabled = true,
                 NetworkRecoveryInterval = connectionConfiguration.RetryDelay,
                 UseBackgroundThreadsForIO = true
             };
@@ -63,14 +62,15 @@
             }
         }
 
-        public IConnection CreatePublishConnection() => CreateConnection("Publish");
+        public IConnection CreatePublishConnection() => CreateConnection("Publish", false);
 
-        public IConnection CreateAdministrationConnection() => CreateConnection("Administration");
+        public IConnection CreateAdministrationConnection() => CreateConnection("Administration", false);
 
-        public IConnection CreateConnection(string connectionName)
+        public IConnection CreateConnection(string connectionName, bool automaticRecoveryEnabled = true)
         {
             lock (lockObject)
             {
+                connectionFactory.AutomaticRecoveryEnabled = automaticRecoveryEnabled;
                 connectionFactory.ClientProperties["connected"] = DateTime.Now.ToString("G");
 
                 return connectionFactory.CreateConnection(connectionName);

--- a/src/NServiceBus.Transport.RabbitMQ/RabbitMQTransportInfrastructure.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/RabbitMQTransportInfrastructure.cs
@@ -42,7 +42,7 @@
                 usePublisherConfirms = true;
             }
 
-            channelProvider = new ChannelProvider(connectionFactory, routingTopology, usePublisherConfirms);
+            channelProvider = new ChannelProvider(connectionFactory, connectionConfiguration.RetryDelay, routingTopology, usePublisherConfirms);
         }
 
         public override IEnumerable<Type> DeliveryConstraints


### PR DESCRIPTION
Instead of trying to fight connection automatic recovery race conditions, this instead lets automatic recovery be enabled/disabled on a per-connection basis.

`ChannelProvider` has been updated to not use automatic recovery and instead creates a new connection when the existing connection has been disconnected. This means that once a connection is closed, all the channels on that connection will be closed as well, and will never be usable again.

Once a new connection is established, new channels will be created.

CC: @tmasternak 