### PR TITLE
Confirm that header collection is always populated on redelivery for quorum queues

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ.Tests/RabbitMqContext.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/RabbitMqContext.cs
@@ -89,10 +89,7 @@
         protected string ReceiverQueue => GetTestQueueName("testreceiver");
         protected string ErrorQueue => GetTestQueueName("error");
 
-        protected string GetTestQueueName(string queueName)
-        {
-            return $"{queueName}-{queueType}";
-        }
+        protected string GetTestQueueName(string queueName) => $"{queueName}-{queueType}";
 
         protected QueueType queueType = QueueType.Quorum;
         protected ConnectionFactory connectionFactory;

--- a/src/NServiceBus.Transport.RabbitMQ.Tests/RabbitMqContext.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/RabbitMqContext.cs
@@ -21,7 +21,7 @@
 
             var useTls = connectionString.StartsWith("https", StringComparison.InvariantCultureIgnoreCase) || connectionString.StartsWith("amqps", StringComparison.InvariantCultureIgnoreCase);
 
-            var transport = new RabbitMQTransport(RoutingTopology.Conventional(QueueType.Classic), connectionString);
+            var transport = new RabbitMQTransport(RoutingTopology.Conventional(QueueType.Quorum), connectionString);
             var connectionConfig = transport.ConnectionConfiguration;
 
             connectionFactory = new ConnectionFactory(ReceiverQueue, connectionConfig, null, true, false, transport.HeartbeatInterval, transport.NetworkRecoveryInterval, null);

--- a/src/NServiceBus.Transport.RabbitMQ.Tests/RabbitMqContext.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/RabbitMqContext.cs
@@ -13,7 +13,7 @@
         public virtual int MaximumConcurrency => 1;
 
         [SetUp]
-        public async Task SetUp()
+        public virtual async Task SetUp()
         {
             receivedMessages = new BlockingCollection<IncomingMessage>();
 
@@ -21,7 +21,7 @@
 
             var useTls = connectionString.StartsWith("https", StringComparison.InvariantCultureIgnoreCase) || connectionString.StartsWith("amqps", StringComparison.InvariantCultureIgnoreCase);
 
-            var transport = new RabbitMQTransport(RoutingTopology.Conventional(QueueType.Quorum), connectionString);
+            var transport = new RabbitMQTransport(RoutingTopology.Conventional(queueType), connectionString);
             var connectionConfig = transport.ConnectionConfiguration;
 
             connectionFactory = new ConnectionFactory(ReceiverQueue, connectionConfig, null, true, false, transport.HeartbeatInterval, transport.NetworkRecoveryInterval, null);
@@ -29,7 +29,7 @@
             infra = await transport.Initialize(new HostSettings(ReceiverQueue, ReceiverQueue, new StartupDiagnosticEntries(),
                 (_, __, ___) => { }, true), new[]
             {
-                new ReceiveSettings(ReceiverQueue, new QueueAddress(ReceiverQueue), true, true, "error")
+                new ReceiveSettings(ReceiverQueue, new QueueAddress(ReceiverQueue), true, true, ErrorQueue)
             }, AdditionalReceiverQueues.Concat(new[] { ErrorQueue }).ToArray());
 
             messageDispatcher = infra.Dispatcher;
@@ -81,13 +81,20 @@
         bool TryReceiveMessage(out IncomingMessage message, TimeSpan timeout) =>
             receivedMessages.TryTake(out message, timeout);
 
-        protected virtual IEnumerable<string> AdditionalReceiverQueues => Enumerable.Empty<string>();
+        protected IList<string> AdditionalReceiverQueues = new List<string>();
 
         protected Func<MessageContext, CancellationToken, Task> OnMessage;
         protected Func<ErrorContext, CancellationToken, Task<ErrorHandleResult>> OnError;
 
-        protected const string ReceiverQueue = "testreceiver";
-        protected const string ErrorQueue = "error";
+        protected string ReceiverQueue => GetTestQueueName("testreceiver");
+        protected string ErrorQueue => GetTestQueueName("error");
+
+        protected string GetTestQueueName(string queueName)
+        {
+            return $"{queueName}-{queueType}";
+        }
+
+        protected QueueType queueType = QueueType.Quorum;
         protected ConnectionFactory connectionFactory;
         protected IMessageDispatcher messageDispatcher;
         protected IMessageReceiver messagePump;

--- a/src/NServiceBus.Transport.RabbitMQ.Tests/When_consuming_from_classic_queues.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/When_consuming_from_classic_queues.cs
@@ -19,7 +19,7 @@
         [Test]
         public async Task Header_collection_is_null_after_redelivery_for_headerless_messages()
         {
-            var message = new OutgoingMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>(), new byte[0]);
+            var message = new OutgoingMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>(), Array.Empty<byte>());
             var headerCollectionWasNullOnFirstDelivery = false;
             var headerCollectionWasNullOnRedelivery = new TaskCompletionSource<bool>();
 
