### PR TITLE
Make BasicDeliverEventArgs available on ErrorContext

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ/NServiceBus.Transport.RabbitMQ.csproj
+++ b/src/NServiceBus.Transport.RabbitMQ/NServiceBus.Transport.RabbitMQ.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Fody" Version="6.1.1" PrivateAssets="All" />
-    <PackageReference Include="NServiceBus" Version="[7.1.6, 8.0.0)" />
+    <PackageReference Include="NServiceBus" Version="[7.2.3, 8.0.0)" />
     <PackageReference Include="Obsolete.Fody" Version="5.2.1" PrivateAssets="All" />
     <PackageReference Include="Particular.CodeRules" Version="0.2.1" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="0.6.2" PrivateAssets="All" />

--- a/src/NServiceBus.Transport.RabbitMQ/Receiving/MessagePump.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Receiving/MessagePump.cs
@@ -247,6 +247,7 @@
                     {
                         var contextBag = new ContextBag();
                         contextBag.Set(message);
+
                         var messageContext = new MessageContext(messageId, headers, message.Body ?? new byte[0], transportTransaction, tokenSource, contextBag);
 
                         await onMessage(messageContext).ConfigureAwait(false);
@@ -256,7 +257,10 @@
                     {
                         ++numberOfDeliveryAttempts;
                         headers = messageConverter.RetrieveHeaders(message);
-                        var errorContext = new ErrorContext(exception, headers, messageId, message.Body ?? new byte[0], transportTransaction, numberOfDeliveryAttempts);
+                        var contextBag = new ContextBag();
+                        contextBag.Set(message);
+
+                        var errorContext = new ErrorContext(exception, headers, messageId, message.Body ?? new byte[0], transportTransaction, numberOfDeliveryAttempts, contextBag);
 
                         try
                         {


### PR DESCRIPTION
Followup to #527

As of https://github.com/Particular/NServiceBus/pull/5433, Core 7.2.x offers a way to pass in a `ContextBag` on the `ErrrorContext`, so we can make `BasicDeliverEventArgs` also available there.