### PR TITLE
Resolve infinite loop with ObjectDisposedException

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ/Receiving/MessagePump.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Receiving/MessagePump.cs
@@ -264,9 +264,9 @@
         async Task Reconnect()
 #pragma warning restore PS0018 // A task-returning method should have a CancellationToken parameter unless it has a parameter implementing ICancellableContext
         {
+            var cancellationToken = messagePumpCancellationTokenSource.Token;  // Will throw ObjectDisposedException if already disposed, obtain token once outside of loop
             try
             {
-                var cancellationToken = messagePumpCancellationTokenSource.Token;  // Will throw ObjectDisposedException if already disposed, obtain token once outside of loop
 
                 while (!cancellationToken.IsCancellationRequested)
                 {

--- a/src/NServiceBus.Transport.RabbitMQ/Receiving/MessagePump.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Receiving/MessagePump.cs
@@ -266,7 +266,7 @@
         {
             try
             {
-                while (!messageProcessingCancellationTokenSource.IsCancellationRequested)
+                while (!messagePumpCancellationTokenSource.IsCancellationRequested)
                 {
                     try
                     {
@@ -279,12 +279,12 @@
 
                         Logger.InfoFormat("'{0}': Attempting to reconnect in {1} seconds.", name, retryDelay.TotalSeconds);
 
-                        await Task.Delay(retryDelay, messageProcessingCancellationTokenSource.Token).ConfigureAwait(false);
+                        await Task.Delay(retryDelay, messagePumpCancellationTokenSource.Token).ConfigureAwait(false);
 
                         ConnectToBroker();
                         break;
                     }
-                    catch (Exception ex) when (!ex.IsCausedBy(messageProcessingCancellationTokenSource.Token))
+                    catch (Exception ex) when (!ex.IsCausedBy(messagePumpCancellationTokenSource.Token))
                     {
                         Logger.InfoFormat("'{0}': Reconnecting to the broker failed: {1}", name, ex);
                     }
@@ -292,7 +292,7 @@
 
                 Logger.InfoFormat("'{0}': Connection to the broker reestablished successfully.", name);
             }
-            catch (Exception ex) when (ex.IsCausedBy(messageProcessingCancellationTokenSource.Token))
+            catch (Exception ex) when (ex.IsCausedBy(messagePumpCancellationTokenSource.Token))
             {
                 Logger.DebugFormat("'{0}': Reconnection canceled since the transport is being stopped: {1}", name, ex);
             }

--- a/src/NServiceBus.Transport.RabbitMQ/Receiving/MessagePump.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Receiving/MessagePump.cs
@@ -524,6 +524,7 @@
             circuitBreaker?.Dispose();
             messagePumpCancellationTokenSource?.Cancel();
             messagePumpCancellationTokenSource?.Dispose();
+            messageProcessingCancellationTokenSource?.Cancel();
             messageProcessingCancellationTokenSource?.Dispose();
 
             connection?.Dispose();

--- a/src/NServiceBus.Transport.RabbitMQ/Receiving/MessagePump.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Receiving/MessagePump.cs
@@ -266,7 +266,7 @@
         {
             try
             {
-                while (true)
+                while (!messageProcessingCancellationTokenSource.IsCancellationRequested)
                 {
                     try
                     {
@@ -522,6 +522,7 @@
             }
 
             circuitBreaker?.Dispose();
+            messagePumpCancellationTokenSource?.Cancel();
             messagePumpCancellationTokenSource?.Dispose();
             messageProcessingCancellationTokenSource?.Dispose();
 

--- a/src/NServiceBus.Transport.RabbitMQ/Receiving/MessagePump.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Receiving/MessagePump.cs
@@ -268,6 +268,10 @@
             {
                 while (!messagePumpCancellationTokenSource.IsCancellationRequested)
                 {
+                    if (disposed)
+                    {
+                        throw new InvalidOperationException("Disposed, terminating reconnect");
+                    }
                     try
                     {
                         if (connection.IsOpen)


### PR DESCRIPTION
- Resolves: https://github.com/Particular/NServiceBus.RabbitMQ/issues/1186

Reconnect method has a loop that did not anticipate on `messageProcessingCancellationTokenSource` to be disposed. This can result in `messageProcessingCancellationTokenSource.Token` throw an `ObjectDisposedException`. When that happens the while loop never breaks and create infinite log entries as fast as it can until the process is killed.

## Cancellation token handling

- Before disposing also canceling, cancellation the CTS should gracefully stop the reconnect loop in situations where Dispose is invoked by the environment but Stop didn't happen yet.
- Moved `.Token` out of loop as that can throw an ODE by passing it as an argument to Reconnect. By obtaining the CT once a ODE cannot occur on the CTS.Token.

## Disposed handling

- Not catching ObjectDisposedException as RabbitMQ client might somewhere throw it. If catching ODE the catches should be around specific APIs