@@ -38,10 +38,7 @@
                 return Task.CompletedTask;
             };
 
-            OnError = (ec, __) =>
-            {
-                return Task.FromResult(ErrorHandleResult.RetryRequired);
-            };
+            OnError = (ec, __) => Task.FromResult(ErrorHandleResult.RetryRequired);
 
             using (var connection = connectionFactory.CreatePublishConnection())
             using (var channel = connection.CreateModel())

--- a/src/NServiceBus.Transport.RabbitMQ.Tests/When_consuming_from_classic_queues.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/When_consuming_from_classic_queues.cs
@@ -17,17 +17,30 @@
         }
 
         [Test]
-        public async Task Header_collection_is_null_for_headerless_messages()
+        public async Task Header_collection_is_null_after_redelivery_for_headerless_messages()
         {
             var message = new OutgoingMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>(), new byte[0]);
-            var headerCollectionWasNull = new TaskCompletionSource<bool>();
+            var headerCollectionWasNullOnFirstDelivery = false;
+            var headerCollectionWasNullOnRedelivery = new TaskCompletionSource<bool>();
 
             OnMessage = (mc, __) =>
             {
                 var basicDeliverEventArgs = mc.Extensions.Get<BasicDeliverEventArgs>();
-                headerCollectionWasNull.SetResult(basicDeliverEventArgs.BasicProperties.Headers == null);
+
+                if (!basicDeliverEventArgs.Redelivered)
+                {
+                    headerCollectionWasNullOnFirstDelivery = basicDeliverEventArgs.BasicProperties.Headers == null;
+                    throw new Exception("Some failure");
+                }
+
+                headerCollectionWasNullOnRedelivery.SetResult(basicDeliverEventArgs.BasicProperties.Headers == null);
 
                 return Task.CompletedTask;
+            };
+
+            OnError = (ec, __) =>
+            {
+                return Task.FromResult(ErrorHandleResult.RetryRequired);
             };
 
             using (var connection = connectionFactory.CreatePublishConnection())
@@ -39,13 +52,15 @@
 
                 channel.BasicPublish(string.Empty, ReceiverQueue, false, properties, message.Body);
 
-                if (await Task.WhenAny(headerCollectionWasNull.Task, Task.Delay(IncomingMessageTimeout)) != headerCollectionWasNull.Task)
+                if (await Task.WhenAny(headerCollectionWasNullOnRedelivery.Task, Task.Delay(IncomingMessageTimeout)) != headerCollectionWasNullOnRedelivery.Task)
                 {
                     Assert.Fail("Message receive timed out");
                 }
 
-                var headersWasNull = await headerCollectionWasNull.Task;
-                Assert.True(headersWasNull, "Header collection is null for classic queues due to a client bug");
+                var headersWasNullOnRedelivery = await headerCollectionWasNullOnRedelivery.Task;
+
+                Assert.True(headerCollectionWasNullOnFirstDelivery, "Header collection should be null on the first delivery");
+                Assert.True(headersWasNullOnRedelivery, "Header collection should be null even after a redelivery");
             }
         }
 

