### PR TITLE
Prevent header dictionary resize & span based overloads

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ/Receiving/MessageConverter.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Receiving/MessageConverter.cs
@@ -67,9 +67,9 @@
                 deserializedHeaders[Headers.EnclosedMessageTypes] = properties.Type;
             }
 
-            if (deserializedHeaders.ContainsKey("NServiceBus.RabbitMQ.CallbackQueue"))
+            if (deserializedHeaders.TryGetValue("NServiceBus.RabbitMQ.CallbackQueue", out var callbackQueue))
             {
-                deserializedHeaders[Headers.ReplyToAddress] = deserializedHeaders["NServiceBus.RabbitMQ.CallbackQueue"];
+                deserializedHeaders[Headers.ReplyToAddress] = callbackQueue;
             }
 
             //These headers need to be removed so that they won't be copied to an outgoing message if this message gets forwarded

--- a/src/NServiceBus.Transport.RabbitMQ/Receiving/MessageConverter.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Receiving/MessageConverter.cs
@@ -120,9 +120,9 @@
                 foreach (var kvp in dictionary)
                 {
                     sb.Append(kvp.Key);
-                    sb.Append("=");
+                    sb.Append('=');
                     sb.Append(ValueToString(kvp.Value));
-                    sb.Append(",");
+                    sb.Append(',');
                 }
 
                 if (sb.Length > 0)
@@ -140,7 +140,7 @@
                 foreach (var entry in list)
                 {
                     sb.Append(ValueToString(entry));
-                    sb.Append(";");
+                    sb.Append(';');
                 }
 
                 if (sb.Length > 0)

--- a/src/NServiceBus.Transport.RabbitMQ/Receiving/MessageConverter.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Receiving/MessageConverter.cs
@@ -51,6 +51,11 @@
                 deserializedHeaders[Headers.ReplyToAddress] = properties.ReplyTo;
             }
 
+            if (deserializedHeaders.TryGetValue("NServiceBus.RabbitMQ.CallbackQueue", out var callbackQueue))
+            {
+                deserializedHeaders[Headers.ReplyToAddress] = callbackQueue;
+            }
+
             if (properties.IsCorrelationIdPresent())
             {
                 deserializedHeaders[Headers.CorrelationId] = properties.CorrelationId;
@@ -65,11 +70,6 @@
             if (!deserializedHeaders.ContainsKey(Headers.EnclosedMessageTypes) && properties.IsTypePresent())
             {
                 deserializedHeaders[Headers.EnclosedMessageTypes] = properties.Type;
-            }
-
-            if (deserializedHeaders.TryGetValue("NServiceBus.RabbitMQ.CallbackQueue", out var callbackQueue))
-            {
-                deserializedHeaders[Headers.ReplyToAddress] = callbackQueue;
             }
 
             //These headers need to be removed so that they won't be copied to an outgoing message if this message gets forwarded

--- a/src/NServiceBus.Transport.RabbitMQ/Receiving/MessageConverter.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Receiving/MessageConverter.cs
@@ -110,7 +110,7 @@
         {
             if (value is byte[] bytes)
             {
-                return Encoding.UTF8.GetString(bytes);
+                return Encoding.UTF8.GetString(bytes.AsSpan());
             }
 
             if (value is Dictionary<string, object> dictionary)

--- a/src/NServiceBus.Transport.RabbitMQ/Receiving/MessageConverter.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Receiving/MessageConverter.cs
@@ -39,11 +39,11 @@
                 messageHeaders.Remove(BasicPropertiesExtensions.ConfirmationIdHeader);
             }
 
-            // Leaving space for ReplyTo, CorrelationId, DeliveryMode, EnclosedMessageTypes and CallbackQueue conditionally
+            // Leaving space for ReplyTo, CorrelationId, DeliveryMode, EnclosedMessageTypes conditionally
             // added below. This is a bit cumbersome and need to be changed when things are conditionally added below
             // but it prevents the header dictionary from growing and relocating which creates quite a bit of
             // memory allocations and eats up CPU cycles.
-            const int extraCapacity = 5;
+            const int extraCapacity = 4;
             var deserializedHeaders = DeserializeHeaders(messageHeaders, extraCapacity);
 
             if (properties.IsReplyToPresent())

--- a/src/NServiceBus.Transport.RabbitMQ/Sending/BasicPropertiesExtensions.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Sending/BasicPropertiesExtensions.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Globalization;
     using System.Linq;
-    using System.Text;
     using global::RabbitMQ.Client;
 
     static class BasicPropertiesExtensions
@@ -113,7 +112,7 @@
             confirmationId = 0;
 
             return properties.Headers.TryGetValue(ConfirmationIdHeader, out var value) &&
-                ulong.TryParse(Encoding.UTF8.GetString(value as byte[] ?? Array.Empty<byte>()), out confirmationId);
+                ulong.TryParse(value as byte[] ?? [], out confirmationId);
         }
 
         public const string ConfirmationIdHeader = "NServiceBus.Transport.RabbitMQ.ConfirmationId";


### PR DESCRIPTION
The message converter resizing in SC accounts for 20% of the allocation for header dictionaries

<img width="1254" alt="image" src="https://github.com/Particular/NServiceBus.RabbitMQ/assets/174258/d970e439-acb6-46a0-a30c-0cb827f5ddbe">

Before

<img width="741" alt="image" src="https://github.com/Particular/NServiceBus.RabbitMQ/assets/174258/f00e767b-d2ca-4fe1-a409-6f25327396ae">


After

<img width="753" alt="image" src="https://github.com/Particular/NServiceBus.RabbitMQ/assets/174258/66860bec-7a79-4fb3-9c4a-5f58d7e12f8f">


