### PR TITLE
Delete `nsb.v2.verify-stream-flag-enabled` queue that gets created during feature probing

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ/Connection/ConnectionExtensions.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Connection/ConnectionExtensions.cs
@@ -29,6 +29,7 @@
             {
                 throw new Exception("An unsupported broker configuration was detected. The 'stream_queue' feature flag needs to be enabled.");
             }
+            channel.QueueDelete("nsb.v2.verify-stream-flag-enabled");
         }
     }
 }


### PR DESCRIPTION
The `nsb.v2.verify-stream-flag-enabled` queue gets created during feature probing but the queue is not deleted resulting in a queue on the broker that isn't used.

Now the queue gets deleted after creation to not have this queue on the broker.

- Resolves: https://github.com/Particular/NServiceBus.RabbitMQ/issues/1272