### PR TITLE
Update to RabbitMQ.Client 6.0

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/ConfigureEndpointRabbitMQTransport.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/ConfigureEndpointRabbitMQTransport.cs
@@ -31,14 +31,14 @@ class ConfigureEndpointRabbitMQTransport : IConfigureEndpointTestExecution
 
         queueBindings = configuration.GetSettings().Get<QueueBindings>();
 
-        return TaskEx.CompletedTask;
+        return Task.CompletedTask;
     }
 
     public Task Cleanup()
     {
         PurgeQueues();
 
-        return TaskEx.CompletedTask;
+        return Task.CompletedTask;
     }
 
     void PurgeQueues()

--- a/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/DelayedDelivery/When_deferring_a_message_longer_than_allowed_maximum.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/DelayedDelivery/When_deferring_a_message_longer_than_allowed_maximum.cs
@@ -41,7 +41,7 @@
 
             public class MyMessageHandler : IHandleMessages<MyMessage>
             {
-                public Task Handle(MyMessage message, IMessageHandlerContext context) => TaskEx.CompletedTask;
+                public Task Handle(MyMessage message, IMessageHandlerContext context) => Task.CompletedTask;
             }
         }
 

--- a/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/NServiceBus.Transport.RabbitMQ.AcceptanceTests.csproj
+++ b/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/NServiceBus.Transport.RabbitMQ.AcceptanceTests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.3.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
-    <PackageReference Include="RabbitMQ.Client" Version="6.0.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/NServiceBus.Transport.RabbitMQ.AcceptanceTests.csproj
+++ b/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/NServiceBus.Transport.RabbitMQ.AcceptanceTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
@@ -14,7 +14,7 @@
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.3.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
-    <PackageReference Include="RabbitMQ.Client" Version="5.2.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/When_publishing_message_implementing_interface_in_direct_topology.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/When_publishing_message_implementing_interface_in_direct_topology.cs
@@ -64,7 +64,7 @@
                 {
                     myContext.GotTheMessage = true;
 
-                    return TaskEx.CompletedTask;
+                    return Task.CompletedTask;
                 }
             }
         }

--- a/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/When_receiving_a_message.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/When_receiving_a_message.cs
@@ -36,7 +36,7 @@
                     Context.HandlerHasAccessToBasicDeliverEventArgs = context.Extensions.TryGet<BasicDeliverEventArgs>(out _);
                     Context.MessageReceived = true;
 
-                    return TaskEx.CompletedTask;
+                    return Task.CompletedTask;
                 }
             }
         }

--- a/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/When_receiving_a_reply_that_contains_a_legacy_callback_header.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/When_receiving_a_reply_that_contains_a_legacy_callback_header.cs
@@ -59,7 +59,7 @@
 
                 public Task Handle(Reply message, IMessageHandlerContext context)
                 {
-                    return TaskEx.CompletedTask;
+                    return Task.CompletedTask;
                 }
             }
         }
@@ -90,7 +90,7 @@
                 {
                     Context.IncorrectHandlerInvoked = true;
 
-                    return TaskEx.CompletedTask;
+                    return Task.CompletedTask;
                 }
             }
         }
@@ -110,7 +110,7 @@
                 {
                     Context.AuditMessageReceived = true;
 
-                    return TaskEx.CompletedTask;
+                    return Task.CompletedTask;
                 }
             }
         }

--- a/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/When_scaling_out_senders_that_uses_callbacks.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/When_scaling_out_senders_that_uses_callbacks.cs
@@ -87,7 +87,7 @@
                         throw new Exception("Wrong endpoint got the response.");
                     }
                     Context.ReplyReceived();
-                    return TaskEx.CompletedTask;
+                    return Task.CompletedTask;
                 }
             }
         }

--- a/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/When_scaling_out_subscribers.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/When_scaling_out_subscribers.cs
@@ -60,7 +60,7 @@
                         myContext.Counter++;
                     }
 
-                    return TaskEx.CompletedTask;
+                    return Task.CompletedTask;
                 }
 
                 static Object objLock = new object();

--- a/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/When_the_broker_connection_is_lost.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/When_the_broker_connection_is_lost.cs
@@ -64,7 +64,7 @@
                         await session.SendLocal(new MyRequest { MessageId = context.MessageId });
                     }
 
-                    protected override Task OnStop(IMessageSession session) => TaskEx.CompletedTask;
+                    protected override Task OnStop(IMessageSession session) => Task.CompletedTask;
 
                     async Task BreakConnectionBySendingInvalidMessage()
                     {
@@ -102,7 +102,7 @@
                         myContext.GotTheMessage = true;
                     }
 
-                    return TaskEx.CompletedTask;
+                    return Task.CompletedTask;
                 }
             }
         }

--- a/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/When_the_message_contains_a_legacy_callback_header.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/When_the_message_contains_a_legacy_callback_header.cs
@@ -58,7 +58,7 @@ namespace NServiceBus.Transport.RabbitMQ.AcceptanceTests
                 {
                     Context.RepliedToWrongQueue = true;
                     Context.Done = true;
-                    return TaskEx.CompletedTask;
+                    return Task.CompletedTask;
                 }
             }
         }
@@ -77,7 +77,7 @@ namespace NServiceBus.Transport.RabbitMQ.AcceptanceTests
                 public Task Handle(Reply message, IMessageHandlerContext context)
                 {
                     Context.Done = true;
-                    return TaskEx.CompletedTask;
+                    return Task.CompletedTask;
                 }
             }
         }

--- a/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/When_using_a_custom_message_id_strategy.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/When_using_a_custom_message_id_strategy.cs
@@ -74,7 +74,7 @@
                         return dispatchMessages.Dispatch(new TransportOperations(transportOperation), new TransportTransaction(), new ContextBag());
                     }
 
-                    protected override Task OnStop(IMessageSession session) => TaskEx.CompletedTask;
+                    protected override Task OnStop(IMessageSession session) => Task.CompletedTask;
 
                     readonly IDispatchMessages dispatchMessages;
                     readonly ReadOnlySettings settings;
@@ -95,7 +95,7 @@
                     myContext.GotTheMessage = true;
                     myContext.ReceivedMessageId = context.MessageId;
 
-                    return TaskEx.CompletedTask;
+                    return Task.CompletedTask;
                 }
             }
         }

--- a/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/When_using_a_custom_message_id_strategy_that_returns_an_invalid_message_id.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/When_using_a_custom_message_id_strategy_that_returns_an_invalid_message_id.cs
@@ -43,7 +43,7 @@
                 {
                     myContext.GotTheMessage = true;
 
-                    return TaskEx.CompletedTask;
+                    return Task.CompletedTask;
                 }
             }
         }

--- a/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/When_using_direct_routing.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/When_using_direct_routing.cs
@@ -40,7 +40,7 @@
                 {
                     myContext.GotTheMessage = true;
 
-                    return TaskEx.CompletedTask;
+                    return Task.CompletedTask;
                 }
             }
         }

--- a/src/NServiceBus.Transport.RabbitMQ.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -46,7 +46,7 @@ namespace NServiceBus.Transport.RabbitMQ
         void BindToDelayInfrastructure(RabbitMQ.Client.IModel channel, string address, string deliveryExchange, string routingKey);
         void Initialize(RabbitMQ.Client.IModel channel, System.Collections.Generic.IEnumerable<string> receivingAddresses, System.Collections.Generic.IEnumerable<string> sendingAddresses);
         void Publish(RabbitMQ.Client.IModel channel, System.Type type, NServiceBus.Transport.OutgoingMessage message, RabbitMQ.Client.IBasicProperties properties);
