### PR TITLE
Improve handling of immediate and delayed retries

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ/Receiving/MessagePump.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Receiving/MessagePump.cs
@@ -438,7 +438,7 @@
 
                 if (Regex.IsMatch(ex.ShutdownReason.ReplyText, @"PRECONDITION_FAILED - delivery acknowledgement on channel [0-9]+ timed out\. Timeout value used: [0-9]+ ms\. This timeout value can be configured, see consumers doc guide to learn more"))
                 {
-                    Logger.Warn($"Failed to acknowledge message '{messageId}' because the handler execution time exceeded the broker delivery acknowledgement timeout. Increase the length of the timeout on the broker. The message was returned to the queue.", ex);
+                    Logger.Error($"Failed to acknowledge message '{messageId}' because the handler execution time exceeded the broker delivery acknowledgement timeout. Increase the length of the timeout on the broker. The message was returned to the queue.", ex);
                 }
                 else
                 {


### PR DESCRIPTION
Follow-up to #1071 

This PR introduces the following changes:

1. When relying on the delivery attempts collection (because of classic queues), we need to consider the delayed retries count as part of the collection key. Without this, the total delivery attempts count never gets reset between delayed retries.
2. When a message should be acknowledged but can't because the channel is closed and the message has been requeued, we now track that and ack it the next time we see it. This prevents the message from getting stuck in an endless retry loop.
3. The log message when we detect a consumer timeout being exceeded has been changed to an error. This error should always be acted on when we log it, so making it an error seems appropriate.