### PR TITLE
Optimize the delay delivery routing key calculation for throughput and fewer allocations

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine/NServiceBus.Transport.RabbitMQ.CommandLine.csproj
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine/NServiceBus.Transport.RabbitMQ.CommandLine.csproj
@@ -11,6 +11,7 @@
     <Nullable>enable</Nullable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBus.snk</AssemblyOriginatorKeyFile>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Transport.RabbitMQ/DelayedDelivery/DelayInfrastructure.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/DelayedDelivery/DelayInfrastructure.cs
@@ -87,7 +87,7 @@
 
             startingDelayLevel = 0;
 
-            IntPtr addr = (IntPtr)Unsafe.AsPointer(ref startingDelayLevel);
+            var addr = (IntPtr)Unsafe.AsPointer(ref startingDelayLevel);
             return string.Create((2 * MaxLevel) + 2 + address.Length, (address, delayInSeconds, addr), Action);
 
             static void Action(Span<char> span, (string address, int, IntPtr) state)
@@ -99,16 +99,16 @@
 
                 var bitVector = new BitVector32(delayInSeconds);
 
-                int index = 0;
+                var index = 0;
                 for (var level = MaxLevel; level >= 0; level--)
                 {
-                    bool flag = bitVector[mask << level];
-                    if (startingDelayLevel == 0 && flag)
+                    var bitFlag = bitVector[mask << level];
+                    if (startingDelayLevel == 0 && bitFlag)
                     {
                         startingDelayLevel = level;
                     }
 
-                    span[index++] = flag ? '1' : '0';
+                    span[index++] = bitFlag ? '1' : '0';
                     span[index++] = '.';
                 }
 

--- a/src/NServiceBus.Transport.RabbitMQ/DelayedDelivery/DelayInfrastructure.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/DelayedDelivery/DelayInfrastructure.cs
@@ -1,8 +1,8 @@
 ﻿namespace NServiceBus.Transport.RabbitMQ
 {
     using System;
-    using System.Collections;
     using System.Collections.Generic;
+    using System.Collections.Specialized;
     using System.Text;
     using global::RabbitMQ.Client;
 
@@ -85,22 +85,23 @@
                 delayInSeconds = 0;
             }
 
-            var bitArray = new BitArray(new[] { delayInSeconds });
+            var bitVector = new BitVector32(delayInSeconds);
             var sb = new StringBuilder();
             startingDelayLevel = 0;
 
+            var mask = BitVector32.CreateMask();
             for (var level = MaxLevel; level >= 0; level--)
             {
-                if (startingDelayLevel == 0 && bitArray[level])
+                bool flag = bitVector[mask << level];
+                if (startingDelayLevel == 0 && flag)
                 {
                     startingDelayLevel = level;
                 }
 
-                sb.Append(bitArray[level] ? "1." : "0.");
+                sb.Append(flag ? "1." : "0.");
             }
 
             sb.Append(address);
-
             return sb.ToString();
         }
     }

