### PR TITLE
Rename ChannelProvider CreateConnection to Initialize

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ.Tests/Connection/ChannelProviderTests.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/Connection/ChannelProviderTests.cs
@@ -15,7 +15,7 @@ namespace NServiceBus.Transport.RabbitMQ.Tests.ConnectionString
         public async Task Should_recover_connection_and_dispose_old_one_when_connection_shutdown()
         {
             var channelProvider = new TestableChannelProvider();
-            await channelProvider.CreateConnection();
+            await channelProvider.Initialize();
 
             var publishConnection = channelProvider.PublishConnections.Dequeue();
             await publishConnection.RaiseConnectionShutdown(new ShutdownEventArgs(ShutdownInitiator.Library, 0, "Test"));
@@ -34,7 +34,7 @@ namespace NServiceBus.Transport.RabbitMQ.Tests.ConnectionString
         public async Task Should_dispose_connection_when_disposed()
         {
             var channelProvider = new TestableChannelProvider();
-            await channelProvider.CreateConnection();
+            await channelProvider.Initialize();
 
             var publishConnection = channelProvider.PublishConnections.Dequeue();
             await channelProvider.DisposeAsync();
@@ -46,7 +46,7 @@ namespace NServiceBus.Transport.RabbitMQ.Tests.ConnectionString
         public async Task Should_not_attempt_to_recover_during_dispose_when_retry_delay_still_pending()
         {
             var channelProvider = new TestableChannelProvider();
-            await channelProvider.CreateConnection();
+            await channelProvider.Initialize();
 
             var publishConnection = channelProvider.PublishConnections.Dequeue();
             await publishConnection.RaiseConnectionShutdown(new ShutdownEventArgs(ShutdownInitiator.Library, 0, "Test"));
@@ -65,7 +65,7 @@ namespace NServiceBus.Transport.RabbitMQ.Tests.ConnectionString
         public async Task Should_dispose_newly_established_connection()
         {
             var channelProvider = new TestableChannelProvider();
-            await channelProvider.CreateConnection();
+            await channelProvider.Initialize();
 
             var publishConnection = channelProvider.PublishConnections.Dequeue();
             await publishConnection.RaiseConnectionShutdown(new ShutdownEventArgs(ShutdownInitiator.Library, 0, "Test"));

--- a/src/NServiceBus.Transport.RabbitMQ/Connection/ChannelProvider.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Connection/ChannelProvider.cs
@@ -22,9 +22,7 @@ namespace NServiceBus.Transport.RabbitMQ
             channels = new ConcurrentQueue<ConfirmsAwareChannel>();
         }
 
-        public async Task<IConnection> CreateConnection(CancellationToken cancellationToken = default) => connection = await CreateConnectionWithShutdownListener(cancellationToken).ConfigureAwait(false);
-
-        protected virtual Task<IConnection> CreatePublishConnection(CancellationToken cancellationToken = default) => connectionFactory.CreatePublishConnection(cancellationToken);
+        public async Task Initialize(CancellationToken cancellationToken = default) => connection = await CreateConnectionWithShutdownListener(cancellationToken).ConfigureAwait(false);
 
         async Task<IConnection> CreateConnectionWithShutdownListener(CancellationToken cancellationToken)
         {
@@ -32,6 +30,8 @@ namespace NServiceBus.Transport.RabbitMQ
             newConnection.ConnectionShutdownAsync += Connection_ConnectionShutdown;
             return newConnection;
         }
+
+        protected virtual Task<IConnection> CreatePublishConnection(CancellationToken cancellationToken = default) => connectionFactory.CreatePublishConnection(cancellationToken);
 
 #pragma warning disable PS0018
         Task Connection_ConnectionShutdown(object? sender, ShutdownEventArgs e)

--- a/src/NServiceBus.Transport.RabbitMQ/RabbitMQTransport.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/RabbitMQTransport.cs
@@ -234,7 +234,7 @@
             await brokerVerifier.VerifyRequirements(cancellationToken).ConfigureAwait(false);
 
             var channelProvider = new ChannelProvider(connectionFactory, NetworkRecoveryInterval, RoutingTopology);
-            await channelProvider.CreateConnection(cancellationToken).ConfigureAwait(false);
+            await channelProvider.Initialize(cancellationToken).ConfigureAwait(false);
 
             var converter = new MessageConverter(MessageIdStrategy);
 


### PR DESCRIPTION
This PR updates the `CreateConnection` method of the `ChannelProvider` class:

- It has been renamed to `Initialize` to make its purpose clearer
- The return type has been changed to `Task` instead of `Task<IConnection>` because the connection is an implementation detail of the class and should be not be exposed.

The ordering of the methods related to `Initialize` has been tweaked as well.