--- a/src/NServiceBus.Transport.RabbitMQ.Tests/When_consuming_from_classic_queues.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/When_consuming_from_classic_queues.cs
@@ -1,0 +1,56 @@
+﻿namespace NServiceBus.Transport.RabbitMQ.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using global::RabbitMQ.Client.Events;
+    using NUnit.Framework;
+
+    [TestFixture]
+    class When_consuming_from_classic_queues : RabbitMqContext
+    {
+        [SetUp]
+        public override Task SetUp()
+        {
+            queueType = QueueType.Classic;
+            return base.SetUp();
+        }
+
+        [Test]
+        public async Task Header_collection_is_null_for_headerless_messages()
+        {
+            var message = new OutgoingMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>(), new byte[0]);
+            var headerCollectionWasNull = new TaskCompletionSource<bool>();
+
+            OnMessage = (mc, __) =>
+            {
+                var basicDeliverEventArgs = mc.Extensions.Get<BasicDeliverEventArgs>();
+                headerCollectionWasNull.SetResult(basicDeliverEventArgs.BasicProperties.Headers == null);
+
+                return Task.CompletedTask;
+            };
+
+            using (var connection = connectionFactory.CreatePublishConnection())
+            using (var channel = connection.CreateModel())
+            {
+                var properties = channel.CreateBasicProperties();
+
+                properties.MessageId = message.MessageId;
+
+                channel.BasicPublish(string.Empty, ReceiverQueue, false, properties, message.Body);
+
+                if (await Task.WhenAny(headerCollectionWasNull.Task, Task.Delay(IncomingMessageTimeout)) != headerCollectionWasNull.Task)
+                {
+                    Assert.Fail("Message receive timed out");
+                }
+
+                var headersWasNull = await headerCollectionWasNull.Task;
+                Assert.True(headersWasNull, "Header collection is null for classic queues due to a client bug");
+            }
+        }
+
+        class MyMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Transport.RabbitMQ.Tests/When_consuming_messages.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/When_consuming_messages.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
+    using global::RabbitMQ.Client.Events;
     using NUnit.Framework;
     using Routing;
 
@@ -102,6 +103,39 @@
                 var wasHandled = await handled.Task;
                 Assert.True(wasHandled, "Error handler should be called after retry");
                 Assert.AreEqual(1, numRetries, "Message should be retried once");
+            }
+        }
+
+        [Test]
+        public async Task Header_collection_is_not_null_for_headerless_messages()
+        {
+            var message = new OutgoingMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>(), new byte[0]);
+            var headerCollectionWasNull = new TaskCompletionSource<bool>();
+
+            OnMessage = (mc, __) =>
+            {
+                var basicDeliverEventArgs = mc.Extensions.Get<BasicDeliverEventArgs>();
+                headerCollectionWasNull.SetResult(basicDeliverEventArgs.BasicProperties.Headers == null);
+
+                return Task.CompletedTask;
+            };
+
+            using (var connection = connectionFactory.CreatePublishConnection())
+            using (var channel = connection.CreateModel())
+            {
+                var properties = channel.CreateBasicProperties();
+
+                properties.MessageId = message.MessageId;
+
+                channel.BasicPublish(string.Empty, ReceiverQueue, false, properties, message.Body);
+
+                if (await Task.WhenAny(headerCollectionWasNull.Task, Task.Delay(IncomingMessageTimeout)) != headerCollectionWasNull.Task)
+                {
+                    Assert.Fail("Message receive timed out");
+                }
+
+                var headersWasNull = await headerCollectionWasNull.Task;
+                Assert.False(headersWasNull, "Header collection should not be null even if message has no headers");
             }
         }
 

--- a/src/NServiceBus.Transport.RabbitMQ.Tests/When_consuming_messages.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/When_consuming_messages.cs
@@ -13,7 +13,7 @@
         [Test]
         public async Task Should_block_until_a_message_is_available()
         {
-            var message = new OutgoingMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>(), new byte[0]);
+            var message = new OutgoingMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>(), Array.Empty<byte>());
             var transportOperations = new TransportOperations(new TransportOperation(message, new UnicastAddressTag(ReceiverQueue)));
 
             await messageDispatcher.Dispatch(transportOperations, new TransportTransaction());
@@ -26,7 +26,7 @@
         [Test]
         public void Should_be_able_to_receive_messages_without_headers()
         {
-            var message = new OutgoingMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>(), new byte[0]);
+            var message = new OutgoingMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>(), Array.Empty<byte>());
 
             using (var connection = connectionFactory.CreatePublishConnection())
             using (var channel = connection.CreateModel())
