### PR TITLE
Ensure reconnect loop in ChannelProvider terminates when disposed

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine/NServiceBus.Transport.RabbitMQ.CommandLine.csproj
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine/NServiceBus.Transport.RabbitMQ.CommandLine.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="9.0.0" />
+    <PackageReference Include="NServiceBus" Version="9.1.0" />
     <PackageReference Include="RabbitMQ.Client" Version="6.8.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>

--- a/src/NServiceBus.Transport.RabbitMQ/Connection/ChannelProvider.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Connection/ChannelProvider.cs
@@ -96,8 +96,15 @@ namespace NServiceBus.Transport.RabbitMQ
 
         public void Dispose()
         {
-            stoppingTokenSource.Cancel();
-            stoppingTokenSource.Dispose();
+            try
+            {
+                stoppingTokenSource.Cancel();
+                stoppingTokenSource.Dispose();
+            }
+            catch (ObjectDisposedException)
+            {
+                // .Cancel can throw if already disposed
+            }
 
             connection?.Dispose();
 


### PR DESCRIPTION
- Fixed #1268

1. ChannelProvider now has a CancellationTokenSource that gets cancelled when it is Disposed to ensure any reconnect while loop to be stopped
2. Shutdown Handler will teardown and dispose existing channel if it exists. 
