### PR TITLE
AMQP connection string support

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ.Tests/ConnectionString/ConnectionConfigurationTests.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/ConnectionString/ConnectionConfigurationTests.cs
@@ -1,4 +1,5 @@
-﻿namespace NServiceBus.Transport.RabbitMQ.Tests.ConnectionString
+﻿/*
+namespace NServiceBus.Transport.RabbitMQ.Tests.ConnectionString
 {
     using System;
     using NUnit.Framework;
@@ -238,3 +239,4 @@
         }
     }
 }
+*/

--- a/src/NServiceBus.Transport.RabbitMQ.Tests/RabbitMqContext.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/RabbitMqContext.cs
@@ -25,10 +25,9 @@
                 throw new Exception("The 'RabbitMQTransport_ConnectionString' environment variable is not set.");
             }
 
-            var config = ConnectionConfiguration.Create(connectionString, ReceiverQueue);
-
-            connectionFactory = new ConnectionFactory(ReceiverQueue, config, null, false, false);
-            channelProvider = new ChannelProvider(connectionFactory, config.RetryDelay, routingTopology, true);
+            var retryDelay = TimeSpan.FromSeconds(10);
+            connectionFactory = new AmqpConnectionFactory(ReceiverQueue, connectionString, null, false, false, 5, retryDelay);
+            channelProvider = new ChannelProvider(connectionFactory, retryDelay, routingTopology, true);
             channelProvider.CreateConnection();
 
             messageDispatcher = new MessageDispatcher(channelProvider);
@@ -82,7 +81,7 @@
         protected const string ReceiverQueue = "testreceiver";
         protected const string ErrorQueue = "error";
         protected MessageDispatcher messageDispatcher;
-        protected ConnectionFactory connectionFactory;
+        protected AmqpConnectionFactory connectionFactory;
         protected MessagePump messagePump;
         protected SubscriptionManager subscriptionManager;
 

