### PR TITLE
Add message count property to Queue model

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ/Administration/ManagementApi/Models/Queue.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Administration/ManagementApi/Models/Queue.cs
@@ -26,6 +26,10 @@ class Queue
     [JsonPropertyName("policy")]
     public string? AppliedPolicyName { get; set; }
 
+    // For ServiceControl queue length provider
+    [JsonPropertyName("messages")]
+    public long MessageCount { get; set; }
+
     // For ServiceControl licensing component
     [JsonPropertyName("message_stats")]
     public QueueMessageStats? MessageStats { get; set; }


### PR DESCRIPTION
This PR enable the management client to return the count of messages in a queue via the `messages` value from the management API.

