### PR TITLE
log a warning instead of info when reconnecting with the broker failed

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ/Connection/ChannelProvider.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Connection/ChannelProvider.cs
@@ -53,7 +53,7 @@ namespace NServiceBus.Transport.RabbitMQ
                 }
                 catch (Exception ex)
                 {
-                    Logger.InfoFormat("'{0}': Reconnecting to the broker failed: {1}", connectionName, ex);
+                    Logger.WarnFormat("'{0}': Reconnecting to the broker failed: {1}", connectionName, ex);
                 }
             }
 


### PR DESCRIPTION
Currently, we log only a single warning when the connection fails and then only info while reconnection attempts are made. E.g.

```
[14:53:49 WRN] [RabbitMQ.Client.IConnection] 'TestDomain Publish' connection shutdown: AMQP close-reason, initiated by Peer, code=320, text='CONNECTION_FORCED - broker forced connection closure with reason 'shutdown'', classId=0, methodId=0
[14:53:49 INF] [NServiceBus.Transport.RabbitMQ.ChannelProvider] 'TestDomain Publish': Attempting to reconnect in 10 seconds.
[14:54:04 INF] [NServiceBus.Transport.RabbitMQ.ChannelProvider] 'TestDomain Publish': Reconnecting to the broker failed:
RabbitMQ.Client.Exceptions.BrokerUnreachableException: None of the specified endpoints were reachable
-- STACK TRACE EXCLUDED--
[14:54:04 INF] [NServiceBus.Transport.RabbitMQ.ChannelProvider] 'TestDomain Publish': Attempting to reconnect in 10 seconds.
```

This means it is not possible to be aware of continued connection failure by monitoring warnings.

With this change, we log a warning each time the reconnection fails, making it possible to be aware of continued connection failure by monitoring warnings.