### PR TITLE
Add requirements check to installers and commands

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine.Tests/MigrateQueue/QueueMigrateToQuorumTests.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine.Tests/MigrateQueue/QueueMigrateToQuorumTests.cs
@@ -249,8 +249,11 @@
         {
             var connectionString = Environment.GetEnvironmentVariable("RabbitMQTransport_ConnectionString") ?? "host=localhost";
 
-            connectionFactory = new RabbitMQ.ConnectionFactory("unit-tests", ConnectionConfiguration.Create(connectionString), null, true, false, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30), null);
-            connection = connectionFactory.CreateAdministrationConnection();
+            var connectionFactory = new RabbitMQ.ConnectionFactory("unit-tests", ConnectionConfiguration.Create(connectionString), null, true, false, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30), null);
+
+            brokerConnection = new BrokerConnection(connectionFactory);
+
+            connection = brokerConnection.Create();
         }
 
         [TearDown]
@@ -262,7 +265,7 @@
 
         Task ExecuteMigration(string endpointName)
         {
-            var migrationCommand = new QueueMigrateCommand(endpointName, connectionFactory, new TestConsole());
+            var migrationCommand = new QueueMigrateCommand(endpointName, brokerConnection, new TestConsole());
 
             return migrationCommand.Run();
         }
@@ -398,7 +401,7 @@
             return $"{endpointName}-migration-temp";
         }
 
-        RabbitMQ.ConnectionFactory connectionFactory;
+        BrokerConnection brokerConnection;
         IConnection connection;
     }
 }

--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine/BrokerConnection.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine/BrokerConnection.cs
@@ -1,0 +1,23 @@
+﻿namespace NServiceBus.Transport.RabbitMQ.CommandLine
+{
+    using global::RabbitMQ.Client;
+    using NServiceBus.Transport.RabbitMQ;
+
+    class BrokerConnection
+    {
+        public BrokerConnection(RabbitMQ.ConnectionFactory connectionFactory)
+        {
+            this.connectionFactory = connectionFactory;
+        }
+
+        public IConnection Create()
+        {
+            var connection = connectionFactory.CreateAdministrationConnection();
+            connection.VerifyBrokerRequirements();
+
+            return connection;
+        }
+
+        RabbitMQ.ConnectionFactory connectionFactory;
+    }
+}

--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine/BrokerConnectionBinder.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine/BrokerConnectionBinder.cs
@@ -4,9 +4,9 @@
     using System.CommandLine.Binding;
     using System.Security.Cryptography.X509Certificates;
 
-    class ConnectionFactoryBinder : BinderBase<ConnectionFactory>
+    class BrokerConnectionBinder : BinderBase<BrokerConnection>
     {
-        public ConnectionFactoryBinder(Option<string> connectionStringOption, Option<string> connectionStringEnvOption, Option<string> certPathOption, Option<string> certPassphraseOption, Option<bool> disableCertificateValidationOption, Option<bool> useExternalAuthOption)
+        public BrokerConnectionBinder(Option<string> connectionStringOption, Option<string> connectionStringEnvOption, Option<string> certPathOption, Option<string> certPassphraseOption, Option<bool> disableCertificateValidationOption, Option<bool> useExternalAuthOption)
         {
             this.connectionStringOption = connectionStringOption;
             this.connectionStringEnvOption = connectionStringEnvOption;
@@ -16,7 +16,7 @@
             this.useExternalAuthOption = useExternalAuthOption;
         }
 
-        protected override ConnectionFactory GetBoundValue(BindingContext bindingContext)
+        protected override BrokerConnection GetBoundValue(BindingContext bindingContext)
         {
             var connectionStringOptionValue = bindingContext.ParseResult.GetValueForOption(connectionStringOption);
             var connectionStringEnvOptionValue = bindingContext.ParseResult.GetValueForOption(connectionStringEnvOption);
@@ -37,8 +37,9 @@
             }
 
             var connectionFactory = new ConnectionFactory("rabbitmq-transport", connectionConfiguration, certificateCollection, disableCertificateValidation, useExternalAuth, TimeSpan.FromSeconds(60), TimeSpan.FromSeconds(10), new List<(string, int)>());
+            var brokerConnection = new BrokerConnection(connectionFactory);
 
-            return connectionFactory;
+            return brokerConnection;
         }
 
         string GetConnectionString(string? connectionString, string? connectionStringEnv)

