### PR TITLE
Add option to specify just management API username and password

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine/BrokerConnectionBinder.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine/BrokerConnectionBinder.cs
@@ -44,6 +44,10 @@
                     managementApiConfiguration = new(managementApiUrl);
                 }
             }
+            else if (managementApiUrl is null && managementApiUserName is not null && managementApiPassword is not null)
+            {
+                managementApiConfiguration = new(managementApiUserName, managementApiPassword);
+            }
 
             var managementClient = new ManagementClient(connectionConfiguration, managementApiConfiguration);
             var brokerVerifier = new BrokerVerifier(managementClient, true);

--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine/BrokerVerifierBinder.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine/BrokerVerifierBinder.cs
@@ -31,6 +31,10 @@
                     managementApiConfiguration = new(managementApiUrl);
                 }
             }
+            else if (managementApiUrl is null && managementApiUserName is not null && managementApiPassword is not null)
+            {
+                managementApiConfiguration = new(managementApiUserName, managementApiPassword);
+            }
 
             var managementClient = new ManagementClient(connectionConfiguration, managementApiConfiguration);
             var brokerVerifier = new BrokerVerifier(managementClient, true);

--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine/SharedOptions.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine/SharedOptions.cs
@@ -40,7 +40,7 @@
         {
             var managementApiUserNameOption = new Option<string>(
                 name: "--managementApiUserName",
-                description: $"Overrides the value inferred from the connection string. If provided, --managementApiUrl and --managementApiPassword must also be provided.");
+                description: $"Overrides the value inferred from the connection string. If provided, --managementApiPassword must also be provided or this option will be ignored.");
 
             return managementApiUserNameOption;
         }
@@ -49,7 +49,7 @@
         {
             var managementApiPasswordOption = new Option<string>(
                 name: "--managementApiPassword",
-                description: $"Overrides the value inferred from the connection string. If provided, --managementApiUrl and --managementApiUserName must also be provided.");
+                description: $"Overrides the value inferred from the connection string. If provided, --managementApiUserName must also be provided or this option will be ignored.");
 
             return managementApiPasswordOption;
         }

--- a/src/NServiceBus.Transport.RabbitMQ.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -6,9 +6,10 @@ namespace NServiceBus
     public class ManagementApiConfiguration
     {
         public ManagementApiConfiguration(string url) { }
+        public ManagementApiConfiguration(string userName, string password) { }
         public ManagementApiConfiguration(string url, string userName, string password) { }
         public string? Password { get; }
-        public string Url { get; }
+        public string? Url { get; }
         public string? UserName { get; }
     }
     public static class NonPersistentDeliveryModeExtensions
@@ -54,6 +55,7 @@ namespace NServiceBus
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> DisableRemoteCertificateValidation(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions) { }
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> DoNotValidateDeliveryLimits(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions) { }
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> ManagementApiConfiguration(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions, string url) { }
+        public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> ManagementApiConfiguration(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions, string userName, string password) { }
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> ManagementApiConfiguration(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions, string url, string userName, string password) { }
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> PrefetchCount(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions, ushort prefetchCount) { }
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> PrefetchMultiplier(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions, int prefetchMultiplier) { }

--- a/src/NServiceBus.Transport.RabbitMQ/Administration/ManagementApi/ManagementClient.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Administration/ManagementApi/ManagementClient.cs
@@ -26,7 +26,7 @@ class ManagementClient : IDisposable
 
         UriBuilder uriBuilder;
 
-        if (managementApiConfiguration is not null)
+        if (managementApiConfiguration?.Url is not null)
         {
             uriBuilder = new UriBuilder(managementApiConfiguration.Url)
             {
@@ -46,8 +46,8 @@ class ManagementClient : IDisposable
                 Scheme = connectionConfiguration.UseTls ? "https" : "http",
                 Host = connectionConfiguration.Host,
                 Port = connectionConfiguration.UseTls ? defaultManagementTlsPort : defaultManagementPort,
-                UserName = connectionConfiguration.UserName,
-                Password = connectionConfiguration.Password
+                UserName = managementApiConfiguration?.UserName ?? connectionConfiguration.UserName,
+                Password = managementApiConfiguration?.Password ?? connectionConfiguration.Password
             };
         }
 

--- a/src/NServiceBus.Transport.RabbitMQ/Configuration/ManagementApiConfiguration.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Configuration/ManagementApiConfiguration.cs
@@ -23,6 +23,20 @@ namespace NServiceBus
         /// <summary>
         /// Initializes a new instance of the <see cref="ManagementApiConfiguration"/> class.
         /// </summary>
+        /// <param name="userName">The user name to use when connecting to the RabbitMQ management API.</param>
+        /// <param name="password">The password to use when connecting to the RabbitMQ management API.</param>
+        public ManagementApiConfiguration(string userName, string password)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(userName);
+            ArgumentException.ThrowIfNullOrWhiteSpace(password);
+
+            UserName = userName;
+            Password = password;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ManagementApiConfiguration"/> class.
+        /// </summary>
         /// <param name="url">The URL to use when connecting to the RabbitMQ management API.</param>
         /// <param name="userName">The user name to use when connecting to the RabbitMQ management API.</param>
         /// <param name="password">The password to use when connecting to the RabbitMQ management API.</param>
@@ -40,7 +54,7 @@ namespace NServiceBus
         /// <summary>
         /// The URL to use when connecting to the RabbitMQ management API.
         /// </summary>
-        public string Url { get; }
+        public string? Url { get; }
 
         /// <summary>
         /// The user name to use when connecting to the RabbitMQ management API.

--- a/src/NServiceBus.Transport.RabbitMQ/Configuration/RabbitMQTransportSettingsExtensions.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Configuration/RabbitMQTransportSettingsExtensions.cs
@@ -184,6 +184,26 @@
         /// The RabbitMQ management API configuration to use instead of inferring values from the connection string.
         /// </summary>
         /// <param name="transportExtensions">The transport settings.</param>
+        /// <param name="userName">The user name to use when connecting to the RabbitMQ management API.</param>
+        /// <param name="password">The password to use when connecting to the RabbitMQ management API.</param>
+        [PreObsolete("https://github.com/Particular/NServiceBus/issues/6811",
+            ReplacementTypeOrMember = "RabbitMQTransport.ManagementApiConfiguration",
+            Message = "The configuration has been moved to RabbitMQTransport class.",
+            Note = "Should not be converted to an ObsoleteEx until API mismatch described in issue is resolved.")]
+        public static TransportExtensions<RabbitMQTransport> ManagementApiConfiguration(this TransportExtensions<RabbitMQTransport> transportExtensions, string userName, string password)
+        {
+            ArgumentNullException.ThrowIfNull(transportExtensions);
+            ArgumentException.ThrowIfNullOrWhiteSpace(userName);
+            ArgumentException.ThrowIfNullOrWhiteSpace(password);
+
+            transportExtensions.Transport.ManagementApiConfiguration = new(userName, password);
+            return transportExtensions;
+        }
+
+        /// <summary>
+        /// The RabbitMQ management API configuration to use instead of inferring values from the connection string.
+        /// </summary>
+        /// <param name="transportExtensions">The transport settings.</param>
         /// <param name="url">The URL to use when connecting to the RabbitMQ management API.</param>
         /// <param name="userName">The user name to use when connecting to the RabbitMQ management API.</param>
         /// <param name="password">The password to use when connecting to the RabbitMQ management API.</param>


### PR DESCRIPTION
This PR adds the option to override just management API username and password and let the URL be inferred from the connection string.