### PR TITLE
Add parameter validation to configuration methods

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ/Configuration/RabbitMQTransportSettingsExtensions.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Configuration/RabbitMQTransportSettingsExtensions.cs
@@ -18,7 +18,11 @@
         /// <param name="topologyFactory">The function used to create the routing topology instance. The parameter of the function indicates whether exchanges and queues declared by the routing topology should be durable.</param>
         public static TransportExtensions<RabbitMQTransport> UseCustomRoutingTopology(this TransportExtensions<RabbitMQTransport> transportExtensions, Func<bool, IRoutingTopology> topologyFactory)
         {
+            Guard.AgainstNull(nameof(transportExtensions), transportExtensions);
+            Guard.AgainstNull(nameof(topologyFactory), topologyFactory);
+
             transportExtensions.GetSettings().Set(topologyFactory);
+
             return transportExtensions;
         }
 
@@ -30,7 +34,11 @@
         [ObsoleteEx(RemoveInVersion = "7.0", TreatAsErrorFromVersion = "6.0", ReplacementTypeOrMember = "RabbitMQTransportSettingsExtensions.UseCustomRoutingTopology(TransportExtensions<RabbitMQTransport> transportExtensions, Func<bool, IRoutingTopology>)")]
         public static TransportExtensions<RabbitMQTransport> UseRoutingTopology(this TransportExtensions<RabbitMQTransport> transportExtensions, Func<bool, IRoutingTopology> topologyFactory)
         {
+            Guard.AgainstNull(nameof(transportExtensions), transportExtensions);
+            Guard.AgainstNull(nameof(topologyFactory), topologyFactory);
+
             transportExtensions.GetSettings().Set(topologyFactory);
+
             return transportExtensions;
         }
 
@@ -38,8 +46,12 @@
         /// Uses the conventional routing topology.
         /// </summary>
         /// <param name="transportExtensions"></param>
-        public static TransportExtensions<RabbitMQTransport> UseConventionalRoutingTopology(this TransportExtensions<RabbitMQTransport> transportExtensions) =>
-            transportExtensions.UseCustomRoutingTopology(durable => new ConventionalRoutingTopology(durable));
+        public static TransportExtensions<RabbitMQTransport> UseConventionalRoutingTopology(this TransportExtensions<RabbitMQTransport> transportExtensions)
+        {
+            Guard.AgainstNull(nameof(transportExtensions), transportExtensions);
+
+            return transportExtensions.UseCustomRoutingTopology(durable => new ConventionalRoutingTopology(durable));
+        }
 
         /// <summary>
         /// Uses the direct routing topology with the specified conventions.
@@ -49,6 +61,8 @@
         /// <param name="exchangeNameConvention">The exchange name convention.</param>
         public static TransportExtensions<RabbitMQTransport> UseDirectRoutingTopology(this TransportExtensions<RabbitMQTransport> transportExtensions, Func<Type, string> routingKeyConvention = null, Func<string> exchangeNameConvention = null)
         {
+            Guard.AgainstNull(nameof(transportExtensions), transportExtensions);
+
             if (routingKeyConvention == null)
             {
                 routingKeyConvention = DefaultRoutingKeyConvention.GenerateRoutingKey;
@@ -59,9 +73,7 @@
                 exchangeNameConvention = () => "amq.topic";
             }
 
-            transportExtensions.UseCustomRoutingTopology(durable => new DirectRoutingTopology(new DirectRoutingTopology.Conventions(exchangeNameConvention, routingKeyConvention), durable));
-
-            return transportExtensions;
+            return transportExtensions.UseCustomRoutingTopology(durable => new DirectRoutingTopology(new DirectRoutingTopology.Conventions(exchangeNameConvention, routingKeyConvention), durable));
         }
 
         /// <summary>
