### PR TITLE
Skip reconnect delay on first reconnect attempt

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ/Receiving/MessagePump.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Receiving/MessagePump.cs
@@ -275,16 +275,15 @@
 
                         connection.Dispose();
 
-                        Logger.InfoFormat("'{0}': Attempting to reconnect in {1} seconds.", name, retryDelay.TotalSeconds);
-
-                        await Task.Delay(retryDelay, cancellationToken).ConfigureAwait(false);
-
                         ConnectToBroker();
                         break;
                     }
                     catch (Exception ex) when (!ex.IsCausedBy(cancellationToken))
                     {
                         Logger.InfoFormat("'{0}': Reconnecting to the broker failed: {1}", name, ex);
+
+                        Logger.InfoFormat("'{0}': Attempting to reconnect in {1} seconds.", name, retryDelay.TotalSeconds);
+                        await Task.Delay(retryDelay, cancellationToken).ConfigureAwait(false);
                     }
                 }
 


### PR DESCRIPTION
An idea to improve the behavior when using [message throughput throttling](https://docs.particular.net/samples/throttling/) in which case the implementation always triggers a reconnect. The default implementation then by default waits 10 seconds causing an unexpected delay in immediate retry processing attempts.

At first thought, the first reconnect attempt can be attempted without any delay, while bringing in the delay in case the first reconnect attempt fails.

Not quite sure if that would cause issues with other calls to `Reconnect`, e.g. in `Channel_ModelShutdown`, `Connection_ConnectionShutdown`, and `Consumer_ConsumerCancelled` though.

Any thoughts on this?