### PR TITLE
Make ConnectionConfiguration public

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ.TransportTests/NServiceBus.Transport.RabbitMQ.TransportTests.csproj
+++ b/src/NServiceBus.Transport.RabbitMQ.TransportTests/NServiceBus.Transport.RabbitMQ.TransportTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -20,10 +20,6 @@
     <PackageReference Include="BitFaster.Caching" Version="2.5.2" />
     <PackageReference Include="NServiceBus.TransportTests.Sources" Version="9.2.2" />
     <PackageReference Include="RabbitMQ.Client" Version="7.0.0-rc.11" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Include="..\NServiceBus.Transport.RabbitMQ\Configuration\ConnectionConfiguration.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.Transport.RabbitMQ/Configuration/ConnectionConfiguration.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Configuration/ConnectionConfiguration.cs
@@ -6,7 +6,10 @@
     using System.Linq;
     using System.Text;
 
-    class ConnectionConfiguration
+    /// <summary>
+    /// Configuration container for the RabbitMQ connection.
+    /// </summary>
+    public class ConnectionConfiguration
     {
         const bool defaultUseTls = false;
         const int defaultPort = 5672;
@@ -15,16 +18,34 @@
         const string defaultUserName = "guest";
         const string defaultPassword = "guest";
 
+        /// <summary>
+        /// Gets the broker host.
+        /// </summary>
         public string Host { get; }
 
+        /// <summary>
+        /// Gets the port the broker uses.
+        /// </summary>
         public int Port { get; }
 
+        /// <summary>
+        /// Gets the virtual host.
+        /// </summary>
         public string VirtualHost { get; }
 
+        /// <summary>
+        /// Gets the user name used for the connection.
+        /// </summary>
         public string UserName { get; }
 
+        /// <summary>
+        /// Gets the password used for the connection.
+        /// </summary>
         public string Password { get; }
 
+        /// <summary>
+        /// Gets whether TLS should be used.
+        /// </summary>
         public bool UseTls { get; }
 
         ConnectionConfiguration(
@@ -43,6 +64,11 @@
             UseTls = useTls;
         }
 
+        /// <summary>
+        /// Parses the connection string and returns the connection information.
+        /// </summary>
+        /// <param name="connectionString">The connection string to be parsed.</param>
+        /// <returns></returns>        
         public static ConnectionConfiguration Create(string connectionString)
         {
             Dictionary<string, string> dictionary;


### PR DESCRIPTION
Make ConnectionConfiguration public in order to be re-usable.

Fixes #1470