-        void RawSendInCaseOfFailure(RabbitMQ.Client.IModel channel, string address, byte[] body, RabbitMQ.Client.IBasicProperties properties);
+        void RawSendInCaseOfFailure(RabbitMQ.Client.IModel channel, string address, System.ReadOnlyMemory<byte> body, RabbitMQ.Client.IBasicProperties properties);
         void Send(RabbitMQ.Client.IModel channel, string address, NServiceBus.Transport.OutgoingMessage message, RabbitMQ.Client.IBasicProperties properties);
         void SetupSubscription(RabbitMQ.Client.IModel channel, System.Type type, string subscriberName);
         void TeardownSubscription(RabbitMQ.Client.IModel channel, System.Type type, string subscriberName);

--- a/src/NServiceBus.Transport.RabbitMQ.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -17,10 +17,7 @@ namespace NServiceBus
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> PrefetchMultiplier(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions, int prefetchMultiplier) { }
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> SetClientCertificate(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions, System.Security.Cryptography.X509Certificates.X509Certificate2 clientCertificate) { }
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> SetClientCertificate(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions, string path, string password) { }
-        [System.ObsoleteAttribute("Use `RabbitMQTransportSettingsExtensions.SetClientCertificate(TransportExtensions" +
-            "<RabbitMQTransport> transportExtensions, X509Certificate2 clientCertificate)` in" +
-            "stead. Will be treated as an error from version 6.0.0. Will be removed in versio" +
-            "n 7.0.0.", false)]
+        [System.ObsoleteAttribute(@"Use `RabbitMQTransportSettingsExtensions.SetClientCertificate(TransportExtensions<RabbitMQTransport> transportExtensions, X509Certificate2 clientCertificate)` instead. The member currently throws a NotImplementedException. Will be removed in version 7.0.0.", true)]
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> SetClientCertificates(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions, System.Security.Cryptography.X509Certificates.X509CertificateCollection clientCertificates) { }
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> SetHeartbeatInterval(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions, System.TimeSpan heartbeatInterval) { }
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> SetNetworkRecoveryInterval(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions, System.TimeSpan networkRecoveryInterval) { }
@@ -33,24 +30,15 @@ namespace NServiceBus
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> UsePublisherConfirms(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions, bool usePublisherConfirms) { }
         [System.ObsoleteAttribute("Use `RabbitMQTransportSettingsExtensions.UseCustomRoutingTopology(TransportExtens" +
             "ions<RabbitMQTransport> transportExtensions, Func<bool, IRoutingTopology>)` inst" +
-            "ead. Will be treated as an error from version 6.0.0. Will be removed in version " +
-            "7.0.0.", false)]
-        public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> UseRoutingTopology(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions, System.Func<bool, NServiceBus.Transport.RabbitMQ.IRoutingTopology> topologyFactory) { }
-        [System.ObsoleteAttribute("Use `RabbitMQTransportSettingsExtensions.UseCustomRoutingTopology(TransportExtens" +
-            "ions<RabbitMQTransport> transportExtensions, Func<bool, IRoutingTopology>)` inst" +
             "ead. The member currently throws a NotImplementedException. Will be removed in v" +
-            "ersion 6.0.0.", true)]
-        public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> UseRoutingTopology<T>(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions)
-            where T : NServiceBus.Transport.RabbitMQ.IRoutingTopology, new () { }
+            "ersion 7.0.0.", true)]
+        public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> UseRoutingTopology(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions, System.Func<bool, NServiceBus.Transport.RabbitMQ.IRoutingTopology> topologyFactory) { }
     }
 }
 namespace NServiceBus.Transport.RabbitMQ
 {
     public class DelayedDeliverySettings : NServiceBus.Configuration.AdvancedExtensibility.ExposeSettings
     {
-        [System.ObsoleteAttribute("The timeout manager is now disabled by default. The member currently throws a Not" +
-            "ImplementedException. Will be removed in version 6.0.0.", true)]
-        public NServiceBus.Transport.RabbitMQ.DelayedDeliverySettings DisableTimeoutManager() { }
         public NServiceBus.Transport.RabbitMQ.DelayedDeliverySettings EnableTimeoutManager() { }
     }
     public interface IRoutingTopology
@@ -58,7 +46,7 @@ namespace NServiceBus.Transport.RabbitMQ
         void BindToDelayInfrastructure(RabbitMQ.Client.IModel channel, string address, string deliveryExchange, string routingKey);
         void Initialize(RabbitMQ.Client.IModel channel, System.Collections.Generic.IEnumerable<string> receivingAddresses, System.Collections.Generic.IEnumerable<string> sendingAddresses);
         void Publish(RabbitMQ.Client.IModel channel, System.Type type, NServiceBus.Transport.OutgoingMessage message, RabbitMQ.Client.IBasicProperties properties);
-        void RawSendInCaseOfFailure(RabbitMQ.Client.IModel channel, string address, byte[] body, RabbitMQ.Client.IBasicProperties properties);
+        void RawSendInCaseOfFailure(RabbitMQ.Client.IModel channel, string address, System.ReadOnlyMemory<byte> body, RabbitMQ.Client.IBasicProperties properties);
         void Send(RabbitMQ.Client.IModel channel, string address, NServiceBus.Transport.OutgoingMessage message, RabbitMQ.Client.IBasicProperties properties);
         void SetupSubscription(RabbitMQ.Client.IModel channel, System.Type type, string subscriberName);
         void TeardownSubscription(RabbitMQ.Client.IModel channel, System.Type type, string subscriberName);

--- a/src/NServiceBus.Transport.RabbitMQ.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -46,7 +46,7 @@ namespace NServiceBus.Transport.RabbitMQ
         void BindToDelayInfrastructure(RabbitMQ.Client.IModel channel, string address, string deliveryExchange, string routingKey);
         void Initialize(RabbitMQ.Client.IModel channel, System.Collections.Generic.IEnumerable<string> receivingAddresses, System.Collections.Generic.IEnumerable<string> sendingAddresses);
         void Publish(RabbitMQ.Client.IModel channel, System.Type type, NServiceBus.Transport.OutgoingMessage message, RabbitMQ.Client.IBasicProperties properties);
-        void RawSendInCaseOfFailure(RabbitMQ.Client.IModel channel, string address, System.ReadOnlyMemory<byte> body, RabbitMQ.Client.IBasicProperties properties);
+        void RawSendInCaseOfFailure(RabbitMQ.Client.IModel channel, string address, byte[] body, RabbitMQ.Client.IBasicProperties properties);
         void Send(RabbitMQ.Client.IModel channel, string address, NServiceBus.Transport.OutgoingMessage message, RabbitMQ.Client.IBasicProperties properties);
         void SetupSubscription(RabbitMQ.Client.IModel channel, System.Type type, string subscriberName);
         void TeardownSubscription(RabbitMQ.Client.IModel channel, System.Type type, string subscriberName);

--- a/src/NServiceBus.Transport.RabbitMQ.Tests/ConnectionString/ConnectionConfigurationTests.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/ConnectionString/ConnectionConfigurationTests.cs
@@ -25,7 +25,7 @@
             Assert.AreEqual(connectionConfiguration.VirtualHost, "Copa");
             Assert.AreEqual(connectionConfiguration.UserName, "Copa");
             Assert.AreEqual(connectionConfiguration.Password, "abc_xyz");
-            Assert.AreEqual(connectionConfiguration.RequestedHeartbeat, 3);
+            Assert.AreEqual(connectionConfiguration.RequestedHeartbeat, TimeSpan.FromSeconds(3));
             Assert.AreEqual(connectionConfiguration.RetryDelay, new TimeSpan(1, 2, 3)); //01:02:03
             Assert.AreEqual(connectionConfiguration.UseTls, true);
             Assert.AreEqual(connectionConfiguration.CertPath, "/path/to/client/keycert.p12");
@@ -94,7 +94,7 @@
         {
             var connectionConfiguration = ConnectionConfiguration.Create("host=localhost;requestedHeartbeat=5", endpointName);
 
-            Assert.AreEqual(5, connectionConfiguration.RequestedHeartbeat);
+            Assert.AreEqual(TimeSpan.FromSeconds(5), connectionConfiguration.RequestedHeartbeat);
         }
 
         [Test]
@@ -210,7 +210,7 @@
         [Test]
         public void Should_set_default_requested_heartbeat()
         {
-            Assert.AreEqual(defaults.RequestedHeartbeat, 60);
+            Assert.AreEqual(defaults.RequestedHeartbeat, TimeSpan.FromSeconds(60));
         }
 
         [Test]

--- a/src/NServiceBus.Transport.RabbitMQ.Tests/ConnectionString/ConnectionConfigurationWithAmqpTests.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/ConnectionString/ConnectionConfigurationWithAmqpTests.cs
@@ -94,7 +94,7 @@
         [Test]
         public void Should_set_default_requested_heartbeat()
         {
-            Assert.AreEqual(defaults.RequestedHeartbeat, 60);
+            Assert.AreEqual(defaults.RequestedHeartbeat, TimeSpan.FromSeconds(60));
         }
 
         [Test]

--- a/src/NServiceBus.Transport.RabbitMQ.Tests/MessageConverterTests.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/MessageConverterTests.cs
@@ -3,13 +3,162 @@
     using System;
     using System.Collections.Generic;
     using System.Text;
+    using global::RabbitMQ.Client;
     using global::RabbitMQ.Client.Events;
-    using global::RabbitMQ.Client.Framing;
     using NUnit.Framework;
 
     [TestFixture]
     class MessageConverterTests
     {
+        class TestingBasicProperties : IBasicProperties
+        {
+            public string AppId { get; set; }
+            public string ClusterId { get; set; }
+            public string ContentEncoding { get; set; }
+            public string ContentType { get; set; }
+            public string CorrelationId { get; set; }
+            public byte DeliveryMode { get; set; }
+            public string Expiration { get; set; }
+            public IDictionary<string, object> Headers { get; set; }
+            public string MessageId { get; set; }
+            public bool Persistent { get; set; }
+            public byte Priority { get; set; }
+            public string ReplyTo { get; set; }
+            public PublicationAddress ReplyToAddress { get; set; }
+            public AmqpTimestamp Timestamp { get; set; }
+            public string Type { get; set; }
+            public string UserId { get; set; }
+
+            public ushort ProtocolClassId => throw new NotImplementedException();
+
+            public string ProtocolClassName => throw new NotImplementedException();
+
+            public void ClearAppId()
+            {
+                throw new NotImplementedException();
+            }
+
+            public void ClearClusterId()
+            {
+                throw new NotImplementedException();
+            }
+
+            public void ClearContentEncoding()
+            {
+                throw new NotImplementedException();
+            }
+
+            public void ClearContentType()
+            {
+                throw new NotImplementedException();
+            }
+
+            public void ClearCorrelationId()
+            {
+                throw new NotImplementedException();
+            }
+
+            public void ClearDeliveryMode()
+            {
+                throw new NotImplementedException();
+            }
+
+            public void ClearExpiration()
+            {
+                throw new NotImplementedException();
+            }
+
+            public void ClearHeaders()
+            {
+                throw new NotImplementedException();
+            }
+
+            public void ClearMessageId()
+            {
+                throw new NotImplementedException();
+            }
+
+            public void ClearPriority()
+            {
+                throw new NotImplementedException();
+            }
+
+            public void ClearReplyTo()
+            {
+                throw new NotImplementedException();
+            }
+
+            public void ClearTimestamp()
+            {
+                throw new NotImplementedException();
+            }
+
+            public void ClearType()
+            {
+                throw new NotImplementedException();
+            }
+
+            public void ClearUserId()
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool IsAppIdPresent()
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool IsClusterIdPresent()
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool IsContentEncodingPresent()
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool IsContentTypePresent()
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool IsCorrelationIdPresent() => !string.IsNullOrEmpty(CorrelationId);
+
+            public bool IsDeliveryModePresent() => DeliveryMode != 0;
+
+            public bool IsExpirationPresent()
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool IsHeadersPresent()
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool IsMessageIdPresent() => !string.IsNullOrEmpty(MessageId);
+
+            public bool IsPriorityPresent()
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool IsReplyToPresent() => !string.IsNullOrEmpty(ReplyTo);
+
+            public bool IsTimestampPresent()
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool IsTypePresent() => !string.IsNullOrEmpty(Type);
+
+            public bool IsUserIdPresent()
+            {
+                throw new NotImplementedException();
+            }
+        }
+
         MessageConverter converter = new MessageConverter();
 
         [Test]
@@ -17,7 +166,7 @@
         {
             var message = new BasicDeliverEventArgs
             {
-                BasicProperties = new BasicProperties
+                BasicProperties = new TestingBasicProperties
                 {
                     MessageId = "Blah"
                 }
@@ -35,7 +184,7 @@
         {
             var message = new BasicDeliverEventArgs
             {
-                BasicProperties = new BasicProperties()
+                BasicProperties = new TestingBasicProperties()
             };
 
             var headers = new Dictionary<string, string>();
@@ -50,7 +199,7 @@
 
             var message = new BasicDeliverEventArgs
             {
-                BasicProperties = new BasicProperties()
+                BasicProperties = new TestingBasicProperties()
             };
 
             var headers = new Dictionary<string, string>();
@@ -65,10 +214,10 @@
 
             var message = new BasicDeliverEventArgs
             {
-                BasicProperties = new BasicProperties()
+                BasicProperties = new TestingBasicProperties()
             };
 
-            var headers = new Dictionary<string, string> { { Headers.MessageId, "Blah" } };
+            var headers = new Dictionary<string, string> { { NServiceBus.Headers.MessageId, "Blah" } };
 
             var messageId = customConverter.RetrieveMessageId(message, headers);
 
@@ -80,7 +229,7 @@
         {
             var message = new BasicDeliverEventArgs
             {
-                BasicProperties = new BasicProperties
+                BasicProperties = new TestingBasicProperties
                 {
                     MessageId = "Blah",
                     Headers = new Dictionary<string, object>
@@ -101,7 +250,7 @@
         {
             var message = new BasicDeliverEventArgs
             {
-                BasicProperties = new BasicProperties
+                BasicProperties = new TestingBasicProperties
                 {
                     ReplyTo = "myaddress",
                     MessageId = "Blah"
@@ -111,7 +260,7 @@
             var headers = converter.RetrieveHeaders(message);
 
             Assert.NotNull(headers);
-            Assert.AreEqual("myaddress", headers[Headers.ReplyToAddress]);
+            Assert.AreEqual("myaddress", headers[NServiceBus.Headers.ReplyToAddress]);
         }
 
         [Test]
@@ -119,13 +268,13 @@
         {
             var message = new BasicDeliverEventArgs
             {
-                BasicProperties = new BasicProperties
+                BasicProperties = new TestingBasicProperties
                 {
                     ReplyTo = "myaddress",
                     MessageId = "Blah",
                     Headers = new Dictionary<string, object>
                     {
-                        {Headers.ReplyToAddress, Encoding.UTF8.GetBytes("nsb set address")}
+                        {NServiceBus.Headers.ReplyToAddress, Encoding.UTF8.GetBytes("nsb set address")}
                     }
                 }
             };
@@ -133,7 +282,7 @@
             var headers = converter.RetrieveHeaders(message);
 
             Assert.NotNull(headers);
-            Assert.AreEqual("myaddress", headers[Headers.ReplyToAddress]);
+            Assert.AreEqual("myaddress", headers[NServiceBus.Headers.ReplyToAddress]);
         }
 
         [Test]
@@ -141,7 +290,7 @@
         {
             var message = new BasicDeliverEventArgs
             {
-                BasicProperties = new BasicProperties
+                BasicProperties = new TestingBasicProperties
                 {
                     MessageId = "Blah",
                     Headers = new Dictionary<string, object>
@@ -176,7 +325,7 @@
         {
             var message = new BasicDeliverEventArgs
             {
-                BasicProperties = new BasicProperties
+                BasicProperties = new TestingBasicProperties
                 {
                     MessageId = "Blah",
                     Headers = new Dictionary<string, object>
@@ -197,7 +346,7 @@
         {
             var message = new BasicDeliverEventArgs
             {
-                BasicProperties = new BasicProperties
+                BasicProperties = new TestingBasicProperties
                 {
                     MessageId = "Blah",
                     Headers = new Dictionary<string, object>
@@ -218,7 +367,7 @@
         {
             var message = new BasicDeliverEventArgs
             {
-                BasicProperties = new BasicProperties
+                BasicProperties = new TestingBasicProperties
                 {
                     MessageId = "Blah",
                     Headers = new Dictionary<string, object>
@@ -239,7 +388,7 @@
         {
             var message = new BasicDeliverEventArgs
             {
-                BasicProperties = new BasicProperties
+                BasicProperties = new TestingBasicProperties
                 {
                     MessageId = "Blah",
                     Headers = new Dictionary<string, object>

--- a/src/NServiceBus.Transport.RabbitMQ.Tests/MessageConverterTests.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/MessageConverterTests.cs
@@ -29,98 +29,98 @@
             public string Type { get; set; }
             public string UserId { get; set; }
 
-            public ushort ProtocolClassId => throw new NotImplementedException();
+            public ushort ProtocolClassId => throw new NotSupportedException();
 
-            public string ProtocolClassName => throw new NotImplementedException();
+            public string ProtocolClassName => throw new NotSupportedException();
 
             public void ClearAppId()
             {
-                throw new NotImplementedException();
+                throw new NotSupportedException();
             }
 
             public void ClearClusterId()
             {
-                throw new NotImplementedException();
+                throw new NotSupportedException();
             }
 
             public void ClearContentEncoding()
             {
-                throw new NotImplementedException();
+                throw new NotSupportedException();
             }
 
             public void ClearContentType()
             {
-                throw new NotImplementedException();
+                throw new NotSupportedException();
             }
 
             public void ClearCorrelationId()
             {
-                throw new NotImplementedException();
+                throw new NotSupportedException();
             }
 
             public void ClearDeliveryMode()
             {
-                throw new NotImplementedException();
+                throw new NotSupportedException();
             }
 
             public void ClearExpiration()
             {
-                throw new NotImplementedException();
+                throw new NotSupportedException();
             }
 
             public void ClearHeaders()
             {
-                throw new NotImplementedException();
+                throw new NotSupportedException();
             }
 
             public void ClearMessageId()
             {
-                throw new NotImplementedException();
+                throw new NotSupportedException();
             }
 
             public void ClearPriority()
             {
-                throw new NotImplementedException();
+                throw new NotSupportedException();
             }
 
             public void ClearReplyTo()
             {
-                throw new NotImplementedException();
+                throw new NotSupportedException();
             }
 
             public void ClearTimestamp()
             {
-                throw new NotImplementedException();
+                throw new NotSupportedException();
             }
 
             public void ClearType()
             {
-                throw new NotImplementedException();
+                throw new NotSupportedException();
             }
 
             public void ClearUserId()
             {
-                throw new NotImplementedException();
+                throw new NotSupportedException();
             }
 
             public bool IsAppIdPresent()
             {
-                throw new NotImplementedException();
+                throw new NotSupportedException();
             }
 
             public bool IsClusterIdPresent()
             {
-                throw new NotImplementedException();
+                throw new NotSupportedException();
             }
 
             public bool IsContentEncodingPresent()
             {
-                throw new NotImplementedException();
+                throw new NotSupportedException();
             }
 
             public bool IsContentTypePresent()
             {
-                throw new NotImplementedException();
+                throw new NotSupportedException();
             }
 
             public bool IsCorrelationIdPresent() => !string.IsNullOrEmpty(CorrelationId);
@@ -129,33 +129,33 @@
 
             public bool IsExpirationPresent()
             {
-                throw new NotImplementedException();
+                throw new NotSupportedException();
             }
 
             public bool IsHeadersPresent()
             {
-                throw new NotImplementedException();
+                throw new NotSupportedException();
             }
 
             public bool IsMessageIdPresent() => !string.IsNullOrEmpty(MessageId);
 
             public bool IsPriorityPresent()
             {
-                throw new NotImplementedException();
+                throw new NotSupportedException();
             }
 
             public bool IsReplyToPresent() => !string.IsNullOrEmpty(ReplyTo);
 
             public bool IsTimestampPresent()
             {
-                throw new NotImplementedException();
+                throw new NotSupportedException();
             }
 
             public bool IsTypePresent() => !string.IsNullOrEmpty(Type);
 
             public bool IsUserIdPresent()
             {
-                throw new NotImplementedException();
+                throw new NotSupportedException();
             }
         }
 

--- a/src/NServiceBus.Transport.RabbitMQ.Tests/NServiceBus.Transport.RabbitMQ.Tests.csproj
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/NServiceBus.Transport.RabbitMQ.Tests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
     <PackageReference Include="Particular.Approvals" Version="0.2.0" />
     <PackageReference Include="PublicApiGenerator" Version="9.3.0" />
-    <PackageReference Include="RabbitMQ.Client" Version="6.0.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.Transport.RabbitMQ.Tests/NServiceBus.Transport.RabbitMQ.Tests.csproj
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/NServiceBus.Transport.RabbitMQ.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBus.snk</AssemblyOriginatorKeyFile>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
@@ -18,7 +18,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
     <PackageReference Include="Particular.Approvals" Version="0.2.0" />
     <PackageReference Include="PublicApiGenerator" Version="9.3.0" />
-    <PackageReference Include="RabbitMQ.Client" Version="5.2.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.Transport.RabbitMQ.Tests/RabbitMqContext.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/RabbitMqContext.cs
@@ -44,10 +44,10 @@
             messagePump.Init(messageContext =>
             {
                 receivedMessages.Add(new IncomingMessage(messageContext.MessageId, messageContext.Headers, messageContext.Body));
-                return TaskEx.CompletedTask;
+                return Task.CompletedTask;
             },
                 ErrorContext => Task.FromResult(ErrorHandleResult.Handled),
-                new CriticalError(_ => TaskEx.CompletedTask),
+                new CriticalError(_ => Task.CompletedTask),
                 new PushSettings(ReceiverQueue, ErrorQueue, true, TransportTransactionMode.ReceiveOnly)
             ).GetAwaiter().GetResult();
 

--- a/src/NServiceBus.Transport.RabbitMQ.Tests/When_sending_a_message_over_rabbitmq.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/When_sending_a_message_over_rabbitmq.cs
@@ -110,7 +110,7 @@
             var convertedHeaders = converter.RetrieveHeaders(result);
             var convertedMessageId = converter.RetrieveMessageId(result, convertedHeaders);
 
-            var incomingMessage = new IncomingMessage(convertedMessageId, convertedHeaders, result.Body);
+            var incomingMessage = new IncomingMessage(convertedMessageId, convertedHeaders, result.Body.ToArray());
 
             assertion(incomingMessage, result);
         }

--- a/src/NServiceBus.Transport.RabbitMQ.TransportTests/NServiceBus.Transport.RabbitMQ.TransportTests.csproj
+++ b/src/NServiceBus.Transport.RabbitMQ.TransportTests/NServiceBus.Transport.RabbitMQ.TransportTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
@@ -14,7 +14,7 @@
     <PackageReference Include="NServiceBus.TransportTests.Sources" Version="7.3.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
-    <PackageReference Include="RabbitMQ.Client" Version="5.2.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.Transport.RabbitMQ.TransportTests/NServiceBus.Transport.RabbitMQ.TransportTests.csproj
+++ b/src/NServiceBus.Transport.RabbitMQ.TransportTests/NServiceBus.Transport.RabbitMQ.TransportTests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="NServiceBus.TransportTests.Sources" Version="7.3.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
-    <PackageReference Include="RabbitMQ.Client" Version="6.0.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.Transport.RabbitMQ/Administration/QueueCreator.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Administration/QueueCreator.cs
@@ -28,7 +28,7 @@
                 }
             }
 
-            return TaskEx.CompletedTask;
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/NServiceBus.Transport.RabbitMQ/Administration/SubscriptionManager.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Administration/SubscriptionManager.cs
@@ -25,7 +25,7 @@
                 routingTopology.SetupSubscription(channel, eventType, localQueue);
             }
 
-            return TaskEx.CompletedTask;
+            return Task.CompletedTask;
         }
 
         public Task Unsubscribe(Type eventType, ContextBag context)
@@ -36,7 +36,7 @@
                 routingTopology.TeardownSubscription(channel, eventType, localQueue);
             }
 
-            return TaskEx.CompletedTask;
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/NServiceBus.Transport.RabbitMQ/Configuration/ConnectionConfiguration.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Configuration/ConnectionConfiguration.cs
@@ -17,7 +17,7 @@
         const string defaultVirtualHost = "/";
         const string defaultUserName = "guest";
         const string defaultPassword = "guest";
-        static readonly TimeSpan defaultRequestedHeartbeat = TimeSpan.FromSeconds(60);
+        const ushort defaultRequestedHeartbeat = 60;
         static readonly TimeSpan defaultRetryDelay = TimeSpan.FromSeconds(10);
         const string defaultCertPath = "";
         const string defaultCertPassphrase = null;
@@ -90,7 +90,10 @@
             var virtualHost = GetValue(dictionary, "virtualHost", defaultVirtualHost);
             var userName = GetValue(dictionary, "userName", defaultUserName);
             var password = GetValue(dictionary, "password", defaultPassword);
-            var requestedHeartbeat = GetValue(dictionary, "requestedHeartbeat", TimeSpan.TryParse, defaultRequestedHeartbeat, invalidOptionsMessage);
+
+            var requestedHeartbeatSeconds = GetValue(dictionary, "requestedHeartbeat", ushort.TryParse, defaultRequestedHeartbeat, invalidOptionsMessage);
+            var requestedHeartbeat = TimeSpan.FromSeconds(requestedHeartbeatSeconds);
+
             var retryDelay = GetValue(dictionary, "retryDelay", TimeSpan.TryParse, defaultRetryDelay, invalidOptionsMessage);
             var certPath = GetValue(dictionary, "certPath", defaultCertPath);
             var certPassPhrase = GetValue(dictionary, "certPassphrase", defaultCertPassphrase);

--- a/src/NServiceBus.Transport.RabbitMQ/Configuration/ConnectionConfiguration.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Configuration/ConnectionConfiguration.cs
@@ -17,7 +17,7 @@
         const string defaultVirtualHost = "/";
         const string defaultUserName = "guest";
         const string defaultPassword = "guest";
-        const ushort defaultRequestedHeartbeat = 60;
+        static readonly TimeSpan defaultRequestedHeartbeat = TimeSpan.FromSeconds(60);
         static readonly TimeSpan defaultRetryDelay = TimeSpan.FromSeconds(10);
         const string defaultCertPath = "";
         const string defaultCertPassphrase = null;
@@ -32,7 +32,7 @@
 
         public string Password { get; }
 
-        public ushort RequestedHeartbeat { get; }
+        public TimeSpan RequestedHeartbeat { get; }
 
         public TimeSpan RetryDelay { get; }
 
@@ -50,7 +50,7 @@
             string virtualHost,
             string userName,
             string password,
-            ushort requestedHeartbeat,
+            TimeSpan requestedHeartbeat,
             TimeSpan retryDelay,
             bool useTls,
             string certPath,
@@ -90,7 +90,7 @@
             var virtualHost = GetValue(dictionary, "virtualHost", defaultVirtualHost);
             var userName = GetValue(dictionary, "userName", defaultUserName);
             var password = GetValue(dictionary, "password", defaultPassword);
-            var requestedHeartbeat = GetValue(dictionary, "requestedHeartbeat", ushort.TryParse, defaultRequestedHeartbeat, invalidOptionsMessage);
+            var requestedHeartbeat = GetValue(dictionary, "requestedHeartbeat", TimeSpan.TryParse, defaultRequestedHeartbeat, invalidOptionsMessage);
             var retryDelay = GetValue(dictionary, "retryDelay", TimeSpan.TryParse, defaultRetryDelay, invalidOptionsMessage);
             var certPath = GetValue(dictionary, "certPath", defaultCertPath);
             var certPassPhrase = GetValue(dictionary, "certPassphrase", defaultCertPassphrase);

--- a/src/NServiceBus.Transport.RabbitMQ/Configuration/RabbitMQTransportSettingsExtensions.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Configuration/RabbitMQTransportSettingsExtensions.cs
@@ -268,15 +268,7 @@
             Guard.AgainstNull(nameof(transportExtensions), transportExtensions);
             Guard.AgainstNegativeAndZero(nameof(heartbeatInterval), heartbeatInterval);
 
-            try
-            {
-                var result = Convert.ToUInt16(heartbeatInterval.TotalSeconds);
-                transportExtensions.GetSettings().Set(SettingsKeys.HeartbeatInterval, result);
-            }
-            catch(OverflowException)
-            {
-                throw new ArgumentOutOfRangeException(nameof(heartbeatInterval), $"Heartbeat interval cannot exceed {ushort.MaxValue} seconds.");
-            }
+            transportExtensions.GetSettings().Set(SettingsKeys.HeartbeatInterval, heartbeatInterval);
 
             return transportExtensions;
         }

--- a/src/NServiceBus.Transport.RabbitMQ/Configuration/RabbitMQTransportSettingsExtensions.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Configuration/RabbitMQTransportSettingsExtensions.cs
@@ -27,22 +27,6 @@
         }
 
         /// <summary>
-        /// Registers a custom routing topology.
-        /// </summary>
-        /// <param name="transportExtensions"></param>
-        /// <param name="topologyFactory">The function used to create the routing topology instance. The parameter of the function indicates whether exchanges and queues declared by the routing topology should be durable.</param>
-        [ObsoleteEx(RemoveInVersion = "7.0", TreatAsErrorFromVersion = "6.0", ReplacementTypeOrMember = "RabbitMQTransportSettingsExtensions.UseCustomRoutingTopology(TransportExtensions<RabbitMQTransport> transportExtensions, Func<bool, IRoutingTopology>)")]
-        public static TransportExtensions<RabbitMQTransport> UseRoutingTopology(this TransportExtensions<RabbitMQTransport> transportExtensions, Func<bool, IRoutingTopology> topologyFactory)
-        {
-            Guard.AgainstNull(nameof(transportExtensions), transportExtensions);
-            Guard.AgainstNull(nameof(topologyFactory), topologyFactory);
-
-            transportExtensions.GetSettings().Set(topologyFactory);
-
-            return transportExtensions;
-        }
-
-        /// <summary>
         /// Uses the conventional routing topology.
         /// </summary>
         /// <param name="transportExtensions"></param>
@@ -147,23 +131,6 @@
             Guard.AgainstNull(nameof(transportExtensions), transportExtensions);
 
             transportExtensions.GetSettings().Set(SettingsKeys.PrefetchCount, prefetchCount);
-
-            return transportExtensions;
-        }
-
-        /// <summary>
-        /// Specifies the certificates to use for client authentication when connecting to the broker via TLS.
-        /// </summary>
-        /// <param name="transportExtensions"></param>
-        /// <param name="clientCertificates">The collection of certificates to use for client authentication.</param>
-        /// <returns></returns>
-        [ObsoleteEx(RemoveInVersion = "7.0", TreatAsErrorFromVersion = "6.0", ReplacementTypeOrMember = "RabbitMQTransportSettingsExtensions.SetClientCertificate(TransportExtensions<RabbitMQTransport> transportExtensions, X509Certificate2 clientCertificate)")]
-        public static TransportExtensions<RabbitMQTransport> SetClientCertificates(this TransportExtensions<RabbitMQTransport> transportExtensions, X509CertificateCollection clientCertificates)
-        {
-            Guard.AgainstNull(nameof(transportExtensions), transportExtensions);
-            Guard.AgainstNull(nameof(clientCertificates), clientCertificates);
-
-            transportExtensions.GetSettings().Set(SettingsKeys.ClientCertificateCollection, clientCertificates);
 
             return transportExtensions;
         }

--- a/src/NServiceBus.Transport.RabbitMQ/Connection/ConfirmsAwareChannel.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Connection/ConfirmsAwareChannel.cs
@@ -85,7 +85,7 @@ namespace NServiceBus.Transport.RabbitMQ
             return task;
         }
 
-        public Task RawSendInCaseOfFailure(string address, ReadOnlyMemory<byte> body, IBasicProperties properties)
+        public Task RawSendInCaseOfFailure(string address, byte[] body, IBasicProperties properties)
         {
             Task task;
 

--- a/src/NServiceBus.Transport.RabbitMQ/Connection/ConfirmsAwareChannel.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Connection/ConfirmsAwareChannel.cs
@@ -48,7 +48,7 @@ namespace NServiceBus.Transport.RabbitMQ
             }
             else
             {
-                task = TaskEx.CompletedTask;
+                task = Task.CompletedTask;
             }
 
             if (properties.Headers.TryGetValue(DelayInfrastructure.DelayHeader, out var delayValue))
@@ -77,7 +77,7 @@ namespace NServiceBus.Transport.RabbitMQ
             }
             else
             {
-                task = TaskEx.CompletedTask;
+                task = Task.CompletedTask;
             }
 
             routingTopology.Publish(channel, type, message, properties);
@@ -102,7 +102,7 @@ namespace NServiceBus.Transport.RabbitMQ
             }
             else
             {
-                task = TaskEx.CompletedTask;
+                task = Task.CompletedTask;
             }
 
             routingTopology.RawSendInCaseOfFailure(channel, address, body, properties);

--- a/src/NServiceBus.Transport.RabbitMQ/Connection/ConfirmsAwareChannel.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Connection/ConfirmsAwareChannel.cs
@@ -85,7 +85,7 @@ namespace NServiceBus.Transport.RabbitMQ
             return task;
         }
 
-        public Task RawSendInCaseOfFailure(string address, byte[] body, IBasicProperties properties)
+        public Task RawSendInCaseOfFailure(string address, ReadOnlyMemory<byte> body, IBasicProperties properties)
         {
             Task task;
 

--- a/src/NServiceBus.Transport.RabbitMQ/Connection/ConnectionFactory.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Connection/ConnectionFactory.cs
@@ -15,7 +15,7 @@
         readonly global::RabbitMQ.Client.ConnectionFactory connectionFactory;
         readonly object lockObject = new object();
 
-        public ConnectionFactory(string endpointName, ConnectionConfiguration connectionConfiguration, X509Certificate2Collection clientCertificateCollection, bool disableRemoteCertificateValidation, bool useExternalAuthMechanism, ushort? heartbeatInterval, TimeSpan? networkRecoveryInterval)
+        public ConnectionFactory(string endpointName, ConnectionConfiguration connectionConfiguration, X509Certificate2Collection clientCertificateCollection, bool disableRemoteCertificateValidation, bool useExternalAuthMechanism, TimeSpan? heartbeatInterval, TimeSpan? networkRecoveryInterval)
         {
             if (endpointName is null)
             {

--- a/src/NServiceBus.Transport.RabbitMQ/NServiceBus.Transport.RabbitMQ.csproj
+++ b/src/NServiceBus.Transport.RabbitMQ/NServiceBus.Transport.RabbitMQ.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBus.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
@@ -12,7 +12,7 @@
     <PackageReference Include="Obsolete.Fody" Version="5.2.1" PrivateAssets="All" />
     <PackageReference Include="Particular.CodeRules" Version="0.3.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="0.9.0" PrivateAssets="All" />
-    <PackageReference Include="RabbitMQ.Client" Version="[5.2.0, 6.0.0)" />
+    <PackageReference Include="RabbitMQ.Client" Version="[6.0.0, 7.0.0)" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/NServiceBus.Transport.RabbitMQ/NServiceBus.Transport.RabbitMQ.csproj
+++ b/src/NServiceBus.Transport.RabbitMQ/NServiceBus.Transport.RabbitMQ.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Obsolete.Fody" Version="5.2.1" PrivateAssets="All" />
     <PackageReference Include="Particular.CodeRules" Version="0.3.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="0.9.0" PrivateAssets="All" />
-    <PackageReference Include="RabbitMQ.Client" Version="[6.0.0, 7.0.0)" />
+    <PackageReference Include="RabbitMQ.Client" Version="[6.1.0, 7.0.0)" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/NServiceBus.Transport.RabbitMQ/RabbitMQTransportInfrastructure.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/RabbitMQTransportInfrastructure.cs
@@ -30,7 +30,7 @@
             settings.TryGet(SettingsKeys.ClientCertificateCollection, out X509Certificate2Collection clientCertificateCollection);
             settings.TryGet(SettingsKeys.DisableRemoteCertificateValidation, out bool disableRemoteCertificateValidation);
             settings.TryGet(SettingsKeys.UseExternalAuthMechanism, out bool useExternalAuthMechanism);
-            settings.TryGet(SettingsKeys.HeartbeatInterval, out ushort? heartbeatInterval);
+            settings.TryGet(SettingsKeys.HeartbeatInterval, out TimeSpan? heartbeatInterval);
             settings.TryGet(SettingsKeys.NetworkRecoveryInterval, out TimeSpan? networkRecoveryInterval);
 
             connectionFactory = new ConnectionFactory(endpointName, connectionConfiguration, clientCertificateCollection, disableRemoteCertificateValidation, useExternalAuthMechanism, heartbeatInterval, networkRecoveryInterval);

--- a/src/NServiceBus.Transport.RabbitMQ/Receiving/MessagePump.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Receiving/MessagePump.cs
@@ -307,7 +307,7 @@
 
                 try
                 {
-                    await channel.RawSendInCaseOfFailure(queue, message.Body, message.BasicProperties).ConfigureAwait(false);
+                    await channel.RawSendInCaseOfFailure(queue, message.Body.ToArray(), message.BasicProperties).ConfigureAwait(false);
                 }
                 finally
                 {

--- a/src/NServiceBus.Transport.RabbitMQ/Receiving/MessagePump.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Receiving/MessagePump.cs
@@ -159,8 +159,7 @@
 
             var messageBody = eventArgs.Body.ToArray();
 
-            // Is here until upgraded to 6.2 , required later for `RetrieveMessageId`.
-            eventArgs = new BasicDeliverEventArgs(
+            var eventArgsCopy = new BasicDeliverEventArgs(
                 consumerTag: eventArgs.ConsumerTag,
                 deliveryTag: eventArgs.DeliveryTag,
                 redelivered: eventArgs.Redelivered,
@@ -205,7 +204,7 @@
                     await Task.Yield();
                 }
 
-                await Process(eventArgs, messageBody).ConfigureAwait(false);
+                await Process(eventArgsCopy, messageBody).ConfigureAwait(false);
             }
             catch (Exception ex)
             {

--- a/src/NServiceBus.Transport.RabbitMQ/Receiving/MessagePump.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Receiving/MessagePump.cs
@@ -159,6 +159,17 @@
 
             var messageBody = eventArgs.Body.ToArray();
 
+            // Is here until upgraded to 6.2 , required later for `RetrieveMessageId`.
+            eventArgs = new BasicDeliverEventArgs(
+                consumerTag: eventArgs.ConsumerTag,
+                deliveryTag: eventArgs.DeliveryTag,
+                redelivered: eventArgs.Redelivered,
+                exchange: eventArgs.Exchange,
+                routingKey: eventArgs.RoutingKey,
+                properties: eventArgs.BasicProperties,
+                body: messageBody
+            );
+
             try
             {
                 await semaphore.WaitAsync(messageProcessing.Token).ConfigureAwait(false);

--- a/src/NServiceBus.Transport.RabbitMQ/Receiving/MessagePump.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Receiving/MessagePump.cs
@@ -228,7 +228,7 @@
             catch (Exception ex)
             {
                 Logger.Error($"Failed to retrieve headers from poison message. Moving message to queue '{settings.ErrorQueue}'...", ex);
-                await MovePoisonMessage(message, messageBody, settings.ErrorQueue).ConfigureAwait(false);
+                await MovePoisonMessage(message, settings.ErrorQueue).ConfigureAwait(false);
 
                 return;
             }
@@ -242,7 +242,7 @@
             catch (Exception ex)
             {
                 Logger.Error($"Failed to retrieve ID from poison message. Moving message to queue '{settings.ErrorQueue}'...", ex);
-                await MovePoisonMessage(message, messageBody, settings.ErrorQueue).ConfigureAwait(false);
+                await MovePoisonMessage(message, settings.ErrorQueue).ConfigureAwait(false);
 
                 return;
             }
@@ -311,7 +311,7 @@
             }
         }
 
-        async Task MovePoisonMessage(BasicDeliverEventArgs message, byte[] messageBody, string queue)
+        async Task MovePoisonMessage(BasicDeliverEventArgs message, string queue)
         {
             try
             {
@@ -319,7 +319,7 @@
 
                 try
                 {
-                    await channel.RawSendInCaseOfFailure(queue, messageBody, message.BasicProperties).ConfigureAwait(false);
+                    await channel.RawSendInCaseOfFailure(queue, message.Body, message.BasicProperties).ConfigureAwait(false);
                 }
                 finally
                 {

--- a/src/NServiceBus.Transport.RabbitMQ/Receiving/MessagePump.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Receiving/MessagePump.cs
@@ -70,7 +70,7 @@
                 queuePurger.Purge(settings.InputQueue);
             }
 
-            return TaskEx.CompletedTask;
+            return Task.CompletedTask;
         }
 
         public void Start(PushRuntimeSettings limitations)

--- a/src/NServiceBus.Transport.RabbitMQ/Receiving/MessagePump.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Receiving/MessagePump.cs
@@ -248,7 +248,7 @@
                         var contextBag = new ContextBag();
                         contextBag.Set(message);
 
-                        var messageContext = new MessageContext(messageId, headers, message.Body ?? new byte[0], transportTransaction, tokenSource, contextBag);
+                        var messageContext = new MessageContext(messageId, headers, message.Body.ToArray(), transportTransaction, tokenSource, contextBag);
 
                         await onMessage(messageContext).ConfigureAwait(false);
                         processed = true;
@@ -260,7 +260,7 @@
                         var contextBag = new ContextBag();
                         contextBag.Set(message);
 
-                        var errorContext = new ErrorContext(exception, headers, messageId, message.Body ?? new byte[0], transportTransaction, numberOfDeliveryAttempts, contextBag);
+                        var errorContext = new ErrorContext(exception, headers, messageId, message.Body.ToArray(), transportTransaction, numberOfDeliveryAttempts, contextBag);
 
                         try
                         {

--- a/src/NServiceBus.Transport.RabbitMQ/Routing/ConventionalRoutingTopology.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Routing/ConventionalRoutingTopology.cs
@@ -67,7 +67,7 @@
             channel.BasicPublish(address, String.Empty, true, properties, message.Body);
         }
 
-        public void RawSendInCaseOfFailure(IModel channel, string address, ReadOnlyMemory<byte> body, IBasicProperties properties)
+        public void RawSendInCaseOfFailure(IModel channel, string address, byte[] body, IBasicProperties properties)
         {
             channel.BasicPublish(address, String.Empty, true, properties, body);
         }

--- a/src/NServiceBus.Transport.RabbitMQ/Routing/ConventionalRoutingTopology.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Routing/ConventionalRoutingTopology.cs
@@ -67,7 +67,7 @@
             channel.BasicPublish(address, String.Empty, true, properties, message.Body);
         }
 
-        public void RawSendInCaseOfFailure(IModel channel, string address, byte[] body, IBasicProperties properties)
+        public void RawSendInCaseOfFailure(IModel channel, string address, ReadOnlyMemory<byte> body, IBasicProperties properties)
         {
             channel.BasicPublish(address, String.Empty, true, properties, body);
         }

--- a/src/NServiceBus.Transport.RabbitMQ/Routing/DirectRoutingTopology.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Routing/DirectRoutingTopology.cs
@@ -37,7 +37,7 @@
             channel.BasicPublish(string.Empty, address, true, properties, message.Body);
         }
 
-        public void RawSendInCaseOfFailure(IModel channel, string address, byte[] body, IBasicProperties properties)
+        public void RawSendInCaseOfFailure(IModel channel, string address, ReadOnlyMemory<byte> body, IBasicProperties properties)
         {
             channel.BasicPublish(string.Empty, address, true, properties, body);
         }

--- a/src/NServiceBus.Transport.RabbitMQ/Routing/DirectRoutingTopology.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Routing/DirectRoutingTopology.cs
@@ -37,7 +37,7 @@
             channel.BasicPublish(string.Empty, address, true, properties, message.Body);
         }
 
-        public void RawSendInCaseOfFailure(IModel channel, string address, ReadOnlyMemory<byte> body, IBasicProperties properties)
+        public void RawSendInCaseOfFailure(IModel channel, string address, byte[] body, IBasicProperties properties)
         {
             channel.BasicPublish(string.Empty, address, true, properties, body);
         }

--- a/src/NServiceBus.Transport.RabbitMQ/Routing/IRoutingTopology.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Routing/IRoutingTopology.cs
@@ -50,7 +50,7 @@
         /// <param name="address">The address of the destination endpoint.</param>
         /// <param name="body">The raw message body to send.</param>
         /// <param name="properties">The RabbitMQ properties of the message to send.</param>
-        void RawSendInCaseOfFailure(IModel channel, string address, ReadOnlyMemory<byte> body, IBasicProperties properties);
+        void RawSendInCaseOfFailure(IModel channel, string address, byte[] body, IBasicProperties properties);
 
         /// <summary>
         /// Declares queues and performs any other initialization logic needed (e.g. creating exchanges and bindings).

--- a/src/NServiceBus.Transport.RabbitMQ/Routing/IRoutingTopology.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Routing/IRoutingTopology.cs
@@ -50,7 +50,7 @@
         /// <param name="address">The address of the destination endpoint.</param>
         /// <param name="body">The raw message body to send.</param>
         /// <param name="properties">The RabbitMQ properties of the message to send.</param>
-        void RawSendInCaseOfFailure(IModel channel, string address, byte[] body, IBasicProperties properties);
+        void RawSendInCaseOfFailure(IModel channel, string address, ReadOnlyMemory<byte> body, IBasicProperties properties);
 
         /// <summary>
         /// Declares queues and performs any other initialization logic needed (e.g. creating exchanges and bindings).

--- a/src/NServiceBus.Transport.RabbitMQ/TaskEx.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/TaskEx.cs
@@ -6,9 +6,6 @@ namespace NServiceBus.Transport.RabbitMQ
 
     static class TaskEx
     {
-        //TODO: remove when we update to 4.6 and can use Task.CompletedTask
-        public static readonly Task CompletedTask = Task.FromResult(0);
-
         public static void Ignore(this Task task) { }
 
         public static Task StartNew(object state, Action<object> action) => StartNew(state, action, TaskScheduler.Default);

--- a/src/NServiceBus.Transport.RabbitMQ/obsoletes.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/obsoletes.cs
@@ -3,26 +3,19 @@
 namespace NServiceBus
 {
     using System;
+    using System.Security.Cryptography.X509Certificates;
     using Transport.RabbitMQ;
 
-    public static partial class RabbitMQTransportSettingsExtensions
+    public partial class RabbitMQTransportSettingsExtensions
     {
-        [ObsoleteEx(RemoveInVersion = "6.0", TreatAsErrorFromVersion = "5.0", ReplacementTypeOrMember = "RabbitMQTransportSettingsExtensions.UseCustomRoutingTopology(TransportExtensions<RabbitMQTransport> transportExtensions, Func<bool, IRoutingTopology>)")]
-        public static TransportExtensions<RabbitMQTransport> UseRoutingTopology<T>(this TransportExtensions<RabbitMQTransport> transportExtensions) where T : IRoutingTopology, new()
+        [ObsoleteEx(RemoveInVersion = "7.0", TreatAsErrorFromVersion = "6.0", ReplacementTypeOrMember = "RabbitMQTransportSettingsExtensions.UseCustomRoutingTopology(TransportExtensions<RabbitMQTransport> transportExtensions, Func<bool, IRoutingTopology>)")]
+        public static TransportExtensions<RabbitMQTransport> UseRoutingTopology(this TransportExtensions<RabbitMQTransport> transportExtensions, Func<bool, IRoutingTopology> topologyFactory)
         {
             throw new NotImplementedException();
         }
-    }
-}
 
-namespace NServiceBus.Transport.RabbitMQ
-{
-    using System;
-
-    public partial class DelayedDeliverySettings
-    {
-        [ObsoleteEx(RemoveInVersion = "6.0", TreatAsErrorFromVersion = "5.0", Message = "The timeout manager is now disabled by default.")]
-        public DelayedDeliverySettings DisableTimeoutManager()
+        [ObsoleteEx(RemoveInVersion = "7.0", TreatAsErrorFromVersion = "6.0", ReplacementTypeOrMember = "RabbitMQTransportSettingsExtensions.SetClientCertificate(TransportExtensions<RabbitMQTransport> transportExtensions, X509Certificate2 clientCertificate)")]
+        public static TransportExtensions<RabbitMQTransport> SetClientCertificates(this TransportExtensions<RabbitMQTransport> transportExtensions, X509CertificateCollection clientCertificates)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
This converts the transport to using the new 6.x client in the minimally invasive way possible.

Adding the message body copy early in the `Consumer_Received` handler seems to have done the trick of getting the tests to pass, but it's possible more changes might be needed.

However, this change doesn't fully shield users from the side effects of the original message body memory being gone by the time we process a message. We have two features in the transport that by-design leak this out to the user;

#### Custom message id strategy

We expose the message body memory through a `Func<BasicDeliverEventArgs, string>` the can be provided to the transport, and that means the `Body` property could potentially be inspected inside it.

####  `ContextBag` access

We also put the `BasicDeliverEventArgs` into the message and error pipeline's `ContextBag` so that you could retrieve it from a handler to access values from it. I don't believe this is documented, but we added it a while back as an alternative to having to copy every property and expose them through some custom API.

---
Both of these have the unfortunate side effect of exposing the internals of the client, and that means potentially accessing the body memory that is no longer valid. Since we are working on a new major, we could alter/remove these APIs, but as soon as the 6.2.0 client is out with Daniel's change, both of these would become safe again since they'd once again be accessible while the body memory is available.

So, does this give us a reason to wait for the 6.2.0 client, or are we okay with there being this potential problem until the 6.2.0 client is released?
