### PR TITLE
Exceptions thrown in recoverability policy are not propagated as critical error

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ.TransportTests/NServiceBus.Transport.RabbitMQ.TransportTests.csproj
+++ b/src/NServiceBus.Transport.RabbitMQ.TransportTests/NServiceBus.Transport.RabbitMQ.TransportTests.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="NServiceBus.TransportTests.Sources" Version="7.1.6" />
+    <PackageReference Include="NServiceBus.TransportTests.Sources" Version="7.2.0-beta0079" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.2" />
     <PackageReference Include="RabbitMQ.Client" Version="5.0.1" />

--- a/src/NServiceBus.Transport.RabbitMQ/Receiving/MessagePump.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Receiving/MessagePump.cs
@@ -28,6 +28,7 @@
         Func<MessageContext, Task> onMessage;
         Func<ErrorContext, Task<ErrorHandleResult>> onError;
         PushSettings settings;
+        CriticalError criticalError;
         MessagePumpConnectionFailedCircuitBreaker circuitBreaker;
         TaskScheduler exclusiveScheduler;
 
@@ -58,6 +59,7 @@
             this.onMessage = onMessage;
             this.onError = onError;
             this.settings = settings;
+            this.criticalError = criticalError;
 
             circuitBreaker = new MessagePumpConnectionFailedCircuitBreaker($"'{settings.InputQueue} MessagePump'", timeToWaitBeforeTriggeringCircuitBreaker, criticalError);
 
@@ -247,11 +249,22 @@
                         await onMessage(messageContext).ConfigureAwait(false);
                         processed = true;
                     }
-                    catch (Exception ex)
+                    catch (Exception exception)
                     {
                         ++numberOfDeliveryAttempts;
-                        var errorContext = new ErrorContext(ex, headers, messageId, message.Body ?? new byte[0], transportTransaction, numberOfDeliveryAttempts);
-                        errorHandled = await onError(errorContext).ConfigureAwait(false) == ErrorHandleResult.Handled;
+                        var errorContext = new ErrorContext(exception, headers, messageId, message.Body ?? new byte[0], transportTransaction, numberOfDeliveryAttempts);
+
+                        try
+                        {
+                            errorHandled = await onError(errorContext).ConfigureAwait(false) == ErrorHandleResult.Handled;
+                        }
+                        catch (Exception ex)
+                        {
+                            criticalError.Raise($"Failed to execute recoverability policy for message with native ID: `{messageId}`", ex);
+                            await consumer.Model.BasicRejectAndRequeueIfOpen(message.DeliveryTag, exclusiveScheduler).ConfigureAwait(false);
+
+                            return;
+                        }
                     }
                 }
 


### PR DESCRIPTION
Backport to 5.0 for #537

## Who's affected
Anyone using the transport.

## Symptoms
Exceptions thrown in recoverability policy are not propagated as critical error and hide the underlying infrastructure problems that user code could be responding to.

## Description
By not properly handling exceptions when the recoverability policy throws, and not raising a critical error, the transport does not allow taking an action when the underlying messaging infrastructure is partially failing. Unnecessary logging clutters the log files with exception information already logged by recoverability in Core. Log level warn downplays the significance of the accident, masquerading transport errors.