### PR TITLE
Fix typo in QueueCreator

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ.Tests/Support/ConventionalRoutingTopologyExtensions.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/Support/ConventionalRoutingTopologyExtensions.cs
@@ -25,12 +25,12 @@
 
                 try
                 {
-                    QueueCreator.RoutingTopoligyInitializeConnection.Value = connection;
+                    QueueCreator.RoutingTopologyInitializeConnection.Value = connection;
                     routingTopology.Initialize(channel, receivingAddresses, sendingAddresses);
                 }
                 finally
                 {
-                    QueueCreator.RoutingTopoligyInitializeConnection.Value = null;
+                    QueueCreator.RoutingTopologyInitializeConnection.Value = null;
                 }
             }
         }

--- a/src/NServiceBus.Transport.RabbitMQ/Administration/QueueCreator.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Administration/QueueCreator.cs
@@ -9,7 +9,7 @@
         readonly ConnectionFactory connectionFactory;
         readonly IRoutingTopology routingTopology;
 
-        public static ThreadLocal<IConnection> RoutingTopoligyInitializeConnection = new ThreadLocal<IConnection>();
+        public static ThreadLocal<IConnection> RoutingTopologyInitializeConnection = new ThreadLocal<IConnection>();
 
         public QueueCreator(ConnectionFactory connectionFactory, IRoutingTopology routingTopology)
         {
@@ -27,12 +27,12 @@
                 try
                 {
                     // workaround to make the connection available to the routing topology
-                    RoutingTopoligyInitializeConnection.Value = connection;
+                    RoutingTopologyInitializeConnection.Value = connection;
                     routingTopology.Initialize(channel, queueBindings.ReceivingAddresses, queueBindings.SendingAddresses);
                 }
                 finally
                 {
-                    RoutingTopoligyInitializeConnection.Value = null;
+                    RoutingTopologyInitializeConnection.Value = null;
                 }
 
                 foreach (var receivingAddress in queueBindings.ReceivingAddresses)

--- a/src/NServiceBus.Transport.RabbitMQ/Routing/ConventionalRoutingTopology.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Routing/ConventionalRoutingTopology.cs
@@ -76,7 +76,7 @@
         {
             foreach (var address in receivingAddresses.Concat(sendingAddresses))
             {
-                if (!QueueHelper.QueueExists(QueueCreator.RoutingTopoligyInitializeConnection.Value, address))
+                if (!QueueHelper.QueueExists(QueueCreator.RoutingTopologyInitializeConnection.Value, address))
                 {
                     channel.QueueDeclare(address, useDurableExchanges, false, false, null);
                 }

--- a/src/NServiceBus.Transport.RabbitMQ/Routing/DirectRoutingTopology.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Routing/DirectRoutingTopology.cs
@@ -46,7 +46,7 @@
         {
             foreach (var address in receivingAddresses.Concat(sendingAddresses))
             {
-                if (!QueueHelper.QueueExists(QueueCreator.RoutingTopoligyInitializeConnection.Value, address))
+                if (!QueueHelper.QueueExists(QueueCreator.RoutingTopologyInitializeConnection.Value, address))
                 {
                     channel.QueueDeclare(address, useDurableExchanges, false, false, null);
                 }


### PR DESCRIPTION
Where are all the linters when you could actually use them 🤷 