### PR TITLE
Better guidance for routing topology in exception message.

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ/obsoletes-v8.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/obsoletes-v8.cs
@@ -57,7 +57,7 @@ namespace NServiceBus
 
             if (RoutingTopology == null)
             {
-                throw new Exception("A routing topology must be configured with one of the 'EndpointConfiguration.UseTransport<RabbitMQTransport>().UseXXXXRoutingTopology()` methods.");
+                throw new Exception("A routing topology must be configured with one of the 'EndpointConfiguration.UseTransport<RabbitMQTransport>().UseXXXXRoutingTopology()` methods. Most new projects should use the Conventional routing topology.");
             }
 
             if (string.IsNullOrEmpty(LegacyApiConnectionString))


### PR DESCRIPTION
A result of [my webinar](https://particular.net/webinars/live-coding-nservicebus-in-the-real-world) when switching from LearningTransport to RabbitMQ.