### PR TITLE
Command cleanup

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine/Commands/Delays/DelaysVerifyCommand.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine/Commands/Delays/DelaysVerifyCommand.cs
@@ -23,7 +23,7 @@
                 IsRequired = true
             };
 
-            var passwordOption = new Option<string>("--password", "The password for acessing the RabbitMQ management API")
+            var passwordOption = new Option<string>("--password", "The password for accessing the RabbitMQ management API")
             {
                 IsRequired = true
             };

--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine/SharedOptions.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine/SharedOptions.cs
@@ -31,7 +31,7 @@
         {
             var routingTopologyTypeOption = new Option<RoutingTopologyType>(
                 name: "--routingTopology",
-                description: $"The routing toplogy to use",
+                description: $"The routing topology to use",
                 getDefaultValue: () => RoutingTopologyType.Conventional);
 
             routingTopologyTypeOption.AddAlias("-r");

--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine/SharedOptions.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine/SharedOptions.cs
@@ -58,7 +58,7 @@
                 description: $"The type of queue to create",
                 getDefaultValue: () => QueueType.Quorum);
 
-            queueTypeOption.AddAlias("-t");
+            queueTypeOption.AddAlias("-q");
 
             return queueTypeOption;
         }


### PR DESCRIPTION
While working on documentation, I found some typos and decided to remove the quiet mode option since there was a single command that implemented it. This let me use `-q` for `--queueType` instead.