### PR TITLE
Protect against empty header collection in queue migrate command

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine/Commands/Queue/QueueMigrateCommand.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine/Commands/Queue/QueueMigrateCommand.cs
@@ -162,7 +162,7 @@
                 {
                     string? messageIdString = null;
 
-                    if (message.BasicProperties.Headers.TryGetValue("NServiceBus.MessageId", out var messageId))
+                    if (message.BasicProperties.Headers != null && message.BasicProperties.Headers.TryGetValue("NServiceBus.MessageId", out var messageId))
                     {
                         if (messageId is byte[] bytes)
                         {


### PR DESCRIPTION
RabbitMQ 3.12.0 includes a [change](https://github.com/rabbitmq/rabbitmq-server/pull/7732) to the `x-delivery-count` header.

Most of the tests for the `queue migrate` command create messages that are simple native messages that don't include all of the normal NServiceBus headers.

That means that these test messages now have no headers at all, and the RabbitMQ client unfortunately represents that with a `null` `Headers` collection instead of an empty collection.

This impacts our tests, but to be observed in a real migration scenario, there would have to be non-NSB messages with no headers in the queue that is being migrated. 