@@ -72,7 +84,11 @@
         /// <returns></returns>
         public static TransportExtensions<RabbitMQTransport> CustomMessageIdStrategy(this TransportExtensions<RabbitMQTransport> transportExtensions, Func<BasicDeliverEventArgs, string> customIdStrategy)
         {
+            Guard.AgainstNull(nameof(transportExtensions), transportExtensions);
+            Guard.AgainstNull(nameof(customIdStrategy), customIdStrategy);
+
             transportExtensions.GetSettings().Set(SettingsKeys.CustomMessageIdStrategy, customIdStrategy);
+
             return transportExtensions;
         }
 
@@ -83,7 +99,11 @@
         /// <param name="waitTime">The time to wait before triggering the circuit breaker.</param>
         public static TransportExtensions<RabbitMQTransport> TimeToWaitBeforeTriggeringCircuitBreaker(this TransportExtensions<RabbitMQTransport> transportExtensions, TimeSpan waitTime)
         {
+            Guard.AgainstNull(nameof(transportExtensions), transportExtensions);
+            Guard.AgainstNegativeAndZero(nameof(waitTime), waitTime);
+
             transportExtensions.GetSettings().Set(SettingsKeys.TimeToWaitBeforeTriggeringCircuitBreaker, waitTime);
+
             return transportExtensions;
         }
 
@@ -95,7 +115,10 @@
         /// <returns></returns>
         public static TransportExtensions<RabbitMQTransport> UsePublisherConfirms(this TransportExtensions<RabbitMQTransport> transportExtensions, bool usePublisherConfirms)
         {
+            Guard.AgainstNull(nameof(transportExtensions), transportExtensions);
+
             transportExtensions.GetSettings().Set(SettingsKeys.UsePublisherConfirms, usePublisherConfirms);
+
             return transportExtensions;
         }
 
@@ -106,12 +129,11 @@
         /// <param name="prefetchMultiplier">The multiplier value to use in the prefetch calculation.</param>
         public static TransportExtensions<RabbitMQTransport> PrefetchMultiplier(this TransportExtensions<RabbitMQTransport> transportExtensions, int prefetchMultiplier)
         {
-            if (prefetchMultiplier <= 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(prefetchMultiplier), "The prefetch multiplier must be greater than zero.");
-            }
+            Guard.AgainstNull(nameof(transportExtensions), transportExtensions);
+            Guard.AgainstNegativeAndZero(nameof(prefetchMultiplier), prefetchMultiplier);
 
             transportExtensions.GetSettings().Set(SettingsKeys.PrefetchMultiplier, prefetchMultiplier);
+
             return transportExtensions;
         }
 
@@ -122,7 +144,10 @@
         /// <param name="prefetchCount">The prefetch count to use.</param>
         public static TransportExtensions<RabbitMQTransport> PrefetchCount(this TransportExtensions<RabbitMQTransport> transportExtensions, ushort prefetchCount)
         {
+            Guard.AgainstNull(nameof(transportExtensions), transportExtensions);
+
             transportExtensions.GetSettings().Set(SettingsKeys.PrefetchCount, prefetchCount);
+
             return transportExtensions;
         }
 
@@ -134,7 +159,11 @@
         /// <returns></returns>
         public static TransportExtensions<RabbitMQTransport> SetClientCertificates(this TransportExtensions<RabbitMQTransport> transportExtensions, X509CertificateCollection clientCertificates)
         {
+            Guard.AgainstNull(nameof(transportExtensions), transportExtensions);
+            Guard.AgainstNull(nameof(clientCertificates), clientCertificates);
+
             transportExtensions.GetSettings().Set(SettingsKeys.ClientCertificates, clientCertificates);
+
             return transportExtensions;
         }
 
@@ -145,7 +174,10 @@
         /// <returns></returns>
         public static TransportExtensions<RabbitMQTransport> DisableRemoteCertificateValidation(this TransportExtensions<RabbitMQTransport> transportExtensions)
         {
+            Guard.AgainstNull(nameof(transportExtensions), transportExtensions);
+
             transportExtensions.GetSettings().Set(SettingsKeys.DisableRemoteCertificateValidation, true);
+
             return transportExtensions;
         }
 