@@ -46,7 +46,7 @@
         [Test]
         public void Should_move_message_without_message_id_to_error_queue()
         {
-            var message = new OutgoingMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>(), new byte[0]);
+            var message = new OutgoingMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>(), Array.Empty<byte>());
 
             using (var connection = connectionFactory.CreatePublishConnection())
             using (var channel = connection.CreateModel())
@@ -67,7 +67,7 @@
         [Test]
         public async Task Should_handle_retries_for_messages_without_headers()
         {
-            var message = new OutgoingMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>(), new byte[0]);
+            var message = new OutgoingMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>(), Array.Empty<byte>());
             var numRetries = 0;
             var handled = new TaskCompletionSource<bool>();
 
@@ -109,7 +109,7 @@
         [Test]
         public async Task Header_collection_is_not_null_after_redelivery_for_headerless_messages()
         {
-            var message = new OutgoingMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>(), new byte[0]);
+            var message = new OutgoingMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>(), Array.Empty<byte>());
             var headerCollectionWasNullOnFirstDelivery = false;
             var headerCollectionWasNullOnRedelivery = new TaskCompletionSource<bool>();
 
@@ -128,10 +128,7 @@
                 return Task.CompletedTask;
             };
 
-            OnError = (ec, __) =>
-            {
-                return Task.FromResult(ErrorHandleResult.RetryRequired);
-            };
+            OnError = (ec, __) => Task.FromResult(ErrorHandleResult.RetryRequired);
 
             using (var connection = connectionFactory.CreatePublishConnection())
             using (var channel = connection.CreateModel())
@@ -157,7 +154,7 @@
         [Test]
         public void Should_up_convert_the_native_type_to_the_enclosed_message_types_header_if_empty()
         {
-            var message = new OutgoingMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>(), new byte[0]);
+            var message = new OutgoingMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>(), Array.Empty<byte>());
 
             var typeName = typeof(MyMessage).FullName;
 

--- a/src/NServiceBus.Transport.RabbitMQ.Tests/When_sending_a_message_over_rabbitmq.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/When_sending_a_message_over_rabbitmq.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.Transport.RabbitMQ.Tests
 {
     using System;
-    using System.Collections.Generic;
     using System.Linq;
     using System.Text;
     using System.Threading;
@@ -12,7 +11,16 @@
     [TestFixture]
     class When_sending_a_message_over_rabbitmq : RabbitMqContext
     {
-        const string QueueToReceiveOn = "testEndPoint";
+        string QueueToReceiveOn;
+
+        [SetUp]
+        public override Task SetUp()
+        {
+            QueueToReceiveOn = GetTestQueueName("testendpoint");
+            AdditionalReceiverQueues.Add(QueueToReceiveOn);
+
+            return base.SetUp();
+        }
 
         [Test]
         public Task Should_populate_the_body()
@@ -92,8 +100,6 @@
                     Assert.AreEqual("v2", result.Headers["h2"]);
                 });
         }
-
-        protected override IEnumerable<string> AdditionalReceiverQueues => new[] { QueueToReceiveOn };
 
         async Task Verify(OutgoingMessageBuilder builder, Action<IncomingMessage, BasicDeliverEventArgs> assertion, CancellationToken cancellationToken = default)
         {

--- a/src/NServiceBus.Transport.RabbitMQ.Tests/When_sending_a_message_over_rabbitmq.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/When_sending_a_message_over_rabbitmq.cs
@@ -129,12 +129,7 @@
             using (var connection = connectionFactory.CreateConnection("Consume"))
             using (var channel = connection.CreateModel())
             {
-                var message = channel.BasicGet(queueToReceiveOn, false);
-
-                if (message == null)
-                {
-                    throw new InvalidOperationException("No message found in queue");
-                }
+                var message = channel.BasicGet(queueToReceiveOn, false) ?? throw new InvalidOperationException("No message found in queue");
 
                 if (message.BasicProperties.MessageId != id)
                 {


### PR DESCRIPTION
This switches the tests to use quorum queues by default since classic queues are being phased out