--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine/Commands/Delays/DelaysCreateCommand.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine/Commands/Delays/DelaysCreateCommand.cs
@@ -8,21 +8,21 @@
         {
             var command = new Command("create", "Create v2 delay infrastructure queues and exchanges");
 
-            var connectionFactoryBinder = SharedOptions.CreateConnectionFactoryBinderWithOptions(command);
+            var brokerConnectionBinder = SharedOptions.CreateBrokerConnectionBinderWithOptions(command);
 
-            command.SetHandler(async (connectionFactory, console, cancellationToken) =>
+            command.SetHandler(async (brokerConnection, console, cancellationToken) =>
             {
-                var delaysCreate = new DelaysCreateCommand(connectionFactory, console);
+                var delaysCreate = new DelaysCreateCommand(brokerConnection, console);
                 await delaysCreate.Run(cancellationToken).ConfigureAwait(false);
             },
-            connectionFactoryBinder, Bind.FromServiceProvider<IConsole>(), Bind.FromServiceProvider<CancellationToken>());
+            brokerConnectionBinder, Bind.FromServiceProvider<IConsole>(), Bind.FromServiceProvider<CancellationToken>());
 
             return command;
         }
 
-        public DelaysCreateCommand(ConnectionFactory connectionFactory, IConsole console)
+        public DelaysCreateCommand(BrokerConnection brokerConnection, IConsole console)
         {
-            this.connectionFactory = connectionFactory;
+            this.brokerConnection = brokerConnection;
             this.console = console;
         }
 
@@ -30,7 +30,7 @@
         {
             console.WriteLine($"Creating v2 delay infrastructure queues and exchanges...");
 
-            using var connection = connectionFactory.CreateAdministrationConnection();
+            using var connection = brokerConnection.Create();
             using var channel = connection.CreateModel();
 
             DelayInfrastructure.Build(channel);
@@ -40,7 +40,7 @@
             return Task.CompletedTask;
         }
 
-        readonly ConnectionFactory connectionFactory;
+        readonly BrokerConnection brokerConnection;
         readonly IConsole console;
     }
 }

--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine/Commands/Endpoint/EndpointCreateCommand.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine/Commands/Endpoint/EndpointCreateCommand.cs
@@ -5,7 +5,7 @@
 
     class EndpointCreateCommand
     {
-        readonly ConnectionFactory connectionFactory;
+        readonly BrokerConnection brokerConnection;
         readonly IRoutingTopology routingTopology;
         readonly IConsole console;
 
@@ -33,7 +33,7 @@
                 AllowMultipleArgumentsPerToken = true
             };
 
-            var connectionFactoryBinder = SharedOptions.CreateConnectionFactoryBinderWithOptions(command);
+            var brokerConnectionBinder = SharedOptions.CreateBrokerConnectionBinderWithOptions(command);
             var routingTopologyBinder = SharedOptions.CreateRoutingTopologyBinderWithOptions(command);
 
             command.AddArgument(endpointNameArgument);
@@ -41,19 +41,19 @@
             command.AddOption(auditQueueOption);
             command.AddOption(instanceDiscriminatorsOption);
 