@@ -156,7 +188,10 @@
         /// <returns></returns>
         public static TransportExtensions<RabbitMQTransport> UseExternalAuthMechanism(this TransportExtensions<RabbitMQTransport> transportExtensions)
         {
+            Guard.AgainstNull(nameof(transportExtensions), transportExtensions);
+
             transportExtensions.GetSettings().Set(SettingsKeys.UseExternalAuthMechanism, true);
+
             return transportExtensions;
         }
 
@@ -165,7 +200,12 @@
         /// </summary>
         /// <param name="transportExtensions"></param>
         /// <returns></returns>
-        public static DelayedDeliverySettings DelayedDelivery(this TransportExtensions<RabbitMQTransport> transportExtensions) => new DelayedDeliverySettings(transportExtensions.GetSettings());
+        public static DelayedDeliverySettings DelayedDelivery(this TransportExtensions<RabbitMQTransport> transportExtensions)
+        {
+            Guard.AgainstNull(nameof(transportExtensions), transportExtensions);
+
+            return new DelayedDeliverySettings(transportExtensions.GetSettings());
+        }
 
         /// <summary>
         /// Specifies whether exchanges and queues should be declared as durable or not.
@@ -175,7 +215,10 @@
         /// <returns></returns>
         public static TransportExtensions<RabbitMQTransport> UseDurableExchangesAndQueues(this TransportExtensions<RabbitMQTransport> transportExtensions, bool useDurableExchangesAndQueues)
         {
+            Guard.AgainstNull(nameof(transportExtensions), transportExtensions);
+
             transportExtensions.GetSettings().Set(SettingsKeys.UseDurableExchangesAndQueues, useDurableExchangesAndQueues);
+
             return transportExtensions;
         }
     }

--- a/src/NServiceBus.Transport.RabbitMQ/Guard.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Guard.cs
@@ -1,0 +1,81 @@
+﻿namespace NServiceBus.Transport.RabbitMQ
+{
+    using System;
+    using System.Collections;
+    using System.Linq;
+    using System.Reflection;
+
+    static class Guard
+    {
+        // ReSharper disable UnusedParameter.Global
+        public static void TypeHasDefaultConstructor(Type type, string argumentName)
+        {
+            if (type.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                .All(ctor => ctor.GetParameters().Length != 0))
+            {
+                var error = $"Type '{type.FullName}' must have a default constructor.";
+                throw new ArgumentException(error, argumentName);
+            }
+        }
+
+        public static void AgainstNull(string argumentName, object value)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(argumentName);
+            }
+        }
+
+        public static void AgainstNullAndEmpty(string argumentName, string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new ArgumentNullException(argumentName);
+            }
+        }
+
+        public static void AgainstNullAndEmpty(string argumentName, ICollection value)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(argumentName);
+            }
+            if (value.Count == 0)
+            {
+                throw new ArgumentOutOfRangeException(argumentName);
+            }
+        }
+
+        public static void AgainstNegativeAndZero(string argumentName, int value)
+        {
+            if (value <= 0)
+            {
+                throw new ArgumentOutOfRangeException(argumentName);
+            }
+        }
+
+        public static void AgainstNegative(string argumentName, int value)
+        {
+            if (value < 0)
+            {
+                throw new ArgumentOutOfRangeException(argumentName);
+            }
+        }
+
+        public static void AgainstNegativeAndZero(string argumentName, TimeSpan value)
+        {
+            if (value <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(argumentName);
+            }
+        }
+
+        public static void AgainstNegative(string argumentName, TimeSpan value)
+        {
+            if (value < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(argumentName);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds the `Guard` util class, copied from the Core repo, and uses it to validate the parameters of the validation methods.

Note, while #448 mentions trying to also validate the values returned from the various `Func` parameters, this isn't really something that's feasible to do since we'd have to invoke the function to attempt it. There's no guarantee it returns the same value each time, and there could be side effects where the function isn't being expected to be invoked at the point we'd need to validate it, or would not be expecting to be invoked more than once.

The only potential solution I see for something like this would be if we get stronger guarantees by introducing C# 8 nullability annotations, but even then I don't think that really guarantees anything across assembly boundaries.

Fixes #448