### PR TITLE
[WIP] Make sure critical error is invoked if recoverability policy throws an exception

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ.TransportTests/NServiceBus.Transport.RabbitMQ.TransportTests.csproj
+++ b/src/NServiceBus.Transport.RabbitMQ.TransportTests/NServiceBus.Transport.RabbitMQ.TransportTests.csproj
@@ -17,4 +17,10 @@
     <PackageReference Include="RabbitMQ.Client" Version="5.1.0" />
   </ItemGroup>
 
+  <!-- Replaces transport tests/classes as of 7.1.6. See KTLO issue 218  -->
+  <ItemGroup>
+    <Compile Remove="\**\nserviceBus.transporttests.sources\**\When_on_error_throws.cs" />
+    <Compile Remove="\**\nserviceBus.transporttests.sources\**\NServiceBusTransportTest.cs" />
+    <Compile Remove="\**\nserviceBus.transporttests.sources\**\TransportTestLoggerFactory.cs" />
+  </ItemGroup>
 </Project>

--- a/src/NServiceBus.Transport.RabbitMQ.TransportTests/NServiceBusTransportTest.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.TransportTests/NServiceBusTransportTest.cs
@@ -1,0 +1,288 @@
+﻿namespace NServiceBus.TransportTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using DeliveryConstraints;
+    using Extensibility;
+    using Logging;
+    using NUnit.Framework;
+    using Routing;
+    using Settings;
+    using Transport;
+
+    public abstract class NServiceBusTransportTest
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            testId = Guid.NewGuid().ToString();
+
+            LogFactory = new TransportTestLoggerFactory();
+            LogManager.UseFactory(LogFactory);
+
+            //when using [TestCase] NUnit will reuse the same test instance so we need to make sure that the message pump is a fresh one
+            MessagePump = null;
+            TransportInfrastructure = null;
+            Configurer = null;
+            testCancellationTokenSource = null;
+        }
+
+        static IConfigureTransportInfrastructure CreateConfigurer()
+        {
+            var transportToUse = EnvironmentHelper.GetEnvironmentVariable("Transport_UseSpecific");
+
+            if (string.IsNullOrWhiteSpace(transportToUse))
+            {
+                var coreAssembly = typeof(IMessage).Assembly;
+
+                var nonCoreTransport = transportDefinitions.Value.FirstOrDefault(t => t.Assembly != coreAssembly);
+
+                transportToUse = nonCoreTransport?.Name ?? DefaultTransportDescriptorKey;
+            }
+
+            var typeName = $"Configure{transportToUse}Infrastructure";
+
+            var configurerType = Type.GetType(typeName, false);
+
+            if (configurerType == null)
+            {
+                throw new InvalidOperationException($"Transport Test project must include a non-namespaced class named '{typeName}' implementing {typeof(IConfigureTransportInfrastructure).Name}.");
+            }
+
+            if (!(Activator.CreateInstance(configurerType) is IConfigureTransportInfrastructure configurer))
+            {
+                throw new InvalidOperationException($"{typeName} does not implement {typeof(IConfigureTransportInfrastructure).Name}.");
+            }
+
+            return configurer;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            testCancellationTokenSource?.Dispose();
+            MessagePump?.Stop().GetAwaiter().GetResult();
+            TransportInfrastructure?.Stop().GetAwaiter().GetResult();
+            Configurer?.Cleanup().GetAwaiter().GetResult();
+
+            transportSettings.Clear();
+        }
+
+        protected async Task StartPump(Func<MessageContext, Task> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError, TransportTransactionMode transactionMode, Action<string, Exception> onCriticalError = null)
+        {
+            InputQueueName = GetTestName() + transactionMode;
+            ErrorQueueName = $"{InputQueueName}.error";
+
+            transportSettings.Set("NServiceBus.Routing.EndpointName", InputQueueName);
+            transportSettings.Set(new StartupDiagnosticEntries());
+
+            var queueBindings = new QueueBindings();
+            queueBindings.BindReceiving(InputQueueName);
+            queueBindings.BindSending(ErrorQueueName);
+            transportSettings.Set(ErrorQueueSettings.SettingsKey, ErrorQueueName);
+            transportSettings.Set(queueBindings);
+
+            transportSettings.Set(new EndpointInstances());
+
+            Configurer = CreateConfigurer();
+
+            var configuration = Configurer.Configure(transportSettings, transactionMode);
+
+            TransportInfrastructure = configuration.TransportInfrastructure;
+
+            IgnoreUnsupportedTransactionModes(transactionMode);
+            IgnoreUnsupportedDeliveryConstraints();
+
+            ReceiveInfrastructure = TransportInfrastructure.ConfigureReceiveInfrastructure();
+
+            var queueCreator = ReceiveInfrastructure.QueueCreatorFactory();
+            var userName = GetUserName();
+            await queueCreator.CreateQueueIfNecessary(queueBindings, userName);
+
+            await TransportInfrastructure.Start();
+
+            SendInfrastructure = TransportInfrastructure.ConfigureSendInfrastructure();
+            lazyDispatcher = new Lazy<IDispatchMessages>(() => SendInfrastructure.DispatcherFactory());
+
+            MessagePump = ReceiveInfrastructure.MessagePumpFactory();
+            await MessagePump.Init(
+                context =>
+                {
+                    if (context.Headers.ContainsKey(TestIdHeaderName) && context.Headers[TestIdHeaderName] == testId)
+                    {
+                        return onMessage(context);
+                    }
+
+                    return Task.FromResult(0);
+                },
+                context =>
+                {
+                    if (context.Message.Headers.ContainsKey(TestIdHeaderName) && context.Message.Headers[TestIdHeaderName] == testId)
+                    {
+                        return onError(context);
+                    }
+
+                    return Task.FromResult(ErrorHandleResult.Handled);
+                },
+                new FakeCriticalError(onCriticalError),
+                new PushSettings(InputQueueName, ErrorQueueName, configuration.PurgeInputQueueOnStartup, transactionMode));
+
+            MessagePump.Start(configuration.PushRuntimeSettings);
+        }
+
+        string GetUserName()
+        {
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            {
+                return $"{Environment.UserDomainName}\\{Environment.UserName}";
+            }
+
+            return Environment.UserName;
+        }
+
+        void IgnoreUnsupportedDeliveryConstraints()
+        {
+            var supportedDeliveryConstraints = TransportInfrastructure.DeliveryConstraints.ToList();
+            var unsupportedDeliveryConstraints = requiredDeliveryConstraints.Where(required => !supportedDeliveryConstraints.Contains(required))
+                .ToList();
+
+            if (unsupportedDeliveryConstraints.Any())
+            {
+                var unsupported = string.Join(",", unsupportedDeliveryConstraints.Select(c => c.Name));
+                Assert.Ignore($"Transport doesn't support required delivery constraint(s) {unsupported}");
+            }
+        }
+
+        void IgnoreUnsupportedTransactionModes(TransportTransactionMode requestedTransactionMode)
+        {
+            if (TransportInfrastructure.TransactionMode < requestedTransactionMode)
+            {
+                Assert.Ignore($"Only relevant for transports supporting {requestedTransactionMode} or higher");
+            }
+        }
+
+        protected Task SendMessage(string address,
+            Dictionary<string, string> headers = null,
+            TransportTransaction transportTransaction = null,
+            List<DeliveryConstraint> deliveryConstraints = null,
+            DispatchConsistency dispatchConsistency = DispatchConsistency.Default)
+        {
+            var messageId = Guid.NewGuid().ToString();
+            var message = new OutgoingMessage(messageId, headers ?? new Dictionary<string, string>(), new byte[0]);
+
+            if (message.Headers.ContainsKey(TestIdHeaderName) == false)
+            {
+                message.Headers.Add(TestIdHeaderName, testId);
+            }
+
+            var dispatcher = lazyDispatcher.Value;
+
+            if (transportTransaction == null)
+            {
+                transportTransaction = new TransportTransaction();
+            }
+
+            var transportOperation = new TransportOperation(message, new UnicastAddressTag(address), dispatchConsistency, deliveryConstraints ?? new List<DeliveryConstraint>());
+
+            return dispatcher.Dispatch(new TransportOperations(transportOperation), transportTransaction, new ContextBag());
+        }
+
+        protected void OnTestTimeout(Action onTimeoutAction)
+        {
+            testCancellationTokenSource = Debugger.IsAttached ? new CancellationTokenSource() : new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+            testCancellationTokenSource.Token.Register(onTimeoutAction);
+        }
+
+        protected void RequireDeliveryConstraint<T>() where T : DeliveryConstraint
+        {
+            requiredDeliveryConstraints.Add(typeof(T));
+        }
+
+        static string GetTestName()
+        {
+            var index = 1;
+            var frame = new StackFrame(index);
+            Type type;
+
+            while (true)
+            {
+                type = frame.GetMethod().DeclaringType;
+
+                if (type != null && !type.IsAbstract && typeof(NServiceBusTransportTest).IsAssignableFrom(type))
+                {
+                    break;
+                }
+
+                frame = new StackFrame(++index);
+            }
+
+            var classCallingUs = type.FullName.Split('.').Last();
+
+            var testName = classCallingUs.Split('+').First();
+
+            testName = testName.Replace("When_", "");
+
+            testName = Thread.CurrentThread.CurrentCulture.TextInfo.ToTitleCase(testName);
+
+            testName = testName.Replace("_", "");
+
+            return testName;
+        }
+
+        protected string InputQueueName;
+        protected string ErrorQueueName;
+        protected TransportTestLoggerFactory LogFactory;
+
+        string testId;
+
+        List<Type> requiredDeliveryConstraints = new List<Type>();
+        SettingsHolder transportSettings = new SettingsHolder();
+        Lazy<IDispatchMessages> lazyDispatcher;
+        TransportReceiveInfrastructure ReceiveInfrastructure;
+        TransportSendInfrastructure SendInfrastructure;
+        TransportInfrastructure TransportInfrastructure;
+        IPushMessages MessagePump;
+        CancellationTokenSource testCancellationTokenSource;
+        IConfigureTransportInfrastructure Configurer;
+
+        const string DefaultTransportDescriptorKey = "LearningTransport";
+        const string TestIdHeaderName = "TransportTest.TestId";
+
+        static Lazy<List<Type>> transportDefinitions = new Lazy<List<Type>>(() => TypeScanner.GetAllTypesAssignableTo<TransportDefinition>().ToList());
+
+        class FakeCriticalError : CriticalError
+        {
+            public FakeCriticalError(Action<string, Exception> errorAction) : base(null)
+            {
+                this.errorAction = errorAction ?? ((s, e) => { });
+            }
+
+            public override void Raise(string errorMessage, Exception exception)
+            {
+                errorAction(errorMessage, exception);
+            }
+
+            Action<string, Exception> errorAction;
+        }
+
+        class EnvironmentHelper
+        {
+            public static string GetEnvironmentVariable(string variable)
+            {
+                var candidate = Environment.GetEnvironmentVariable(variable, EnvironmentVariableTarget.User);
+
+                if (string.IsNullOrWhiteSpace(candidate))
+                {
+                    return Environment.GetEnvironmentVariable(variable);
+                }
+
+                return candidate;
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Transport.RabbitMQ.TransportTests/TransportTestLoggerFactory.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.TransportTests/TransportTestLoggerFactory.cs
@@ -1,0 +1,133 @@
+﻿namespace NServiceBus.TransportTests
+{
+    using System;
+    using System.Collections.Generic;
+    using Logging;
+    using NUnit.Framework;
+
+    public class TransportTestLoggerFactory : ILoggerFactory
+    {
+        public ILog GetLogger(Type type)
+        {
+            return GetLogger(type.FullName);
+        }
+
+        public ILog GetLogger(string name)
+        {
+            return new TransportTestLogger(name, LogItems);
+        }
+
+        public List<LogItem> LogItems { get; } = new List<LogItem>();
+
+        public class LogItem
+        {
+            public LogLevel Level;
+            // ReSharper disable once NotAccessedField.Global
+            public string Message;
+        }
+
+        class TransportTestLogger : ILog
+        {
+            public TransportTestLogger(string name, List<LogItem> logItems)
+            {
+                this.name = name;
+                this.logItems = logItems;
+            }
+
+            public bool IsDebugEnabled { get; } = true;
+            public bool IsInfoEnabled { get; } = true;
+            public bool IsWarnEnabled { get; } = true;
+            public bool IsErrorEnabled { get; } = true;
+            public bool IsFatalEnabled { get; } = true;
+
+            public void Debug(string message)
+            {
+                Log(LogLevel.Debug, message);
+            }
+
+            public void Debug(string message, Exception exception)
+            {
+                Log(LogLevel.Debug, $"{message} {exception}");
+            }
+
+            public void DebugFormat(string format, params object[] args)
+            {
+                Log(LogLevel.Debug, string.Format(format, args));
+            }
+
+            public void Info(string message)
+            {
+                Log(LogLevel.Info, message);
+            }
+
+            public void Info(string message, Exception exception)
+            {
+                Log(LogLevel.Info, $"{message} {exception}");
+            }
+
+            public void InfoFormat(string format, params object[] args)
+            {
+                Log(LogLevel.Info, string.Format(format, args));
+            }
+
+            public void Warn(string message)
+            {
+                Log(LogLevel.Warn, message);
+            }
+
+            public void Warn(string message, Exception exception)
+            {
+                Log(LogLevel.Warn, $"{message} {exception}");
+            }
+
+            public void WarnFormat(string format, params object[] args)
+            {
+                Log(LogLevel.Warn, string.Format(format, args));
+            }
+
+            public void Error(string message)
+            {
+                Log(LogLevel.Error, message);
+            }
+
+            public void Error(string message, Exception exception)
+            {
+                Log(LogLevel.Error, $"{message} {exception}");
+            }
+
+            public void ErrorFormat(string format, params object[] args)
+            {
+                Log(LogLevel.Error, string.Format(format, args));
+            }
+
+            public void Fatal(string message)
+            {
+                Log(LogLevel.Fatal, message);
+            }
+
+            public void Fatal(string message, Exception exception)
+            {
+                Log(LogLevel.Fatal, $"{message} {exception}");
+            }
+
+            public void FatalFormat(string format, params object[] args)
+            {
+                Log(LogLevel.Fatal, string.Format(format, args));
+            }
+
+            void Log(LogLevel level, string message)
+            {
+                logItems.Add(new LogItem
+                {
+                    Level = level,
+                    Message = message
+                });
+
+                TestContext.WriteLine($"{DateTime.Now:T} {level} {name}: {message}");
+            }
+
+            string name;
+            List<LogItem> logItems;
+        }
+    }
+}

--- a/src/NServiceBus.Transport.RabbitMQ.TransportTests/When_on_error_throws.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.TransportTests/When_on_error_throws.cs
@@ -1,0 +1,65 @@
+﻿namespace NServiceBus.TransportTests
+{
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Logging;
+    using NUnit.Framework;
+    using Transport;
+
+    public class When_on_error_throws : NServiceBusTransportTest
+    {
+        // [TestCase(TransportTransactionMode.None)] -- not relevant
+        [TestCase(TransportTransactionMode.ReceiveOnly)]
+        [TestCase(TransportTransactionMode.SendsAtomicWithReceive)]
+        [TestCase(TransportTransactionMode.TransactionScope)]
+        public async Task Should_invoke_critical_error_and_retry(TransportTransactionMode transactionMode)
+        {
+            var onErrorCalled = new TaskCompletionSource<ErrorContext>();
+            var criticalErrorCalled = false;
+            string criticalErrorMessage = null;
+
+            OnTestTimeout(() => onErrorCalled.SetCanceled());
+
+            var firstInvocation = true;
+            string nativeMessageId = null;
+
+            await StartPump(
+                context =>
+                {
+                    nativeMessageId = context.MessageId;
+
+                    throw new Exception("Simulated exception");
+                },
+                context =>
+                {
+                    if (firstInvocation)
+                    {
+                        firstInvocation = false;
+
+                        throw new Exception("Exception from onError");
+                    }
+
+                    onErrorCalled.SetResult(context);
+
+                    return Task.FromResult(ErrorHandleResult.Handled);
+                },
+                transactionMode,
+                (message, exception) =>
+                {
+                    criticalErrorCalled = true;
+                    criticalErrorMessage = message;
+                }
+                );
+
+            await SendMessage(InputQueueName);
+
+            var errorContext = await onErrorCalled.Task;
+
+            Assert.AreEqual("Simulated exception", errorContext.Exception.Message, "Should retry the message");
+            Assert.True(criticalErrorCalled, "Should invoke critical error");
+            StringAssert.Contains(nativeMessageId, criticalErrorMessage, "Should include the native message id in the critical error message");
+            Assert.False(LogFactory.LogItems.Any(item => item.Level > LogLevel.Info));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #537

- [x] Check critical error is called
- [x] Make sure that message is retried
- [x] Make sure native transport id is included in failure message
- [x] Make sure no extra logs above WARN is done
- [x] Agree and potentially verify the format of the failure message

This PR aligns the RabbitMQ transport behavior when the recoverability policy throws an exception.