### PR TITLE
Exceptions thrown in recoverability policy are not propagated as critical error

### DIFF
--- a/src/NServiceBus.RabbitMQ/NServiceBus.RabbitMQ.csproj
+++ b/src/NServiceBus.RabbitMQ/NServiceBus.RabbitMQ.csproj
@@ -126,12 +126,12 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Particular.CodeRules.0.1.1\build\Particular.CodeRules.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Particular.CodeRules.0.1.1\build\Particular.CodeRules.props'))" />
     <Error Condition="!Exists('..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets'))" />
-    <Error Condition="!Exists('..\packages\Fody.3.3.3\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.3.3.3\build\Fody.targets'))" />
     <Error Condition="!Exists('..\packages\Janitor.Fody.1.6.5\build\Janitor.Fody.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Janitor.Fody.1.6.5\build\Janitor.Fody.props'))" />
     <Error Condition="!Exists('..\packages\Obsolete.Fody.4.4.3\build\Obsolete.Fody.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Obsolete.Fody.4.4.3\build\Obsolete.Fody.props'))" />
     <Error Condition="!Exists('..\packages\NuGetPackager.0.6.5\build\NuGetPackager.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NuGetPackager.0.6.5\build\NuGetPackager.targets'))" />
+    <Error Condition="!Exists('..\packages\Fody.4.2.1\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.4.2.1\build\Fody.targets'))" />
   </Target>
   <Import Project="..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets" Condition="Exists('..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets')" />
-  <Import Project="..\packages\Fody.3.3.3\build\Fody.targets" Condition="Exists('..\packages\Fody.3.3.3\build\Fody.targets')" />
   <Import Project="..\packages\NuGetPackager.0.6.5\build\NuGetPackager.targets" Condition="Exists('..\packages\NuGetPackager.0.6.5\build\NuGetPackager.targets')" />
+  <Import Project="..\packages\Fody.4.2.1\build\Fody.targets" Condition="Exists('..\packages\Fody.4.2.1\build\Fody.targets')" />
 </Project>

--- a/src/NServiceBus.RabbitMQ/packages.config
+++ b/src/NServiceBus.RabbitMQ/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Fody" version="3.3.3" targetFramework="net452" developmentDependency="true" />
+  <package id="Fody" version="4.2.1" targetFramework="net452" developmentDependency="true" />
   <package id="GitVersionTask" version="3.6.5" targetFramework="net452" developmentDependency="true" />
   <package id="Janitor.Fody" version="1.6.5" targetFramework="net452" developmentDependency="true" />
   <package id="Microsoft.Diagnostics.Tracing.EventSource.Redist" version="1.1.28" targetFramework="net452" />

--- a/src/NServiceBus.Transport.RabbitMQ.TransportTests/NServiceBus.Transport.RabbitMQ.TransportTests.csproj
+++ b/src/NServiceBus.Transport.RabbitMQ.TransportTests/NServiceBus.Transport.RabbitMQ.TransportTests.csproj
@@ -81,6 +81,7 @@
     <Compile Include="App_Packages\NSB.TransportTests.6.1.1\When_user_aborts_processing.cs" />
     <Compile Include="App_Packages\NSB.TransportTests.6.1.1\When_using_non_durable_delivery.cs" />
     <Compile Include="ConfigureRabbitMQTransportInfrastructure.cs" />
+    <Compile Include="TransportTestLoggerFactory.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NServiceBus.RabbitMQ\NServiceBus.RabbitMQ.csproj">

--- a/src/NServiceBus.Transport.RabbitMQ.TransportTests/TransportTestLoggerFactory.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.TransportTests/TransportTestLoggerFactory.cs
@@ -1,0 +1,134 @@
+﻿namespace NServiceBus.TransportTests
+{
+    using System;
+    using System.Collections.Generic;
+    using Logging;
+    using NUnit.Framework;
+
+    public class TransportTestLoggerFactory : ILoggerFactory
+    {
+        public ILog GetLogger(Type type)
+        {
+            return GetLogger(type.FullName);
+        }
+
+        public ILog GetLogger(string name)
+        {
+            return new TransportTestLogger(name, LogItems);
+        }
+
+        public List<LogItem> LogItems { get; } = new List<LogItem>();
+
+        public class LogItem
+        {
+            // ReSharper disable NotAccessedField.Global
+            public LogLevel Level;
+            public string Message;
+            // ReSharper restore NotAccessedField.Global
+        }
+
+        class TransportTestLogger : ILog
+        {
+            public TransportTestLogger(string name, List<LogItem> logItems)
+            {
+                this.name = name;
+                this.logItems = logItems;
+            }
+
+            public bool IsDebugEnabled { get; } = true;
+            public bool IsInfoEnabled { get; } = true;
+            public bool IsWarnEnabled { get; } = true;
+            public bool IsErrorEnabled { get; } = true;
+            public bool IsFatalEnabled { get; } = true;
+
+            public void Debug(string message)
+            {
+                Log(LogLevel.Debug, message);
+            }
+
+            public void Debug(string message, Exception exception)
+            {
+                Log(LogLevel.Debug, $"{message} {exception}");
+            }
+
+            public void DebugFormat(string format, params object[] args)
+            {
+                Log(LogLevel.Debug, string.Format(format, args));
+            }
+
+            public void Info(string message)
+            {
+                Log(LogLevel.Info, message);
+            }
+
+            public void Info(string message, Exception exception)
+            {
+                Log(LogLevel.Info, $"{message} {exception}");
+            }
+
+            public void InfoFormat(string format, params object[] args)
+            {
+                Log(LogLevel.Info, string.Format(format, args));
+            }
+
+            public void Warn(string message)
+            {
+                Log(LogLevel.Warn, message);
+            }
+
+            public void Warn(string message, Exception exception)
+            {
+                Log(LogLevel.Warn, $"{message} {exception}");
+            }
+
+            public void WarnFormat(string format, params object[] args)
+            {
+                Log(LogLevel.Warn, string.Format(format, args));
+            }
+
+            public void Error(string message)
+            {
+                Log(LogLevel.Error, message);
+            }
+
+            public void Error(string message, Exception exception)
+            {
+                Log(LogLevel.Error, $"{message} {exception}");
+            }
+
+            public void ErrorFormat(string format, params object[] args)
+            {
+                Log(LogLevel.Error, string.Format(format, args));
+            }
+
+            public void Fatal(string message)
+            {
+                Log(LogLevel.Fatal, message);
+            }
+
+            public void Fatal(string message, Exception exception)
+            {
+                Log(LogLevel.Fatal, $"{message} {exception}");
+            }
+
+            public void FatalFormat(string format, params object[] args)
+            {
+                Log(LogLevel.Fatal, string.Format(format, args));
+            }
+
+            void Log(LogLevel level, string message)
+            {
+                logItems.Add(new LogItem
+                {
+                    Level = level,
+                    Message = message
+                });
+
+                TestContext.WriteLine($"{DateTime.Now:T} {level} {name}: {message}");
+            }
+
+            string name;
+            List<LogItem> logItems;
+        }
+    }
+}


### PR DESCRIPTION
Backport to 5.0 for #537

## Who's affected
Anyone using the transport.

## Symptoms
Exceptions thrown in recoverability policy are not propagated as critical error and hide the underlying infrastructure problems that user code could be responding to.

## Description
By not properly handling exceptions when the recoverability policy throws, and not raising a critical error, the transport does not allow taking an action when the underlying messaging infrastructure is partially failing. Unnecessary logging clutters the log files with exception information already logged by recoverability in Core. Log level warn downplays the significance of the accident, masquerading transport errors.