### PR TITLE
Add endpoint name to connection names

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ.Tests/RabbitMqContext.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/RabbitMqContext.cs
@@ -27,7 +27,7 @@
 
             var config = ConnectionConfiguration.Create(connectionString, ReceiverQueue);
 
-            connectionFactory = new ConnectionFactory(config, null, false, false);
+            connectionFactory = new ConnectionFactory(ReceiverQueue, config, null, false, false);
             channelProvider = new ChannelProvider(connectionFactory, config.RetryDelay, routingTopology, true);
             channelProvider.CreateConnection();
 

--- a/src/NServiceBus.Transport.RabbitMQ/Connection/ConnectionFactory.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Connection/ConnectionFactory.cs
@@ -11,11 +11,24 @@
     {
         static readonly ILog Logger = LogManager.GetLogger(typeof(IConnection));
 
+        readonly string endpointName;
         readonly global::RabbitMQ.Client.ConnectionFactory connectionFactory;
         readonly object lockObject = new object();
 
-        public ConnectionFactory(ConnectionConfiguration connectionConfiguration, X509CertificateCollection clientCertificates, bool disableRemoteCertificateValidation, bool useExternalAuthMechanism)
+        public ConnectionFactory(string endpointName, ConnectionConfiguration connectionConfiguration, X509CertificateCollection clientCertificates, bool disableRemoteCertificateValidation, bool useExternalAuthMechanism)
         {
+            if (endpointName is null)
+            {
+                throw new ArgumentNullException(nameof(endpointName));
+            }
+
+            if (endpointName == string.Empty)
+            {
+                throw new ArgumentException("The endpoint name cannot be empty.", nameof(endpointName));
+            }
+
+            this.endpointName = endpointName;
+
             if (connectionConfiguration == null)
             {
                 throw new ArgumentNullException(nameof(connectionConfiguration));
@@ -65,9 +78,9 @@
             }
         }
 
-        public IConnection CreatePublishConnection() => CreateConnection("Publish", false);
+        public IConnection CreatePublishConnection() => CreateConnection($"{endpointName} Publish", false);
 
-        public IConnection CreateAdministrationConnection() => CreateConnection("Administration", false);
+        public IConnection CreateAdministrationConnection() => CreateConnection($"{endpointName} Administration", false);
 
         public IConnection CreateConnection(string connectionName, bool automaticRecoveryEnabled = true)
         {

--- a/src/NServiceBus.Transport.RabbitMQ/RabbitMQTransportInfrastructure.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/RabbitMQTransportInfrastructure.cs
@@ -25,12 +25,13 @@
         {
             this.settings = settings;
 
-            var connectionConfiguration = ConnectionConfiguration.Create(connectionString, settings.EndpointName());
-
+            var endpointName = settings.EndpointName();
+            var connectionConfiguration = ConnectionConfiguration.Create(connectionString, endpointName);
             settings.TryGet(SettingsKeys.ClientCertificates, out X509CertificateCollection clientCertificates);
             settings.TryGet(SettingsKeys.DisableRemoteCertificateValidation, out bool disableRemoteCertificateValidation);
             settings.TryGet(SettingsKeys.UseExternalAuthMechanism, out bool useExternalAuthMechanism);
-            connectionFactory = new ConnectionFactory(connectionConfiguration, clientCertificates, disableRemoteCertificateValidation, useExternalAuthMechanism);
+
+            connectionFactory = new ConnectionFactory(endpointName, connectionConfiguration, clientCertificates, disableRemoteCertificateValidation, useExternalAuthMechanism);
 
             routingTopology = CreateRoutingTopology();
 


### PR DESCRIPTION
This adds the endpoint name to the client-provided name for the `Publish` and `Administration` connections, making it easier to determine which endpoint these belong to when viewing them on the RabbitMQ connection management web page.

The message pump connections already include the queue name in the connection name, so no change is needed for those.

Fixes #561