### PR TITLE
Fix CI Azure Docker cleanup by switching to powershell action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
         uses: azure/login@v1.3.0
         with:
           creds: ${{ secrets.AZURE_ACI_CREDENTIALS }}
+          enable-AzPSSession: true
       - name: Setup RabbitMQ
         id: setup-rabbitmq
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,7 @@ jobs:
           reset-script: dotnet run --project src/targets
       - name: Teardown RabbitMQ
         if: ${{ always() }}
-        shell: pwsh
-        run: |
-          $ignore = az container delete --resource-group GitHubActions-RG --name ${{ steps.setup-rabbitmq.outputs.hostname }} --yes
+        uses: Azure/powershell@v1
+        with:
+          inlineScript: Remove-AzContainerGroup -ResourceGroupName GitHubActions-RG -Name ${{ steps.setup-rabbitmq.outputs.hostname }}
+          azPSVersion: latest


### PR DESCRIPTION
Version 2.28.0 of the Azure CLI introduces [a bug](https://github.com/Azure/azure-cli/issues/19489) that prevents deletion of containers.

This PR switches to the powershell module to perform the cleanup