-            command.SetHandler(async (endpointName, errorQueue, auditQueue, instanceDiscriminators, connectionFactory, routingTopology, console, cancellationToken) =>
+            command.SetHandler(async (endpointName, errorQueue, auditQueue, instanceDiscriminators, brokerConnection, routingTopology, console, cancellationToken) =>
             {
-                var queueCreate = new EndpointCreateCommand(connectionFactory, routingTopology, console);
+                var queueCreate = new EndpointCreateCommand(brokerConnection, routingTopology, console);
                 await queueCreate.Run(endpointName, errorQueue, auditQueue, instanceDiscriminators, cancellationToken).ConfigureAwait(false);
             },
-            endpointNameArgument, errorQueueOption, auditQueueOption, instanceDiscriminatorsOption, connectionFactoryBinder, routingTopologyBinder, Bind.FromServiceProvider<IConsole>(), Bind.FromServiceProvider<CancellationToken>());
+            endpointNameArgument, errorQueueOption, auditQueueOption, instanceDiscriminatorsOption, brokerConnectionBinder, routingTopologyBinder, Bind.FromServiceProvider<IConsole>(), Bind.FromServiceProvider<CancellationToken>());
 
             return command;
         }
 
-        public EndpointCreateCommand(ConnectionFactory connectionFactory, IRoutingTopology routingTopology, IConsole console)
+        public EndpointCreateCommand(BrokerConnection brokerConnection, IRoutingTopology routingTopology, IConsole console)
         {
-            this.connectionFactory = connectionFactory;
+            this.brokerConnection = brokerConnection;
             this.routingTopology = routingTopology;
             this.console = console;
         }
@@ -62,7 +62,7 @@
         {
             console.WriteLine("Connecting to broker");
 
-            using var connection = connectionFactory.CreateAdministrationConnection();
+            using var connection = brokerConnection.Create();
             using var channel = connection.CreateModel();
 
             console.WriteLine("Checking for v2 delay infrastructure");

--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine/NServiceBus.Transport.RabbitMQ.CommandLine.csproj
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine/NServiceBus.Transport.RabbitMQ.CommandLine.csproj
@@ -26,6 +26,7 @@
   <ItemGroup>
     <Compile Include="..\NServiceBus.Transport.RabbitMQ\Configuration\ConnectionConfiguration.cs" Link="Transport\ConnectionConfiguration.cs" />
     <Compile Include="..\NServiceBus.Transport.RabbitMQ\Connection\ConnectionFactory.cs" Link="Transport\ConnectionFactory.cs" />
+    <Compile Include="..\NServiceBus.Transport.RabbitMQ\Connection\ConnectionExtensions.cs" Link="Transport\ConnectionExtension.cs" />
     <Compile Include="..\NServiceBus.Transport.RabbitMQ\DelayedDelivery\DelayInfrastructure.cs" Link="Transport\DelayInfrastructure.cs" />
     <Compile Include="..\NServiceBus.Transport.RabbitMQ\QueueType.cs" Link="Transport\QueueType.cs" />
     <Compile Include="..\NServiceBus.Transport.RabbitMQ\Routing\*.cs" Link="Transport\Routing\%(Filename)%(Extension)" />

--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine/SharedOptions.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine/SharedOptions.cs
@@ -101,7 +101,7 @@
             return certPassphraseOption;
         }
 
-        public static ConnectionFactoryBinder CreateConnectionFactoryBinderWithOptions(Command command)
+        public static BrokerConnectionBinder CreateBrokerConnectionBinderWithOptions(Command command)
         {
             var connectionStringOption = CreateConnectionStringOption();
             var connectionStringEnvOption = CreateConnectionStringEnvOption();
@@ -117,7 +117,7 @@
             command.AddOption(disableCertVaidationOption);
             command.AddOption(useExternalAuthOption);
 
-            return new ConnectionFactoryBinder(connectionStringOption, connectionStringEnvOption, certPathOption, certPassphraseOption, disableCertVaidationOption, useExternalAuthOption);
+            return new BrokerConnectionBinder(connectionStringOption, connectionStringEnvOption, certPathOption, certPassphraseOption, disableCertVaidationOption, useExternalAuthOption);
         }
 
         public static RoutingTopologyBinder CreateRoutingTopologyBinderWithOptions(Command command)

