### PR TITLE
Improve Connection event logging

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ/Connection/ChannelProvider.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Connection/ChannelProvider.cs
@@ -29,8 +29,6 @@ namespace NServiceBus.Transport.RabbitMQ
         {
             if (e.Initiator != ShutdownInitiator.Application)
             {
-                Logger.WarnFormat("Connection to the broker lost: {0}", e.ReplyText);
-
                 Task.Run(Reconnect).Ignore();
             }
         }

--- a/src/NServiceBus.Transport.RabbitMQ/Connection/ConnectionFactory.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Connection/ConnectionFactory.cs
@@ -5,7 +5,7 @@
     using System.Security.Authentication;
     using System.Security.Cryptography.X509Certificates;
     using global::RabbitMQ.Client;
-    using NServiceBus.Logging;
+    using Logging;
 
     class ConnectionFactory
     {

--- a/src/NServiceBus.Transport.RabbitMQ/Connection/ConnectionFactory.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Connection/ConnectionFactory.cs
@@ -81,6 +81,16 @@
                 connection.ConnectionBlocked += (sender, e) => Logger.WarnFormat("'{0}' connection blocked: {1}", connectionName, e.Reason);
                 connection.ConnectionUnblocked += (sender, e) => Logger.WarnFormat("'{0}' connection unblocked}", connectionName);
 
+                connection.ConnectionShutdown += (sender, e) =>
+                {
+                    if (e.Initiator == ShutdownInitiator.Application && e.ReplyCode == 200)
+                    {
+                        return;
+                    }
+
+                    Logger.WarnFormat("'{0}' connection shutdown: {1}", connectionName, e);
+                };
+
                 return connection;
             }
         }


### PR DESCRIPTION
This added logging for the connection blocked/unblocked events and also ensures that the log entry for when a connection is shut down unexpectedly is consistent.

Fixes #468