### PR TITLE
Remove leftover destination parameter

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ/Sending/BasicPropertiesExtensions.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Sending/BasicPropertiesExtensions.cs
@@ -12,7 +12,7 @@
 
     static class BasicPropertiesExtensions
     {
-        public static void Fill(this IBasicProperties properties, OutgoingMessage message, List<DeliveryConstraint> deliveryConstraints, out string destination)
+        public static void Fill(this IBasicProperties properties, OutgoingMessage message, List<DeliveryConstraint> deliveryConstraints)
         {
             if (message.MessageId != null)
             {
@@ -23,7 +23,7 @@
 
             var messageHeaders = message.Headers ?? new Dictionary<string, string>();
 
-            var delayed = CalculateDelay(deliveryConstraints, out var delay, out destination);
+            var delayed = CalculateDelay(deliveryConstraints, out var delay);
 
             properties.Headers = messageHeaders.ToDictionary(p => p.Key, p => (object)p.Value);
 
@@ -77,10 +77,8 @@
             }
         }
 
-        static bool CalculateDelay(List<DeliveryConstraint> deliveryConstraints, out long delay, out string destination)
+        static bool CalculateDelay(List<DeliveryConstraint> deliveryConstraints, out long delay)
         {
-            destination = null;
-
             delay = 0;
             var delayed = false;
 

--- a/src/NServiceBus.Transport.RabbitMQ/Sending/MessageDispatcher.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Sending/MessageDispatcher.cs
@@ -50,9 +50,9 @@
             var message = transportOperation.Message;
 
             var properties = channel.CreateBasicProperties();
-            properties.Fill(message, transportOperation.DeliveryConstraints, out var destination);
+            properties.Fill(message, transportOperation.DeliveryConstraints);
 
-            return channel.SendMessage(destination ?? transportOperation.Destination, message, properties);
+            return channel.SendMessage(transportOperation.Destination, message, properties);
         }
 
         Task PublishMessage(MulticastTransportOperation transportOperation, ConfirmsAwareChannel channel)
@@ -60,7 +60,7 @@
             var message = transportOperation.Message;
 
             var properties = channel.CreateBasicProperties();
-            properties.Fill(message, transportOperation.DeliveryConstraints, out _);
+            properties.Fill(message, transportOperation.DeliveryConstraints);
 
             return channel.PublishMessage(transportOperation.MessageType, message, properties);
         }


### PR DESCRIPTION
The `destination` parameter should have been removed as part of the changes in #520, so this is just cleaning up something that was missed.