--- a/src/NServiceBus.Transport.RabbitMQ/Connection/ConnectionExtensions.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Connection/ConnectionExtensions.cs
@@ -1,0 +1,34 @@
+﻿namespace NServiceBus.Transport.RabbitMQ
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using global::RabbitMQ.Client;
+
+    static class ConnectionExtensions
+    {
+        public static void VerifyBrokerRequirements(this IConnection connection)
+        {
+            var minimumBrokerVersion = Version.Parse("3.10.0");
+            var brokerVersionString = Encoding.UTF8.GetString((byte[])connection.ServerProperties["version"]);
+
+            if (Version.TryParse(brokerVersionString, out var brokerVersion) && brokerVersion < minimumBrokerVersion)
+            {
+                throw new Exception($"An unsupported broker version was detected: {brokerVersion}. The broker must be at least version {minimumBrokerVersion}.");
+            }
+
+            using var channel = connection.CreateModel();
+
+            var arguments = new Dictionary<string, object> { { "x-queue-type", "stream" } };
+
+            try
+            {
+                channel.QueueDeclare("nsb.v2.verify-stream-flag-enabled", true, false, false, arguments);
+            }
+            catch (Exception ex) when (ex.Message.Contains("the corresponding feature flag is disabled"))
+            {
+                throw new Exception("An unsupported broker configuration was detected. The 'stream_queue' feature flag needs to be enabled.");
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Transport.RabbitMQ/Connection/ConnectionFactory.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Connection/ConnectionFactory.cs
@@ -8,7 +8,6 @@
     using System.Net.Security;
     using System.Security.Authentication;
     using System.Security.Cryptography.X509Certificates;
-    using System.Text;
     using global::RabbitMQ.Client;
     using Logging;
     using Support;
@@ -16,7 +15,6 @@
     class ConnectionFactory
     {
         static readonly ILog Logger = LogManager.GetLogger(typeof(IConnection));
-        static readonly Version MinimumBrokerVersion = Version.Parse("3.10.0");
 
         readonly string endpointName;
         readonly global::RabbitMQ.Client.ConnectionFactory connectionFactory;
@@ -120,8 +118,6 @@
 
                 var connection = connectionFactory.CreateConnection(hostnames, connectionName);
 
-                CheckForMinimumBrokerVersion(connection);
-
                 connection.ConnectionBlocked += (sender, e) => Logger.WarnFormat("'{0}' connection blocked: {1}", connectionName, e.Reason);
                 connection.ConnectionUnblocked += (sender, e) => Logger.WarnFormat("'{0}' connection unblocked}", connectionName);
 
@@ -136,16 +132,6 @@
                 };
 
                 return connection;
-            }
-        }
-
-        void CheckForMinimumBrokerVersion(IConnection connection)
-        {
-            var brokerVersionString = Encoding.UTF8.GetString((byte[])connection.ServerProperties["version"]);
-
-            if (Version.TryParse(brokerVersionString, out var brokerVersion) && brokerVersion < MinimumBrokerVersion)
-            {
-                throw new Exception($"An unsupported broker version was detected: {brokerVersion}. The broker must be at least version {MinimumBrokerVersion}.");
             }
         }
     }


### PR DESCRIPTION
This PR is an enhancement to #1039.

With this change, we are now able to ensure the following broker requirements for the v2 delay infrastructure:

1. Minimum version of 3.10.0
2. `quorum_queue` feature flag enabled
3. `stream_queue` feature flag enabled

These checks happen for every command line tool command that requires a broker connection (so all of them except `delays verify` which is using the management API to check these requirements in the first place) and on endpoint startup if installers are enabled.

There is no direct way to check for feature flags with the RabbitMQ client, so instead we try to create a `stream` queue and if that fails, we know the feature flag isn't enabled.

We don't need a similar check for the `quorum_queue` feature flag because the various `QueueDeclare` calls will throw an exception indicating that the flag needs to be enabled if it isn't.