--- a/src/NServiceBus.Transport.RabbitMQ/DelayedDelivery/DelayInfrastructure.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/DelayedDelivery/DelayInfrastructure.cs
@@ -8,10 +8,10 @@
 
     static class DelayInfrastructure
     {
-        const int maxNumberOfBitsToUse = 28;
+        const int MaxNumberOfBitsToUse = 28;
 
-        public const int MaxLevel = maxNumberOfBitsToUse - 1;
-        public const int MaxDelayInSeconds = (1 << maxNumberOfBitsToUse) - 1;
+        public const int MaxLevel = MaxNumberOfBitsToUse - 1;
+        public const int MaxDelayInSeconds = (1 << MaxNumberOfBitsToUse) - 1;
         public const string DelayHeader = "NServiceBus.Transport.RabbitMQ.DelayInSeconds";
         public const string XDeathHeader = "x-death";
         public const string XFirstDeathExchangeHeader = "x-first-death-exchange";

--- a/src/NServiceBus.Transport.RabbitMQ/NServiceBus.Transport.RabbitMQ.csproj
+++ b/src/NServiceBus.Transport.RabbitMQ/NServiceBus.Transport.RabbitMQ.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBus.snk</AssemblyOriginatorKeyFile>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Based upon #1412 

This PR optimizes the delay delivery routing key algorithm to:

- No longer use the BitArray which is a class that leads to allocations and internally copies the array passed
- No longer use the string builder which allocates quite a bit of char array garbage

The routing key length is well-defined by the number of levels we allow plus the space needed for the address. This means we can use `string.Create` to get rid of the `StringBuilder`.

As a replacement for the `BitArray` the `BitVector32` is a nice fit which is a struct.

To avoid having to loop through the bit vector multiple times or encoding some custom string parts into the string created to then splice the delayLevel out again I had to do a bit of more advanced trickery to be able to write the delayLevel which requires some unsafe declaration. That is fine though and even something the underlying RabbitMQ client uses.

![image](https://github.com/Particular/NServiceBus.RabbitMQ/assets/174258/96213750-8be8-47b4-8945-d192fe38f6ae)

<details>

## Benchmark

```csharp
using System;
using System.Collections;
using System.Collections.Generic;
using System.Collections.Specialized;
using System.Runtime.CompilerServices;
using System.Text;
using BenchmarkDotNet.Attributes;

namespace MicroBenchmarks.RabbitMQ;

[SimpleJob]
[MemoryDiagnoser]
public class RoutingKey
{
    [Benchmark(Baseline = true)]
    [ArgumentsSource(nameof(Arguments))]
    public string Before(int delay, string address) => CalculateRoutingKeyOld(10, "some-address", out _);
    
    [Benchmark]
    [ArgumentsSource(nameof(Arguments))]
    public string After(int delay, string address) => CalculateRoutingKeyNew(10, "some-address", out _);
    
    public IEnumerable<object[]> Arguments()
    {
        yield return [0, "some-address"];
        yield return [10, "some-address"];
        yield return [MaxDelayInSeconds - 1, "almost-max"];
        yield return [MaxDelayInSeconds, "max"];
    }
    
    public static string CalculateRoutingKeyOld(int delayInSeconds, string address, out int startingDelayLevel)
    {
        if (delayInSeconds < 0)
        {
            delayInSeconds = 0;
        }

        var bitArray = new BitArray(new[] { delayInSeconds });
        var sb = new StringBuilder();
        startingDelayLevel = 0;

        for (var level = MaxLevel; level >= 0; level--)
        {
            if (startingDelayLevel == 0 && bitArray[level])
            {
                startingDelayLevel = level;
            }

            sb.Append(bitArray[level] ? "1." : "0.");
        }

        sb.Append(address);

        return sb.ToString();
    }
    
    public static unsafe string CalculateRoutingKeyNew(int delayInSeconds, string address, out int startingDelayLevel)
    {
        if (delayInSeconds < 0)
        {
            delayInSeconds = 0;
        }

        startingDelayLevel = 0;

        fixed (int* startingDelayLevelPtr = &startingDelayLevel)
        {
            var addr = (IntPtr)startingDelayLevelPtr;

            return string.Create((2 * MaxLevel) + 2 + address.Length, (address, delayInSeconds, addr), Action);

            static void Action(Span<char> span, (string address, int, IntPtr) state)
            {
                var (address, delayInSeconds, startingDelayLevelPtr) = state;

                var startingDelayLevel = 0;
                var mask = BitVector32.CreateMask();

                var bitVector = new BitVector32(delayInSeconds);

                var index = 0;
                for (var level = MaxLevel; level >= 0; level--)
                {
                    var flag = bitVector[mask << level];
                    if (startingDelayLevel == 0 && flag)
                    {
                        startingDelayLevel = level;
                    }

                    span[index++] = flag ? '1' : '0';
                    span[index++] = '.';
                }

                address.AsSpan().CopyTo(span[index..]);

                Unsafe.Write(startingDelayLevelPtr.ToPointer(), startingDelayLevel);
            }
        }
    }
    
    const int maxNumberOfBitsToUse = 28;

    public const int MaxLevel = maxNumberOfBitsToUse - 1;
    public const int MaxDelayInSeconds = (1 << maxNumberOfBitsToUse) - 1;
}
```
</details>
