### PR TITLE
Retries of headerless message causes indefinite requeuing on classic queues

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ.Tests/When_consuming_messages.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/When_consuming_messages.cs
@@ -58,8 +58,50 @@
 
                 var result = channel.BasicGet(ErrorQueue, true);
 
-                Assert.False(messageWasReceived, "Message should not be processed processed successfully.");
+                Assert.False(messageWasReceived, "Message should not be processed successfully.");
                 Assert.NotNull(result, "Message should be considered poison and moved to the error queue.");
+            }
+        }
+
+        [Test]
+        public async Task Should_handle_retries_for_messages_without_headers()
+        {
+            var message = new OutgoingMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>(), new byte[0]);
+            var numRetries = 0;
+            var handled = new TaskCompletionSource<bool>();
+
+            OnMessage = (_, __) => throw new Exception("Simulated exception");
+
+            OnError = (ec, __) =>
+            {
+                if (numRetries == 0)
+                {
+                    numRetries++;
+                    return Task.FromResult(ErrorHandleResult.RetryRequired);
+                }
+
+                handled.SetResult(true);
+
+                return Task.FromResult(ErrorHandleResult.Handled);
+            };
+
+            using (var connection = connectionFactory.CreatePublishConnection())
+            using (var channel = connection.CreateModel())
+            {
+                var properties = channel.CreateBasicProperties();
+
+                properties.MessageId = message.MessageId;
+
+                channel.BasicPublish(string.Empty, ReceiverQueue, false, properties, message.Body);
+
+                if (await Task.WhenAny(handled.Task, Task.Delay(IncomingMessageTimeout)) != handled.Task)
+                {
+                    Assert.Fail("Message receive timed out");
+                }
+
+                var wasHandled = await handled.Task;
+                Assert.True(wasHandled, "Error handler should be called after retry");
+                Assert.AreEqual(1, numRetries, "Message should be retried once");
             }
         }
 

--- a/src/NServiceBus.Transport.RabbitMQ/Receiving/MessagePump.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Receiving/MessagePump.cs
@@ -464,7 +464,7 @@
                 return attempts;
             }
 
-            if (message.BasicProperties.Headers.TryGetValue("x-delivery-count", out var headerValue))
+            if (message.BasicProperties.Headers != null && message.BasicProperties.Headers.TryGetValue("x-delivery-count", out var headerValue))
             {
                 attempts = Convert.ToInt32(headerValue) + 1;
             }


### PR DESCRIPTION
Backport of https://github.com/Particular/NServiceBus.RabbitMQ/issues/1222