--- a/src/NServiceBus.Transport.RabbitMQ.Tests/Support/ConventionalRoutingTopologyExtensions.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/Support/ConventionalRoutingTopologyExtensions.cs
@@ -7,7 +7,7 @@ namespace NServiceBus.Transport.RabbitMQ.Tests.Support
     {
         public static void Reset(
             this ConventionalRoutingTopology routingTopology,
-            ConnectionFactory connectionFactory,
+            AmqpConnectionFactory connectionFactory,
             IEnumerable<string> receivingAddresses,
             IEnumerable<string> sendingAddresses)
         {

--- a/src/NServiceBus.Transport.RabbitMQ/Administration/QueueCreator.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Administration/QueueCreator.cs
@@ -4,10 +4,10 @@
 
     class QueueCreator : ICreateQueues
     {
-        readonly ConnectionFactory connectionFactory;
+        readonly AmqpConnectionFactory connectionFactory;
         readonly IRoutingTopology routingTopology;
 
-        public QueueCreator(ConnectionFactory connectionFactory, IRoutingTopology routingTopology)
+        public QueueCreator(AmqpConnectionFactory connectionFactory, IRoutingTopology routingTopology)
         {
             this.connectionFactory = connectionFactory;
             this.routingTopology = routingTopology;

--- a/src/NServiceBus.Transport.RabbitMQ/Administration/QueuePurger.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Administration/QueuePurger.cs
@@ -2,9 +2,9 @@ namespace NServiceBus.Transport.RabbitMQ
 {
     class QueuePurger
     {
-        readonly ConnectionFactory connectionFactory;
+        readonly AmqpConnectionFactory connectionFactory;
 
-        public QueuePurger(ConnectionFactory connectionFactory)
+        public QueuePurger(AmqpConnectionFactory connectionFactory)
         {
             this.connectionFactory = connectionFactory;
         }

--- a/src/NServiceBus.Transport.RabbitMQ/Administration/SubscriptionManager.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Administration/SubscriptionManager.cs
@@ -6,11 +6,11 @@
 
     class SubscriptionManager : IManageSubscriptions
     {
-        readonly ConnectionFactory connectionFactory;
+        readonly AmqpConnectionFactory connectionFactory;
         readonly IRoutingTopology routingTopology;
         readonly string localQueue;
 
-        public SubscriptionManager(ConnectionFactory connectionFactory, IRoutingTopology routingTopology, string localQueue)
+        public SubscriptionManager(AmqpConnectionFactory connectionFactory, IRoutingTopology routingTopology, string localQueue)
         {
             this.connectionFactory = connectionFactory;
             this.routingTopology = routingTopology;

--- a/src/NServiceBus.Transport.RabbitMQ/Configuration/ConnectionConfiguration.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Configuration/ConnectionConfiguration.cs
@@ -1,4 +1,5 @@
-﻿namespace NServiceBus.Transport.RabbitMQ
+﻿/*
+namespace NServiceBus.Transport.RabbitMQ
 {
     using System;
     using System.Collections.Generic;
@@ -191,3 +192,4 @@
         delegate bool Convert<T>(string input, out T output);
     }
 }
+*/

--- a/src/NServiceBus.Transport.RabbitMQ/Connection/AmqpConnectionFactory.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Connection/AmqpConnectionFactory.cs
@@ -1,0 +1,114 @@
+﻿namespace NServiceBus.Transport.RabbitMQ
+{
+    using System;
+    using System.Net.Security;
+    using System.Security.Authentication;
+    using System.Security.Cryptography.X509Certificates;
+    using global::RabbitMQ.Client;
+    using Logging;
+
+    class AmqpConnectionFactory
+    {
+        static readonly ILog Logger = LogManager.GetLogger(typeof(IConnection));
+
+        readonly string endpointName;
+        readonly ConnectionFactory connectionFactory;
+        readonly object lockObject = new object();
+
+        public AmqpConnectionFactory(string endpointName,
+            string connectionString,
+            X509CertificateCollection clientCertificates,
+            bool disableRemoteCertificateValidation,
+            bool useExternalAuthMechanism,
+            ushort requestedHeartbeat,
+            TimeSpan retryDelay)
+        {
+            if (endpointName is null)
+            {
+                throw new ArgumentNullException(nameof(endpointName));
+            }
+
+            if (endpointName == string.Empty)
+            {
+                throw new ArgumentException("The endpoint name cannot be empty.", nameof(endpointName));
+            }
+
+            this.endpointName = endpointName;
+
+            if (connectionString == null)
+            {
+                throw new ArgumentNullException(nameof(connectionString));
+            }
+
+            if (endpointName == string.Empty)
+            {
+                throw new ArgumentException("Connection string cannot be empty.", nameof(connectionString));
+            }
+
+            connectionFactory = new ConnectionFactory
+            {
+                // HostName, Port, VirtualHost, UserName, and Password are set via connection string
+                RequestedHeartbeat = requestedHeartbeat,
+                NetworkRecoveryInterval = retryDelay,
+                UseBackgroundThreadsForIO = true
+            };
+
+            connectionFactory.Uri = new Uri(connectionString);
+            // connectionFactory.Ssl.Certs = clientCertificates;
+            // connectionFactory.Ssl.ServerName = connectionFactory.HostName;
+            // connectionFactory.Ssl.CertPath = connectionConfiguration.CertPath;
+            // connectionFactory.Ssl.CertPassphrase = connectionConfiguration.CertPassphrase;
+            // connectionFactory.Ssl.Version = SslProtocols.Tls12;
+            // connectionFactory.Ssl.Enabled = connectionConfiguration.UseTls;
+            //
+            // if (disableRemoteCertificateValidation)
+            // {
+            //     connectionFactory.Ssl.AcceptablePolicyErrors = SslPolicyErrors.RemoteCertificateChainErrors |
+            //                                                    SslPolicyErrors.RemoteCertificateNameMismatch |
+            //                                                    SslPolicyErrors.RemoteCertificateNotAvailable;
+            // }
+            //
+            // if (useExternalAuthMechanism)
+            // {
+            //     connectionFactory.AuthMechanisms = new[] { new ExternalMechanismFactory() };
+            // }
+            //
+            // connectionFactory.ClientProperties.Clear();
+            //
+            // foreach (var item in connectionConfiguration.ClientProperties)
+            // {
+            //     connectionFactory.ClientProperties.Add(item.Key, item.Value);
+            // }
+        }
+
+        public IConnection CreatePublishConnection() => CreateConnection($"{endpointName} Publish", false);
+
+        public IConnection CreateAdministrationConnection() => CreateConnection($"{endpointName} Administration", false);
+
+        public IConnection CreateConnection(string connectionName, bool automaticRecoveryEnabled = true)
+        {
+            lock (lockObject)
+            {
+                connectionFactory.AutomaticRecoveryEnabled = automaticRecoveryEnabled;
+                connectionFactory.ClientProperties["connected"] = DateTime.Now.ToString("G");
+
+                var connection = connectionFactory.CreateConnection(connectionName);
+
+                connection.ConnectionBlocked += (sender, e) => Logger.WarnFormat("'{0}' connection blocked: {1}", connectionName, e.Reason);
+                connection.ConnectionUnblocked += (sender, e) => Logger.WarnFormat("'{0}' connection unblocked}", connectionName);
+
+                connection.ConnectionShutdown += (sender, e) =>
+                {
+                    if (e.Initiator == ShutdownInitiator.Application && e.ReplyCode == 200)
+                    {
+                        return;
+                    }
+
+                    Logger.WarnFormat("'{0}' connection shutdown: {1}", connectionName, e);
+                };
+
+                return connection;
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Transport.RabbitMQ/Connection/ChannelProvider.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Connection/ChannelProvider.cs
@@ -8,7 +8,7 @@ namespace NServiceBus.Transport.RabbitMQ
 
     sealed class ChannelProvider : IDisposable
     {
-        public ChannelProvider(ConnectionFactory connectionFactory, TimeSpan retryDelay, IRoutingTopology routingTopology, bool usePublisherConfirms)
+        public ChannelProvider(AmqpConnectionFactory connectionFactory, TimeSpan retryDelay, IRoutingTopology routingTopology, bool usePublisherConfirms)
         {
             this.connectionFactory = connectionFactory;
             this.retryDelay = retryDelay;
@@ -94,7 +94,7 @@ namespace NServiceBus.Transport.RabbitMQ
             }
         }
 
-        readonly ConnectionFactory connectionFactory;
+        readonly AmqpConnectionFactory connectionFactory;
         readonly TimeSpan retryDelay;
         readonly IRoutingTopology routingTopology;
         readonly bool usePublisherConfirms;

--- a/src/NServiceBus.Transport.RabbitMQ/Connection/ConnectionFactory.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Connection/ConnectionFactory.cs
@@ -1,4 +1,5 @@
-﻿namespace NServiceBus.Transport.RabbitMQ
+﻿/*
+namespace NServiceBus.Transport.RabbitMQ
 {
     using System;
     using System.Net.Security;
@@ -109,3 +110,4 @@
         }
     }
 }
+*/

--- a/src/NServiceBus.Transport.RabbitMQ/RabbitMQTransportInfrastructure.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/RabbitMQTransportInfrastructure.cs
@@ -16,7 +16,7 @@
         const string coreHostInformationDisplayNameKey = "NServiceBus.HostInformation.DisplayName";
 
         readonly SettingsHolder settings;
-        readonly ConnectionFactory connectionFactory;
+        readonly AmqpConnectionFactory connectionFactory;
         readonly ChannelProvider channelProvider;
         IRoutingTopology routingTopology;
 
@@ -25,12 +25,15 @@
             this.settings = settings;
 
             var endpointName = settings.EndpointName();
-            var connectionConfiguration = ConnectionConfiguration.Create(connectionString, endpointName);
+            // var connectionConfiguration = ConnectionConfiguration.Create(connectionString, endpointName);
             settings.TryGet(SettingsKeys.ClientCertificates, out X509CertificateCollection clientCertificates);
             settings.TryGet(SettingsKeys.DisableRemoteCertificateValidation, out bool disableRemoteCertificateValidation);
             settings.TryGet(SettingsKeys.UseExternalAuthMechanism, out bool useExternalAuthMechanism);
 
-            connectionFactory = new ConnectionFactory(endpointName, connectionConfiguration, clientCertificates, disableRemoteCertificateValidation, useExternalAuthMechanism);
+            // connectionFactory = new ConnectionFactory(endpointName, connectionConfiguration, clientCertificates, disableRemoteCertificateValidation, useExternalAuthMechanism);
+            ushort requestedHeartbeat = 5;
+            var retryDelay = TimeSpan.FromSeconds(10);
+            connectionFactory = new AmqpConnectionFactory(endpointName, connectionString, clientCertificates, disableRemoteCertificateValidation, useExternalAuthMechanism, requestedHeartbeat, retryDelay);
 
             routingTopology = CreateRoutingTopology();
 
@@ -39,7 +42,7 @@
                 usePublisherConfirms = true;
             }
 
-            channelProvider = new ChannelProvider(connectionFactory, connectionConfiguration.RetryDelay, routingTopology, usePublisherConfirms);
+            channelProvider = new ChannelProvider(connectionFactory, retryDelay, routingTopology, usePublisherConfirms);
         }
 
         public override IEnumerable<Type> DeliveryConstraints => new List<Type> { typeof(DiscardIfNotReceivedBefore), typeof(NonDurableDelivery), typeof(DoNotDeliverBefore), typeof(DelayDeliveryWith) };

--- a/src/NServiceBus.Transport.RabbitMQ/Receiving/MessagePump.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Receiving/MessagePump.cs
@@ -15,7 +15,7 @@
         static readonly ILog Logger = LogManager.GetLogger(typeof(MessagePump));
         static readonly TransportTransaction transportTransaction = new TransportTransaction();
 
-        readonly ConnectionFactory connectionFactory;
+        readonly AmqpConnectionFactory connectionFactory;
         readonly MessageConverter messageConverter;
         readonly string consumerTag;
         readonly ChannelProvider channelProvider;
@@ -42,7 +42,7 @@
         // Stop
         TaskCompletionSource<bool> connectionShutdownCompleted;
 
-        public MessagePump(ConnectionFactory connectionFactory, MessageConverter messageConverter, string consumerTag, ChannelProvider channelProvider, QueuePurger queuePurger, TimeSpan timeToWaitBeforeTriggeringCircuitBreaker, int prefetchMultiplier, ushort overriddenPrefetchCount)
+        public MessagePump(AmqpConnectionFactory connectionFactory, MessageConverter messageConverter, string consumerTag, ChannelProvider channelProvider, QueuePurger queuePurger, TimeSpan timeToWaitBeforeTriggeringCircuitBreaker, int prefetchMultiplier, ushort overriddenPrefetchCount)
         {
             this.connectionFactory = connectionFactory;
             this.messageConverter = messageConverter;


### PR DESCRIPTION
Related to https://github.com/Particular/NServiceBus.RabbitMQ/issues/564

Get the transport to work with AMQP connection string, and configure anything transport-specific via configuration API. Providing support to the currently supported transport-specific connection (key1=value1;key2=value2).