### PR TITLE
Fix message deduplication logic in migrate-to-quorum command

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine.Tests/MigrateQueue/QueueMigrateToQuorumTests.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine.Tests/MigrateQueue/QueueMigrateToQuorumTests.cs
@@ -78,6 +78,22 @@
         }
 
         [Test]
+        public async Task Should_preserve_existing_messages_with_messageIds()
+        {
+            var endpointName = "EndpointWithExistingMessages";
+            var numExistingMessages = 10;
+
+            PrepareTestEndpoint(endpointName);
+
+            AddMessages(endpointName, numExistingMessages, properties => properties.Headers = new Dictionary<string, object> { { NServiceBus.Headers.MessageId, Guid.NewGuid().ToString() } });
+
+            await ExecuteMigration(endpointName);
+
+            Assert.True(QueueIsQuorum(endpointName));
+            Assert.AreEqual(numExistingMessages, MessageCount(endpointName));
+        }
+
+        [Test]
         public async Task Should_preserve_existing_messages_in_holding_queue()
         {
             var endpointName = "EndpointWithExistingMessagesInHolding";

--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine/Commands/Queue/QueueMigrateCommand.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine/Commands/Queue/QueueMigrateCommand.cs
@@ -89,11 +89,11 @@
 
             // bind the holding queue to the exchange of the queue under migration
             // this will throw if the exchange for the queue doesn't exist
-            channel.QueueBind(holdingQueueName, queueName, emptyRoutingKey);
+            channel.QueueBind(holdingQueueName, queueName, string.Empty);
             console.WriteLine($"Bound '{holdingQueueName}' to exchange '{queueName}'");
 
             // unbind the queue under migration to stop more messages from coming in
-            channel.QueueUnbind(queueName, queueName, emptyRoutingKey);
+            channel.QueueUnbind(queueName, queueName, string.Empty);
             console.WriteLine($"Unbound '{queueName}' from exchange '{queueName}' ");
 
             // move all existing messages to the holding queue
@@ -104,7 +104,7 @@
                 queueName,
                 message =>
                 {
-                    channel.BasicPublish(emptyRoutingKey, holdingQueueName, message.BasicProperties, message.Body);
+                    channel.BasicPublish(string.Empty, holdingQueueName, message.BasicProperties, message.Body);
                     channel.WaitForConfirmsOrDie();
                 },
                 cancellationToken);
@@ -144,10 +144,10 @@
         {
             using var channel = connection.CreateModel();
 
-            channel.QueueBind(queueName, queueName, emptyRoutingKey);
+            channel.QueueBind(queueName, queueName, string.Empty);
             console.WriteLine($"Re-bound '{queueName}' to exchange '{queueName}'");
 
-            channel.QueueUnbind(holdingQueueName, queueName, emptyRoutingKey);
+            channel.QueueUnbind(holdingQueueName, queueName, string.Empty);
             console.WriteLine($"Unbound '{holdingQueueName}' from exchange '{queueName}'");
 
             var messageIds = new Dictionary<string, string>();
@@ -175,7 +175,7 @@
                         }
                     }
 
-                    channel.BasicPublish(emptyRoutingKey, queueName, message.BasicProperties, message.Body);
+                    channel.BasicPublish(string.Empty, queueName, message.BasicProperties, message.Body);
                     channel.WaitForConfirmsOrDie();
 
                     if (messageIdString != null)
@@ -235,7 +235,6 @@
         readonly IConsole console;
         readonly MigrationState migrationState;
 
-        static string emptyRoutingKey = string.Empty;
         static Dictionary<string, object> quorumQueueArguments = new Dictionary<string, object> { { "x-queue-type", "quorum" } };
 
         enum MigrationStage

--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine/Commands/Queue/QueueMigrateCommand.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine/Commands/Queue/QueueMigrateCommand.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.CommandLine;
+    using System.Text;
     using global::RabbitMQ.Client;
     using global::RabbitMQ.Client.Exceptions;
 
@@ -163,7 +164,10 @@
 
                     if (message.BasicProperties.Headers.TryGetValue("NServiceBus.MessageId", out var messageId))
                     {
-                        messageIdString = messageId?.ToString();
+                        if (messageId is byte[] bytes)
+                        {
+                            messageIdString = Encoding.UTF8.GetString(bytes);
+                        }
 
                         if (messageIdString != null && messageIds.ContainsKey(messageIdString))
                         {

--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine/NServiceBus.Transport.RabbitMQ.CommandLine.csproj
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine/NServiceBus.Transport.RabbitMQ.CommandLine.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <ToolCommandName>rabbitmq-transport</ToolCommandName>
     <PackAsTool>True</PackAsTool>


### PR DESCRIPTION
When the `queue migrate-to-quorum` command was added in #1006, the message deduplication logic overlooked that the RabbitMQ client exposes string values in the `Headers` collection as UTF-8 byte arrays. Because of this, the deduplication did not work correctly, resulting in all but the first message processed being considered a duplicate and discarded.

This is fixed by first converting the byte array to a string via `Encoding.UTF8.GetString`,

This PR also includes the following changes:
- `emptyRoutingKey` has been removed and replaced with `string.Empty` uses directly because the name of the variable could be confusing in some of the places it was being used.
- A `net7.0` TFM was added to the CommandLine project to ensure that the command line tool can work with only a .NET 7 SDK installed.