### PR TITLE
Custom exchange name for generic messages

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ.Tests/NServiceBus.Transport.RabbitMQ.Tests.csproj
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/NServiceBus.Transport.RabbitMQ.Tests.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+	  <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="NServiceBus" Version="8.0.0-alpha.1895" />
     <PackageReference Include="NUnit" Version="3.13.2" />

--- a/src/NServiceBus.Transport.RabbitMQ.Tests/Routing/ConventionalRoutingTopologyTests.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/Routing/ConventionalRoutingTopologyTests.cs
@@ -1,0 +1,87 @@
+﻿namespace NServiceBus.Transport.RabbitMQ.Tests.Routing
+{
+    using System.Collections.Generic;
+    using global::RabbitMQ.Client;
+    using Moq;
+    using NUnit.Framework;
+    using Unicast.Messages;
+
+    [TestFixture]
+    class ConventionalRoutingTopologyTests
+    {
+        class TestMessage
+        {
+        }
+
+        class GenericMessage<TTarget, TSource>
+        {
+        }
+
+        ConventionalRoutingTopology topology;
+        Mock<IModel> model;
+
+        [SetUp]
+        public void SetUp()
+        {
+            topology = new ConventionalRoutingTopology(useDurableEntities: true);
+
+            model = new Mock<IModel>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            model.Verify();
+            model.VerifyNoOtherCalls();
+        }
+
+        [Test]
+        public void SetupTypeSubscriptions_When_GenericType()
+        {
+            const string expectedExchangeName = "System.Collections.Generic:List--NServiceBus.Transport.RabbitMQ.Tests.Routing:TestMessage--";
+
+            // exchange
+            model.Setup(x => x.ExchangeDeclare(expectedExchangeName, ExchangeType.Fanout, true, false, null)).Verifiable();
+            model.Setup(x => x.ExchangeDeclare("System:Object", ExchangeType.Fanout, true, false, null)).Verifiable();
+            // exchange for interface
+            model.Setup(x => x.ExchangeDeclare("System.Collections.Generic:IList--NServiceBus.Transport.RabbitMQ.Tests.Routing:TestMessage--", ExchangeType.Fanout, true, false, null)).Verifiable();
+            model.Setup(x => x.ExchangeDeclare("System.Collections.Generic:IReadOnlyList--NServiceBus.Transport.RabbitMQ.Tests.Routing:TestMessage--", ExchangeType.Fanout, true, false, null)).Verifiable();
+            model.Setup(x => x.ExchangeDeclare("System.Collections:IList", ExchangeType.Fanout, true, false, null)).Verifiable();
+            model.Setup(x => x.ExchangeDeclare("System.Collections.Generic:ICollection--NServiceBus.Transport.RabbitMQ.Tests.Routing:TestMessage--", ExchangeType.Fanout, true, false, null)).Verifiable();
+            model.Setup(x => x.ExchangeDeclare("System.Collections.Generic:IEnumerable--NServiceBus.Transport.RabbitMQ.Tests.Routing:TestMessage--", ExchangeType.Fanout, true, false, null)).Verifiable();
+            model.Setup(x => x.ExchangeDeclare("System.Collections:IEnumerable", ExchangeType.Fanout, true, false, null)).Verifiable();
+            model.Setup(x => x.ExchangeDeclare("System.Collections:ICollection", ExchangeType.Fanout, true, false, null)).Verifiable();
+            model.Setup(x => x.ExchangeDeclare("System.Collections.Generic:IReadOnlyCollection--NServiceBus.Transport.RabbitMQ.Tests.Routing:TestMessage--", ExchangeType.Fanout, true, false, null)).Verifiable();
+
+            // binding
+            model.Setup(x => x.ExchangeBind("System:Object", expectedExchangeName, string.Empty, null)).Verifiable();
+            model.Setup(x => x.ExchangeBind("System.Collections.Generic:IList--NServiceBus.Transport.RabbitMQ.Tests.Routing:TestMessage--", expectedExchangeName, string.Empty, null)).Verifiable();
+            model.Setup(x => x.ExchangeBind("System.Collections.Generic:IReadOnlyList--NServiceBus.Transport.RabbitMQ.Tests.Routing:TestMessage--", expectedExchangeName, string.Empty, null)).Verifiable();
+            model.Setup(x => x.ExchangeBind("System.Collections:IList", expectedExchangeName, string.Empty, null)).Verifiable();
+            model.Setup(x => x.ExchangeBind("System.Collections.Generic:ICollection--NServiceBus.Transport.RabbitMQ.Tests.Routing:TestMessage--", expectedExchangeName, string.Empty, null)).Verifiable();
+            model.Setup(x => x.ExchangeBind("System.Collections.Generic:IEnumerable--NServiceBus.Transport.RabbitMQ.Tests.Routing:TestMessage--", expectedExchangeName, string.Empty, null)).Verifiable();
+            model.Setup(x => x.ExchangeBind("System.Collections:IEnumerable", expectedExchangeName, string.Empty, null)).Verifiable();
+            model.Setup(x => x.ExchangeBind("System.Collections:ICollection", expectedExchangeName, string.Empty, null)).Verifiable();
+            model.Setup(x => x.ExchangeBind("System.Collections.Generic:IReadOnlyCollection--NServiceBus.Transport.RabbitMQ.Tests.Routing:TestMessage--", expectedExchangeName, string.Empty, null)).Verifiable();
+            model.Setup(x => x.ExchangeBind("test", expectedExchangeName, string.Empty, null)).Verifiable();
+
+            topology.SetupSubscription(model.Object, new MessageMetadata(typeof(List<TestMessage>)), "test");
+        }
+
+        [Test]
+        public void SetupTypeSubscriptions_When_GenericTypeWithTwoArgs()
+        {
+            const string expectedExchangeName = "NServiceBus.Transport.RabbitMQ.Tests.Routing:GenericMessage--NServiceBus.Transport.RabbitMQ.Tests.Routing:TestMessage::NServiceBus.Transport.RabbitMQ.Tests.Routing:TestMessage--";
+
+            // exchange
+            model.Setup(x => x.ExchangeDeclare(expectedExchangeName, ExchangeType.Fanout, true, false, null)).Verifiable();
+            model.Setup(x => x.ExchangeDeclare("System:Object", ExchangeType.Fanout, true, false, null)).Verifiable();
+
+            // binding
+            model.Setup(x => x.ExchangeBind("System:Object", expectedExchangeName, string.Empty, null)).Verifiable();
+            model.Setup(x => x.ExchangeBind("test", expectedExchangeName, string.Empty, null)).Verifiable();
+
+            topology.SetupSubscription(model.Object, new MessageMetadata(typeof(GenericMessage<TestMessage, TestMessage>)), "test");
+        }
+    }
+}

--- a/src/NServiceBus.Transport.RabbitMQ/Routing/ConventionalRoutingTopology.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Routing/ConventionalRoutingTopology.cs
@@ -49,7 +49,7 @@ namespace NServiceBus.Transport.RabbitMQ
             }
 
             int index = type.Name.IndexOf('`');
-            string typeName = index == -1 ? type.Name : type.Name.Substring(0, index);
+            string typeName = index == -1 ? type.Name : type.Name.Remove(index);
             return $"{type.Namespace}:{typeName}--{string.Join("::", type.GetGenericArguments().Select(DefaultExchangeNameConvention))}--";
         }
 


### PR DESCRIPTION
Currently exchange name for generic message type does not contains generic params specific. 
This leads to a problem when endpoint handler needs to handle only `Message<Type 1>` type, it actually receive all `Message<>` messages.

After fix exchange name for generic messages will look like
`NameSpace:TypeName--GenericType1Namespace:GenericType1Name::GenericType2Namespace:GenericType2Name--`