### PR TITLE
Quorum compatibility for RabbitMQ transport v6

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/ConfigureEndpointRabbitMQTransport.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/ConfigureEndpointRabbitMQTransport.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Data.Common;
 using System.Linq;
 using System.Threading.Tasks;
 using NServiceBus;
@@ -7,12 +6,11 @@ using NServiceBus.AcceptanceTesting.Support;
 using NServiceBus.Configuration.AdvancedExtensibility;
 using NServiceBus.Transport;
 using NServiceBus.Transport.RabbitMQ.AcceptanceTests;
-using RabbitMQ.Client;
 
 class ConfigureEndpointRabbitMQTransport : IConfigureEndpointTestExecution
 {
-    DbConnectionStringBuilder connectionStringBuilder;
     QueueBindings queueBindings;
+    TransportExtensions<RabbitMQTransport> transport;
 
     public Task Configure(string endpointName, EndpointConfiguration configuration, RunSettings settings, PublisherMetadata publisherMetadata)
     {
@@ -23,10 +21,8 @@ class ConfigureEndpointRabbitMQTransport : IConfigureEndpointTestExecution
             throw new Exception("The 'RabbitMQTransport_ConnectionString' environment variable is not set.");
         }
 
-        connectionStringBuilder = new DbConnectionStringBuilder { ConnectionString = connectionString };
-
-        var transport = configuration.UseTransport<RabbitMQTransport>();
-        transport.ConnectionString(connectionStringBuilder.ConnectionString);
+        transport = configuration.UseTransport<RabbitMQTransport>();
+        transport.ConnectionString(ConnectionHelper.ConnectionString);
         transport.UseConventionalRoutingTopology();
 
         queueBindings = configuration.GetSettings().Get<QueueBindings>();
@@ -43,44 +39,14 @@ class ConfigureEndpointRabbitMQTransport : IConfigureEndpointTestExecution
 
     void PurgeQueues()
     {
-        if (connectionStringBuilder == null)
+        if (transport == null)
         {
             return;
         }
 
-        var connectionFactory = new ConnectionFactory
-        {
-            AutomaticRecoveryEnabled = true,
-            UseBackgroundThreadsForIO = true
-        };
-
-        if (connectionStringBuilder.TryGetValue("username", out var value))
-        {
-            connectionFactory.UserName = value.ToString();
-        }
-
-        if (connectionStringBuilder.TryGetValue("password", out value))
-        {
-            connectionFactory.Password = value.ToString();
-        }
-
-        if (connectionStringBuilder.TryGetValue("virtualhost", out value))
-        {
-            connectionFactory.VirtualHost = value.ToString();
-        }
-
-        if (connectionStringBuilder.TryGetValue("host", out value))
-        {
-            connectionFactory.HostName = value.ToString();
-        }
-        else
-        {
-            throw new Exception("The connection string doesn't contain a value for 'host'.");
-        }
-
         var queues = queueBindings.ReceivingAddresses.Concat(queueBindings.SendingAddresses);
 
-        using (var connection = connectionFactory.CreateConnection("Test Queue Purger"))
+        using (var connection = ConnectionHelper.ConnectionFactory.CreateConnection("Test Queue Purger"))
         using (var channel = connection.CreateModel())
         {
             foreach (var queue in queues)

--- a/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/ConnectionHelper.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/ConnectionHelper.cs
@@ -1,0 +1,62 @@
+﻿namespace NServiceBus.Transport.RabbitMQ.AcceptanceTests
+{
+    using System;
+    using System.Data.Common;
+    using global::RabbitMQ.Client;
+
+    public class ConnectionHelper
+    {
+        static Lazy<string> connectionString = new Lazy<string>(() =>
+        {
+            var connectionString = Environment.GetEnvironmentVariable("RabbitMQTransport_ConnectionString");
+
+            if (string.IsNullOrEmpty(connectionString))
+            {
+                throw new Exception("The 'RabbitMQTransport_ConnectionString' environment variable is not set.");
+            }
+
+            return connectionString;
+        });
+
+        static Lazy<ConnectionFactory> connectionFactory = new Lazy<ConnectionFactory>(() =>
+        {
+            var connectionStringBuilder = new DbConnectionStringBuilder { ConnectionString = ConnectionString };
+
+            var connectionFactory = new ConnectionFactory
+            {
+                AutomaticRecoveryEnabled = true,
+                UseBackgroundThreadsForIO = true
+            };
+
+            if (connectionStringBuilder.TryGetValue("username", out var value))
+            {
+                connectionFactory.UserName = value.ToString();
+            }
+
+            if (connectionStringBuilder.TryGetValue("password", out value))
+            {
+                connectionFactory.Password = value.ToString();
+            }
+
+            if (connectionStringBuilder.TryGetValue("virtualhost", out value))
+            {
+                connectionFactory.VirtualHost = value.ToString();
+            }
+
+            if (connectionStringBuilder.TryGetValue("host", out value))
+            {
+                connectionFactory.HostName = value.ToString();
+            }
+            else
+            {
+                throw new Exception("The connection string doesn't contain a value for 'host'.");
+            }
+
+            return connectionFactory;
+        });
+
+        public static string ConnectionString => connectionString.Value;
+
+        public static ConnectionFactory ConnectionFactory => connectionFactory.Value;
+    }
+}

--- a/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/QuorumQueues/ChannelExtensions.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/QuorumQueues/ChannelExtensions.cs
@@ -1,0 +1,21 @@
+﻿namespace NServiceBus.Transport.RabbitMQ.AcceptanceTests
+{
+    using System.Collections.Generic;
+    using global::RabbitMQ.Client;
+
+    static class ChannelExtensions
+    {
+        public static void DeclareQuorumQueue(this IModel channel, string queueName)
+        {
+            channel.QueueDeclare(queueName, true, false, false, new Dictionary<string, object>
+            {
+                { "x-queue-type", "quorum" }
+            });
+        }
+
+        public static void DeclareClassicQueue(this IModel channel, string queueName)
+        {
+            channel.QueueDeclare(queueName, true, false, false);
+        }
+    }
+}

--- a/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/QuorumQueues/When_endpoint_sends_to_quorum_queue_receiver.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/QuorumQueues/When_endpoint_sends_to_quorum_queue_receiver.cs
@@ -1,0 +1,50 @@
+﻿namespace NServiceBus.Transport.RabbitMQ.AcceptanceTests
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using global::RabbitMQ.Client;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_endpoint_sends_to_quorum_queue_receiver : NServiceBusAcceptanceTest
+    {
+        const string DestinationQueueName = "rabbitmq.transport.tests.quorum-destination";
+
+        [Test]
+        public async Task Should_not_fail_to_send()
+        {
+            using (var connection = ConnectionHelper.ConnectionFactory.CreateConnection())
+            using (var channel = connection.CreateModel())
+            {
+                channel.DeclareQuorumQueue(DestinationQueueName);
+                channel.ExchangeDeclare(DestinationQueueName, ExchangeType.Fanout, true);
+                channel.QueueBind(DestinationQueueName, DestinationQueueName, string.Empty);
+            }
+
+            var context = await Scenario.Define<ScenarioContext>()
+                .WithEndpoint<ClassicQueueEndpoint>(e => e.When(async s =>
+                {
+                    var options = new SendOptions();
+                    options.SetDestination(DestinationQueueName);
+                    await s.Send(new MessageToQuorumReceiver(), options);
+                }))
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.IsTrue(context.EndpointsStarted);
+        }
+
+        class ClassicQueueEndpoint : EndpointConfigurationBuilder
+        {
+            public ClassicQueueEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        class MessageToQuorumReceiver : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/QuorumQueues/When_endpoint_uses_quorum_audit_queue.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/QuorumQueues/When_endpoint_uses_quorum_audit_queue.cs
@@ -1,0 +1,45 @@
+﻿namespace NServiceBus.Transport.RabbitMQ.AcceptanceTests
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_endpoint_uses_quorum_audit_queue : NServiceBusAcceptanceTest
+    {
+        const string AuditQueueName = "rabbitmq.transport.tests.quorum-audit";
+
+        [Test]
+        public async Task Should_start_without_error()
+        {
+            using (var connection = ConnectionHelper.ConnectionFactory.CreateConnection())
+            using (var channel = connection.CreateModel())
+            {
+                channel.DeclareQuorumQueue(AuditQueueName);
+            }
+
+            var context = await Scenario.Define<ScenarioContext>()
+                .WithEndpoint<ClassicQueueEndpoint>()
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.IsTrue(context.EndpointsStarted);
+            // Verify error queue is indeed a quorum queue:
+            using (var connection = ConnectionHelper.ConnectionFactory.CreateConnection())
+            using (var channel = connection.CreateModel())
+            {
+                channel.DeclareQuorumQueue(AuditQueueName);
+            }
+        }
+
+        class ClassicQueueEndpoint : EndpointConfigurationBuilder
+        {
+            public ClassicQueueEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c => c
+                    .AuditProcessedMessagesTo(AuditQueueName));
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/QuorumQueues/When_endpoint_uses_quorum_error_queue.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/QuorumQueues/When_endpoint_uses_quorum_error_queue.cs
@@ -1,0 +1,45 @@
+﻿namespace NServiceBus.Transport.RabbitMQ.AcceptanceTests
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_endpoint_uses_quorum_error_queue : NServiceBusAcceptanceTest
+    {
+        const string ErrorQueueName = "rabbitmq.transport.tests.quorum-error";
+
+        [Test]
+        public async Task Should_start_without_error()
+        {
+            using (var connection = ConnectionHelper.ConnectionFactory.CreateConnection())
+            using (var channel = connection.CreateModel())
+            {
+                channel.DeclareQuorumQueue(ErrorQueueName);
+            }
+
+            var context = await Scenario.Define<ScenarioContext>()
+                .WithEndpoint<ClassicQueueEndpoint>()
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.IsTrue(context.EndpointsStarted);
+            // Verify error queue is indeed a quorum queue:
+            using (var connection = ConnectionHelper.ConnectionFactory.CreateConnection())
+            using (var channel = connection.CreateModel())
+            {
+                channel.DeclareQuorumQueue(ErrorQueueName);
+            }
+        }
+
+        class ClassicQueueEndpoint : EndpointConfigurationBuilder
+        {
+            public ClassicQueueEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c => c
+                    .SendFailedMessagesTo(ErrorQueueName));
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/QuorumQueues/When_input_queue_is_quorum_queue.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/QuorumQueues/When_input_queue_is_quorum_queue.cs
@@ -1,0 +1,40 @@
+﻿namespace NServiceBus.Transport.RabbitMQ.AcceptanceTests
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_input_queue_is_quorum_queue : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_not_fail()
+        {
+            var queueName = Conventions.EndpointNamingConvention(typeof(ClassicQueueEndpoint));
+
+            using (var connection = ConnectionHelper.ConnectionFactory.CreateConnection())
+            using (var channel = connection.CreateModel())
+            {
+                channel.DeclareQuorumQueue(queueName);
+            }
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<ClassicQueueEndpoint>()
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.IsTrue(context.EndpointsStarted);
+        }
+
+        class Context : ScenarioContext
+        {
+        }
+
+        class ClassicQueueEndpoint : EndpointConfigurationBuilder
+        {
+            public ClassicQueueEndpoint() => EndpointSetup<DefaultServer>();
+        }
+    }
+}

--- a/src/NServiceBus.Transport.RabbitMQ.Tests/Support/ConventionalRoutingTopologyExtensions.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/Support/ConventionalRoutingTopologyExtensions.cs
@@ -23,7 +23,15 @@
                 DelayInfrastructure.TearDown(channel);
                 DelayInfrastructure.Build(channel);
 
-                routingTopology.Initialize(channel, receivingAddresses, sendingAddresses);
+                try
+                {
+                    QueueCreator.RoutingTopoligyInitializeConnection.Value = connection;
+                    routingTopology.Initialize(channel, receivingAddresses, sendingAddresses);
+                }
+                finally
+                {
+                    QueueCreator.RoutingTopoligyInitializeConnection.Value = null;
+                }
             }
         }
     }

--- a/src/NServiceBus.Transport.RabbitMQ/Routing/ConventionalRoutingTopology.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Routing/ConventionalRoutingTopology.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
+    using System.Linq;
     using global::RabbitMQ.Client;
 
     /// <summary>
@@ -73,22 +74,15 @@
 
         public void Initialize(IModel channel, IEnumerable<string> receivingAddresses, IEnumerable<string> sendingAddresses)
         {
-            foreach (var address in receivingAddresses)
+            foreach (var address in receivingAddresses.Concat(sendingAddresses))
             {
-                channel.QueueDeclare(address, useDurableExchanges, false, false, null);
-                CreateExchange(channel, address);
-                channel.QueueBind(address, address, string.Empty);
-            }
-
-            foreach (var sendingAddress in sendingAddresses)
-            {
-                if (!QueueHelper.QueueExists(QueueCreator.RoutingTopoligyInitializeConnection.Value, sendingAddress))
+                if (!QueueHelper.QueueExists(QueueCreator.RoutingTopoligyInitializeConnection.Value, address))
                 {
-                    channel.QueueDeclare(sendingAddress, useDurableExchanges, false, false, null);
+                    channel.QueueDeclare(address, useDurableExchanges, false, false, null);
                 }
 
-                CreateExchange(channel, sendingAddress);
-                channel.QueueBind(sendingAddress, sendingAddress, string.Empty);
+                CreateExchange(channel, address);
+                channel.QueueBind(address, address, string.Empty);
             }
         }
 

--- a/src/NServiceBus.Transport.RabbitMQ/Routing/DirectRoutingTopology.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Routing/DirectRoutingTopology.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using global::RabbitMQ.Client;
 
     /// <summary>
@@ -44,9 +43,17 @@
 
         public void Initialize(IModel channel, IEnumerable<string> receivingAddresses, IEnumerable<string> sendingAddresses)
         {
-            foreach (var address in receivingAddresses.Concat(sendingAddresses))
+            foreach (var address in receivingAddresses)
             {
                 channel.QueueDeclare(address, useDurableExchanges, false, false, null);
+            }
+
+            foreach (var address in sendingAddresses)
+            {
+                if (!QueueHelper.QueueExists(QueueCreator.RoutingTopoligyInitializeConnection.Value, address))
+                {
+                    channel.QueueDeclare(address, useDurableExchanges, false, false, null);
+                }
             }
         }
 

--- a/src/NServiceBus.Transport.RabbitMQ/Routing/DirectRoutingTopology.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Routing/DirectRoutingTopology.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using global::RabbitMQ.Client;
 
     /// <summary>
@@ -43,12 +44,7 @@
 
         public void Initialize(IModel channel, IEnumerable<string> receivingAddresses, IEnumerable<string> sendingAddresses)
         {
-            foreach (var address in receivingAddresses)
-            {
-                channel.QueueDeclare(address, useDurableExchanges, false, false, null);
-            }
-
-            foreach (var address in sendingAddresses)
+            foreach (var address in receivingAddresses.Concat(sendingAddresses))
             {
                 if (!QueueHelper.QueueExists(QueueCreator.RoutingTopoligyInitializeConnection.Value, address))
                 {

--- a/src/NServiceBus.Transport.RabbitMQ/Routing/QueueHelper.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Routing/QueueHelper.cs
@@ -1,0 +1,27 @@
+﻿namespace NServiceBus.Transport.RabbitMQ
+{
+    using global::RabbitMQ.Client;
+    using global::RabbitMQ.Client.Exceptions;
+
+    static class QueueHelper
+    {
+        public static bool QueueExists(IConnection connection, string queueAddress)
+        {
+            try
+            {
+                // create temporary channel as the channel will be faulted if the queue does not exist.
+                using (var tempChannel = connection.CreateModel())
+                {
+                    // check queue existence via DeclarePassive to allow the destination queue to be either a quorum or a classic queue without failing the operation.
+                    tempChannel.QueueDeclarePassive(queueAddress);
+                    return true;
+                }
+            }
+            catch (OperationInterruptedException e) when (e.ShutdownReason.ReplyCode == 404)
+            {
+                // queue does not exist
+                return false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Connects to #556 to bring compatibility for RabbitMQ transport v6:
* Allow endpoints to "connect" (aka not fail installation) to quorum audit/error queues
* Allows endpoints to consume from quorum input (aka not fail installation) queues.
  * This use case is primarily designed for ServiceControl

V6 endpoints are not able to define the quorum queue mode themselves and therefore cannot create quorum queues but they can interact with existing quorum queues both as incoming as well as outgoing queues.