### PR TITLE
Add a constructor parameter to not create the delayed delivery infrastructure

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -17,6 +17,7 @@ namespace NServiceBus
     public class RabbitMQTransport : NServiceBus.Transport.TransportDefinition
     {
         public RabbitMQTransport(NServiceBus.RoutingTopology routingTopology, string connectionString) { }
+        public RabbitMQTransport(NServiceBus.RoutingTopology routingTopology, string connectionString, bool enableDelayedDelivery) { }
         public System.Security.Cryptography.X509Certificates.X509Certificate2 ClientCertificate { get; set; }
         public System.TimeSpan HeartbeatInterval { get; set; }
         public System.Func<RabbitMQ.Client.Events.BasicDeliverEventArgs, string> MessageIdStrategy { get; set; }

--- a/src/NServiceBus.Transport.RabbitMQ.TransportTests/ConfigureRabbitMQTransportInfrastructure.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.TransportTests/ConfigureRabbitMQTransportInfrastructure.cs
@@ -16,7 +16,7 @@ class ConfigureRabbitMQTransportInfrastructure : IConfigureTransportInfrastructu
     {
         var connectionString = Environment.GetEnvironmentVariable("RabbitMQTransport_ConnectionString") ?? "host=localhost";
 
-        var transport = new RabbitMQTransport(RoutingTopology.Conventional(QueueType.Classic), connectionString);
+        var transport = new RabbitMQTransport(RoutingTopology.Conventional(QueueType.Classic), connectionString, false, false);
 
         return transport;
     }

--- a/src/NServiceBus.Transport.RabbitMQ.TransportTests/ConfigureRabbitMQTransportInfrastructure.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.TransportTests/ConfigureRabbitMQTransportInfrastructure.cs
@@ -16,7 +16,7 @@ class ConfigureRabbitMQTransportInfrastructure : IConfigureTransportInfrastructu
     {
         var connectionString = Environment.GetEnvironmentVariable("RabbitMQTransport_ConnectionString") ?? "host=localhost";
 
-        var transport = new RabbitMQTransport(RoutingTopology.Conventional(QueueType.Classic), connectionString, false, false);
+        var transport = new RabbitMQTransport(RoutingTopology.Conventional(QueueType.Classic), connectionString, false);
 
         return transport;
     }

--- a/src/NServiceBus.Transport.RabbitMQ.TransportTests/When_delayed_delivery_is_disabled.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.TransportTests/When_delayed_delivery_is_disabled.cs
@@ -1,0 +1,26 @@
+﻿namespace NServiceBus.Transport.RabbitMQ.TransportTests
+{
+    using System;
+    using System.Threading.Tasks;
+    using DelayedDelivery;
+    using NServiceBus.TransportTests;
+    using NUnit.Framework;
+
+    public class When_delayed_delivery_is_disabled : NServiceBusTransportTest
+    {
+        [TestCase(TransportTransactionMode.ReceiveOnly)]
+        public async Task Should_throw_when_sending(TransportTransactionMode transactionMode)
+        {
+            await StartPump(
+                (context, _) => Task.FromResult(0),
+                (_, __) => Task.FromResult(ErrorHandleResult.RetryRequired),
+                transactionMode);
+
+            Assert.ThrowsAsync<Exception>(async () =>
+            {
+                var dispatchProperties = new DispatchProperties { DelayDeliveryWith = new DelayDeliveryWith(TimeSpan.FromHours(1)) };
+                await SendMessage(InputQueueName, [], null, dispatchProperties);
+            });
+        }
+    }
+}

--- a/src/NServiceBus.Transport.RabbitMQ/RabbitMQTransport.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/RabbitMQTransport.cs
@@ -46,12 +46,11 @@
         /// </summary>
         /// <param name="routingTopology">The routing topology to use.</param>
         /// <param name="connectionString">The connection string to use when connecting to the broker.</param>
-        /// <param name="enableDelayedDelivery"></param>
-        /// <param name="enablePublishSubscribe"></param>
-        public RabbitMQTransport(RoutingTopology routingTopology, string connectionString, bool enableDelayedDelivery, bool enablePublishSubscribe)
+        /// <param name="enableDelayedDelivery">Should the delayed delivery infrastructure be created by the endpoint</param>
+        public RabbitMQTransport(RoutingTopology routingTopology, string connectionString, bool enableDelayedDelivery)
             : base(TransportTransactionMode.ReceiveOnly,
                 supportsDelayedDelivery: enableDelayedDelivery,
-                supportsPublishSubscribe: enablePublishSubscribe,
+                supportsPublishSubscribe: true,
                 supportsTTBR: true)
         {
             ArgumentNullException.ThrowIfNull(routingTopology);

--- a/src/NServiceBus.Transport.RabbitMQ/RabbitMQTransport.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/RabbitMQTransport.cs
@@ -41,6 +41,26 @@
             ConnectionConfiguration = ConnectionConfiguration.Create(connectionString);
         }
 
+        /// <summary>
+        /// Creates a new instance of the RabbitMQ transport.
+        /// </summary>
+        /// <param name="routingTopology">The routing topology to use.</param>
+        /// <param name="connectionString">The connection string to use when connecting to the broker.</param>
+        /// <param name="enableDelayedDelivery"></param>
+        /// <param name="enablePublishSubscribe"></param>
+        public RabbitMQTransport(RoutingTopology routingTopology, string connectionString, bool enableDelayedDelivery, bool enablePublishSubscribe)
+            : base(TransportTransactionMode.ReceiveOnly,
+                supportsDelayedDelivery: enableDelayedDelivery,
+                supportsPublishSubscribe: enablePublishSubscribe,
+                supportsTTBR: true)
+        {
+            ArgumentNullException.ThrowIfNull(routingTopology);
+            ArgumentNullException.ThrowIfNull(connectionString);
+
+            RoutingTopology = routingTopology.Create();
+            ConnectionConfiguration = ConnectionConfiguration.Create(connectionString);
+        }
+
         internal ConnectionConfiguration ConnectionConfiguration { get; set; }
 
         internal IRoutingTopology RoutingTopology { get; set; }
@@ -174,7 +194,7 @@
 
             var infra = new RabbitMQTransportInfrastructure(hostSettings, receivers, connectionFactory,
                 RoutingTopology, channelProvider, converter, TimeToWaitBeforeTriggeringCircuitBreaker,
-                PrefetchCountCalculation, NetworkRecoveryInterval);
+                PrefetchCountCalculation, NetworkRecoveryInterval, SupportsDelayedDelivery);
 
             if (hostSettings.SetupInfrastructure)
             {

--- a/src/NServiceBus.Transport.RabbitMQ/Sending/MessageDispatcher.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Sending/MessageDispatcher.cs
@@ -53,7 +53,7 @@
 
         Task SendMessage(UnicastTransportOperation transportOperation, ConfirmsAwareChannel channel, CancellationToken cancellationToken)
         {
-            ThrowIfDelayedDeliveryDisabled(transportOperation);
+            ThrowIfDelayedDeliveryIsDisabledAndMessageIsDelayed(transportOperation);
 
             var message = transportOperation.Message;
 
@@ -65,7 +65,7 @@
 
         Task PublishMessage(MulticastTransportOperation transportOperation, ConfirmsAwareChannel channel, CancellationToken cancellationToken)
         {
-            ThrowIfDelayedDeliveryDisabled(transportOperation);
+            ThrowIfDelayedDeliveryIsDisabledAndMessageIsDelayed(transportOperation);
 
             var message = transportOperation.Message;
 
@@ -75,7 +75,7 @@
             return channel.PublishMessage(transportOperation.MessageType, message, properties, cancellationToken);
         }
 
-        void ThrowIfDelayedDeliveryDisabled(IOutgoingTransportOperation transportOperation)
+        void ThrowIfDelayedDeliveryIsDisabledAndMessageIsDelayed(IOutgoingTransportOperation transportOperation)
         {
             if (!supportsDelayedDelivery &&
                 (transportOperation.Properties.DelayDeliveryWith != null ||

--- a/src/NServiceBus.Transport.RabbitMQ/Sending/MessageDispatcher.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Sending/MessageDispatcher.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Transport.RabbitMQ
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
@@ -7,10 +8,12 @@
     class MessageDispatcher : IMessageDispatcher
     {
         readonly ChannelProvider channelProvider;
+        readonly bool supportsDelayedDelivery;
 
-        public MessageDispatcher(ChannelProvider channelProvider)
+        public MessageDispatcher(ChannelProvider channelProvider, bool supportsDelayedDelivery)
         {
             this.channelProvider = channelProvider;
+            this.supportsDelayedDelivery = supportsDelayedDelivery;
         }
 
         public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, CancellationToken cancellationToken = default)
@@ -50,6 +53,8 @@
 
         Task SendMessage(UnicastTransportOperation transportOperation, ConfirmsAwareChannel channel, CancellationToken cancellationToken)
         {
+            ThrowIfDelayedDeliveryDisabled(transportOperation);
+
             var message = transportOperation.Message;
 
             var properties = channel.CreateBasicProperties();
@@ -60,6 +65,8 @@
 
         Task PublishMessage(MulticastTransportOperation transportOperation, ConfirmsAwareChannel channel, CancellationToken cancellationToken)
         {
+            ThrowIfDelayedDeliveryDisabled(transportOperation);
+
             var message = transportOperation.Message;
 
             var properties = channel.CreateBasicProperties();
@@ -68,5 +75,14 @@
             return channel.PublishMessage(transportOperation.MessageType, message, properties, cancellationToken);
         }
 
+        void ThrowIfDelayedDeliveryDisabled(IOutgoingTransportOperation transportOperation)
+        {
+            if (!supportsDelayedDelivery &&
+                (transportOperation.Properties.DelayDeliveryWith != null ||
+                 transportOperation.Properties.DoNotDeliverBefore != null))
+            {
+                throw new Exception("Delayed delivery has been disabled in the transport settings.");
+            }
+        }
     }
 }


### PR DESCRIPTION
Adds a constructor parameter to disable the creation of the delayed delivery infrastructure.

Use cases include:

* Integration with existing systems
* Prevent unnecessary creation of delayed delivery infrastructure when not needed (e.g. within ServiceControl)
