### PR TITLE
Switch sample connection string to AMQP

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ/RabbitMQTransport.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/RabbitMQTransport.cs
@@ -20,6 +20,6 @@
         /// <summary>
         /// Gets an example connection string to use when reporting the lack of a configured connection string to the user.
         /// </summary>
-        public override string ExampleConnectionStringForErrorMessage => "host=localhost";
+        public override string ExampleConnectionStringForErrorMessage => "amqp://localhost";
     }
 }


### PR DESCRIPTION
Show an AMQP sample connection string when the transport is not provided with a connection string

The output will be

> System.InvalidOperationException: 'Transport connection string has not been explicitly configured via 'ConnectionString' method. Here is an example of what is required: endpointConfig.UseTransport<RabbitMQTransport>().ConnectionString("**amqp://localhost**");'

instead of 

> System.InvalidOperationException: 'Transport connection string has not been explicitly configured via 'ConnectionString' method. Here is an example of what is required: endpointConfig.UseTransport<RabbitMQTransport>().ConnectionString("**host=localhost**");'