### PR TITLE
Call VerifyBrokerRequirements in installer

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ/Administration/QueueCreator.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Administration/QueueCreator.cs
@@ -18,6 +18,8 @@
             using (var connection = connectionFactory.CreateAdministrationConnection())
             using (var channel = connection.CreateModel())
             {
+                connection.VerifyBrokerRequirements();
+
                 DelayInfrastructure.Build(channel);
 
                 routingTopology.Initialize(channel, queueBindings.ReceivingAddresses, queueBindings.SendingAddresses);


### PR DESCRIPTION
Follow-up to #1042 

While backporting the changes, I forgot to actually call `VerifyBrokerRequirements` in the `QueueCreator` class, which is invoked by NSB 7 installers.

🙄 