### PR TITLE
Updates to management client and broker verifier

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine/BrokerConnectionBinder.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine/BrokerConnectionBinder.cs
@@ -23,6 +23,11 @@
             var connectionString = GetConnectionString(connectionStringOptionValue, connectionStringEnvOptionValue);
 
             var connectionConfiguration = ConnectionConfiguration.Create(connectionString);
+            var managementApiConfiguration = ManagementApiConfiguration.Create(managementApiUrl, managementApiUserName, managementApiPassword);
+
+            var managementClient = new ManagementClient(connectionConfiguration, managementApiConfiguration);
+            var brokerVerifier = new BrokerVerifier(managementClient, true);
+
             var certificateCollection = new X509Certificate2Collection();
 
             if (certPath != null)
@@ -31,26 +36,6 @@
                 certificateCollection.Add(certificate);
             }
 
-            ManagementApiConfiguration? managementApiConfiguration = null;
-
-            if (managementApiUrl is not null)
-            {
-                if (managementApiUserName is not null && managementApiPassword is not null)
-                {
-                    managementApiConfiguration = new(managementApiUrl, managementApiUserName, managementApiPassword);
-                }
-                else
-                {
-                    managementApiConfiguration = new(managementApiUrl);
-                }
-            }
-            else if (managementApiUrl is null && managementApiUserName is not null && managementApiPassword is not null)
-            {
-                managementApiConfiguration = new(managementApiUserName, managementApiPassword);
-            }
-
-            var managementClient = new ManagementClient(connectionConfiguration, managementApiConfiguration);
-            var brokerVerifier = new BrokerVerifier(managementClient, true);
             var connectionFactory = new ConnectionFactory("rabbitmq-transport", connectionConfiguration, certificateCollection, disableCertificateValidation, useExternalAuth, TimeSpan.FromSeconds(60), TimeSpan.FromSeconds(10), []);
             var brokerConnection = new BrokerConnection(brokerVerifier, connectionFactory);
 

--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine/BrokerVerifierBinder.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine/BrokerVerifierBinder.cs
@@ -17,24 +17,7 @@
             var connectionString = GetConnectionString(connectionStringOptionValue, connectionStringEnvOptionValue);
 
             var connectionConfiguration = ConnectionConfiguration.Create(connectionString);
-
-            ManagementApiConfiguration? managementApiConfiguration = null;
-
-            if (managementApiUrl is not null)
-            {
-                if (managementApiUserName is not null && managementApiPassword is not null)
-                {
-                    managementApiConfiguration = new(managementApiUrl, managementApiUserName, managementApiPassword);
-                }
-                else
-                {
-                    managementApiConfiguration = new(managementApiUrl);
-                }
-            }
-            else if (managementApiUrl is null && managementApiUserName is not null && managementApiPassword is not null)
-            {
-                managementApiConfiguration = new(managementApiUserName, managementApiPassword);
-            }
+            var managementApiConfiguration = ManagementApiConfiguration.Create(managementApiUrl, managementApiUserName, managementApiPassword);
 
             var managementClient = new ManagementClient(connectionConfiguration, managementApiConfiguration);
             var brokerVerifier = new BrokerVerifier(managementClient, true);

--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine/Commands/Delays/DelaysVerifyCommand.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine/Commands/Delays/DelaysVerifyCommand.cs
@@ -2,139 +2,37 @@
 {
     using System;
     using System.CommandLine;
-    using System.Net.Http.Headers;
-    using System.Text;
-    using System.Text.Json;
-    using System.Text.Json.Serialization;
 
-    class DelaysVerifyCommand
+    class DelaysVerifyCommand(BrokerVerifier brokerVerifier, IConsole console)
     {
         public static Command CreateCommand()
         {
             var command = new Command("verify", "Verify broker requirements for using the v2 delay infrastructure");
 
-            var urlOption = new Option<string>("--url", "The URL of the RabbitMQ management API")
-            {
-                IsRequired = true
-            };
+            var brokerVerifierBinder = SharedOptions.CreateBrokerVerifierBinderWithOptions(command);
 
-            var usernameOption = new Option<string>("--username", "The username for accessing the RabbitMQ management API")
+            command.SetHandler(async (brokerVerifier, console, cancellationToken) =>
             {
-                IsRequired = true
-            };
-
-            var passwordOption = new Option<string>("--password", "The password for accessing the RabbitMQ management API")
-            {
-                IsRequired = true
-            };
-
-            command.AddOption(urlOption);
-            command.AddOption(usernameOption);
-            command.AddOption(passwordOption);
-
-            command.SetHandler(async (url, username, password, console, cancellationToken) =>
-            {
-                var delaysVerify = new DelaysVerifyCommand(url, username, password, console);
+                var delaysVerify = new DelaysVerifyCommand(brokerVerifier, console);
                 await delaysVerify.Run(cancellationToken);
             },
-            urlOption, usernameOption, passwordOption, Bind.FromServiceProvider<IConsole>(), Bind.FromServiceProvider<CancellationToken>());
+            brokerVerifierBinder, Bind.FromServiceProvider<IConsole>(), Bind.FromServiceProvider<CancellationToken>());
 
             return command;
         }
 
-        public DelaysVerifyCommand(string baseUrl, string username, string password, IConsole console)
-        {
-            this.baseUrl = baseUrl;
-            this.username = username;
-            this.password = password;
-            this.console = console;
-        }
-
         public async Task Run(CancellationToken cancellationToken = default)
         {
-            using var httpClient = new HttpClient();
-
-            var authString = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{username}:{password}"));
-            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", authString);
-
-            var serverDetails = await GetServerDetails(httpClient, cancellationToken);
-
-            if (Version.TryParse(serverDetails.Overview?.ProductVersion, out var version) && version < Version.Parse("3.10.0"))
+            try
             {
-                throw new Exception($"Fail: Detected broker version is {serverDetails.Overview.ProductVersion}, at least 3.10.0 is required");
+                await brokerVerifier.Initialize(cancellationToken);
+                await brokerVerifier.VerifyRequirements(cancellationToken);
+
+                console.WriteLine("All checks OK");
             }
-
-            var streamQueueState = serverDetails.FeatureFlags?.SingleOrDefault(fs => fs.Name == "stream_queue");
-
-            if (streamQueueState == null || !streamQueueState.IsEnabled())
+            catch (Exception ex) when (!ex.IsCausedBy(cancellationToken))
             {
-                throw new Exception($"Fail: stream_queue feature flag is not enabled");
-            }
-
-            var quorumQueueState = serverDetails.FeatureFlags?.SingleOrDefault(fs => fs.Name == "quorum_queue");
-
-            if (quorumQueueState == null || !quorumQueueState.IsEnabled())
-            {
-                throw new Exception($"Fail: quorum_queue feature flag is not enabled");
-            }
-
-            console.WriteLine("All checks OK");
-        }
-
-        async Task<ServerDetails> GetServerDetails(HttpClient httpClient, CancellationToken cancellationToken)
-        {
-            return new ServerDetails
-            {
-                Overview = await MakeHttpRequest<Overview>(httpClient, "overview", cancellationToken),
-                FeatureFlags = await MakeHttpRequest<FeatureFlag[]>(httpClient, "feature-flags", cancellationToken)
-            };
-        }
-
-        async Task<T?> MakeHttpRequest<T>(HttpClient httpClient, string urlPart, CancellationToken cancellationToken)
-        {
-            var url = $"{baseUrl}/api/{urlPart}";
-            using var response = await httpClient.GetAsync(url, cancellationToken);
-            response.EnsureSuccessStatusCode();
-
-            var content = await response.Content.ReadAsStringAsync(cancellationToken);
-
-            if (string.IsNullOrEmpty(content))
-            {
-                throw new Exception("Empty response returned for " + url);
-            }
-
-            return JsonSerializer.Deserialize<T>(content);
-        }
-
-        readonly string baseUrl;
-        readonly string username;
-        readonly string password;
-        readonly IConsole console;
-
-        class ServerDetails
-        {
-            public Overview? Overview { get; set; }
-
-            public FeatureFlag[]? FeatureFlags { get; set; }
-        }
-
-        class Overview
-        {
-            [JsonPropertyName("product_version")]
-            public string ProductVersion { get; set; } = string.Empty;
-        }
-
-        class FeatureFlag
-        {
-            [JsonPropertyName("name")]
-            public string Name { get; set; } = string.Empty;
-
-            [JsonPropertyName("state")]
-            public string State { get; set; } = string.Empty;
-
-            public bool IsEnabled()
-            {
-                return State?.ToLower() == "enabled";
+                console.WriteLine($"Fail: {ex.Message}");
             }
         }
     }

--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine/Properties/launchSettings.json
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine/Properties/launchSettings.json
@@ -26,7 +26,12 @@
     "queue migrate": {
       "commandName": "Executable",
       "executablePath": ".\\NServiceBus.Transport.RabbitMQ.CommandLine.exe",
-      "commandLineArgs": "queue migrate-to-quorum Samples.RabbitMQ.SimpleReceiver -c host=localhost"
+      "commandLineArgs": "queue migrate-to-quorum TestEndpoint"
+    },
+    "queue validate delivery limit": {
+      "commandName": "Executable",
+      "executablePath": ".\\NServiceBus.Transport.RabbitMQ.CommandLine.exe",
+      "commandLineArgs": "queue validate-delivery-limit TestEndpoint"
     }
   }
 }

--- a/src/NServiceBus.Transport.RabbitMQ.Tests/BrokerVerifierTests.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/BrokerVerifierTests.cs
@@ -4,7 +4,6 @@ namespace NServiceBus.Transport.RabbitMQ.Tests;
 
 using System;
 using System.Collections.Generic;
-using System.Net;
 using System.Threading.Tasks;
 using NServiceBus.Transport.RabbitMQ.ManagementApi;
 using NUnit.Framework;
@@ -49,9 +48,9 @@ class BrokerVerifierTests
 
         for (int i = 0; i < attempts; i++)
         {
-            var response = await managementClient.GetQueue(queueName);
+            var queue = await managementClient.GetQueue(queueName);
 
-            if (response.StatusCode == HttpStatusCode.OK && response.Value?.DeliveryLimit == -1 && response.Value.AppliedPolicyName == policyName)
+            if (queue.DeliveryLimit == -1 && queue.AppliedPolicyName == policyName)
             {
                 // Policy applied successfully
                 return;

--- a/src/NServiceBus.Transport.RabbitMQ.Tests/BrokerVerifierTests.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/BrokerVerifierTests.cs
@@ -71,7 +71,7 @@ class BrokerVerifierTests
         await brokerVerifier.Initialize();
 
         var exception = Assert.ThrowsAsync<InvalidOperationException>(async () => await brokerVerifier.ValidateDeliveryLimit(queueName));
-        Assert.That(exception.Message, Does.Contain($"Could not get queue details for '{queueName}'."));
+        Assert.That(exception.Message, Does.Contain($"Cannot validate the delivery limit of the '{queueName}' queue because it does not exist."));
     }
 
     [Test]

--- a/src/NServiceBus.Transport.RabbitMQ.Tests/ManagementClientTests.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/ManagementClientTests.cs
@@ -5,7 +5,6 @@ namespace NServiceBus.Transport.RabbitMQ.Tests
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Net;
     using System.Threading.Tasks;
     using NServiceBus.Transport.RabbitMQ.ManagementApi;
     using NUnit.Framework;
@@ -36,11 +35,7 @@ namespace NServiceBus.Transport.RabbitMQ.Tests
 
             var response = await managementClient.GetQueue(queueName);
 
-            Assert.Multiple(() =>
-            {
-                Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
-                Assert.That(response.Value?.Name, Is.EqualTo(queueName));
-            });
+            Assert.That(response.Name, Is.EqualTo(queueName));
         }
 
         [Test]
@@ -50,11 +45,7 @@ namespace NServiceBus.Transport.RabbitMQ.Tests
 
             var response = await managementClient.GetOverview();
 
-            Assert.Multiple(() =>
-            {
-                Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
-                Assert.That(response.Value?.BrokerVersion, Is.Not.Null);
-            });
+            Assert.That(response.BrokerVersion, Is.Not.Null);
         }
 
         [Test]
@@ -64,11 +55,7 @@ namespace NServiceBus.Transport.RabbitMQ.Tests
 
             var response = await managementClient.GetFeatureFlags();
 
-            Assert.Multiple(() =>
-            {
-                Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
-                Assert.That(response.Value, Is.Not.Empty);
-            });
+            Assert.That(response, Is.Not.Empty);
         }
 
         [Test]
@@ -90,9 +77,8 @@ namespace NServiceBus.Transport.RabbitMQ.Tests
             while (true)
             {
                 var response = await managementClient.GetQueues(page++, pageSize);
-                Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
 
-                if (response.Value?.Count(q => q.Name.StartsWith(queueName)) == pageSize)
+                if (response.Queues.Count(q => q.Name.StartsWith(queueName)) == pageSize)
                 {
                     return;
                 }
@@ -115,11 +101,7 @@ namespace NServiceBus.Transport.RabbitMQ.Tests
 
             var response = await managementClient.GetBindingsForQueue(queueName);
 
-            Assert.Multiple(() =>
-            {
-                Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
-                Assert.That(response.Value, Has.Count.EqualTo(2));
-            });
+            Assert.That(response, Has.Count.EqualTo(2));
         }
 
         [Test]
@@ -133,11 +115,7 @@ namespace NServiceBus.Transport.RabbitMQ.Tests
 
             var response = await managementClient.GetBindingsForExchange(destinationExchangeName);
 
-            Assert.Multiple(() =>
-            {
-                Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
-                Assert.That(response.Value, Has.Count.EqualTo(1));
-            });
+            Assert.That(response, Has.Count.EqualTo(1));
         }
 
         [Test]

--- a/src/NServiceBus.Transport.RabbitMQ/Configuration/ManagementApiConfiguration.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Configuration/ManagementApiConfiguration.cs
@@ -3,12 +3,15 @@
 namespace NServiceBus
 {
     using System;
+    using System.Runtime.CompilerServices;
 
     /// <summary>
     /// The RabbitMQ management API configuration to use instead of inferring values from the connection string.
     /// </summary>
     public class ManagementApiConfiguration
     {
+        ManagementApiConfiguration() { }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ManagementApiConfiguration"/> class.
         /// </summary>
@@ -54,16 +57,38 @@ namespace NServiceBus
         /// <summary>
         /// The URL to use when connecting to the RabbitMQ management API.
         /// </summary>
-        public string? Url { get; }
+        public string? Url { get; private init; }
 
         /// <summary>
         /// The user name to use when connecting to the RabbitMQ management API.
         /// </summary>
-        public string? UserName { get; }
+        public string? UserName { get; private init; }
 
         /// <summary>
         /// The password to use when connecting to the RabbitMQ management API.
         /// </summary>
-        public string? Password { get; }
+        public string? Password { get; private init; }
+
+        internal static ManagementApiConfiguration Create(string? url, string? userName, string? password)
+        {
+            ThrowIfWhiteSpace(url);
+            ThrowIfWhiteSpace(userName);
+            ThrowIfWhiteSpace(password);
+
+            return new ManagementApiConfiguration
+            {
+                Url = url,
+                UserName = userName,
+                Password = password
+            };
+        }
+
+        static void ThrowIfWhiteSpace(string? argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
+        {
+            if (argument is not null && string.IsNullOrWhiteSpace(argument))
+            {
+                throw new ArgumentException("The value cannot be an empty string or composed entirely of whitespace.", paramName);
+            }
+        }
     }
 }

--- a/src/NServiceBus.Transport.RabbitMQ/Configuration/ManagementApiConfiguration.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Configuration/ManagementApiConfiguration.cs
@@ -19,6 +19,7 @@ namespace NServiceBus
         public ManagementApiConfiguration(string url)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(url);
+            ThrowIfNotValidUrl(url);
 
             Url = url;
         }
@@ -46,6 +47,7 @@ namespace NServiceBus
         public ManagementApiConfiguration(string url, string userName, string password)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(url);
+            ThrowIfNotValidUrl(url);
             ArgumentException.ThrowIfNullOrWhiteSpace(userName);
             ArgumentException.ThrowIfNullOrWhiteSpace(password);
 
@@ -72,6 +74,12 @@ namespace NServiceBus
         internal static ManagementApiConfiguration Create(string? url, string? userName, string? password)
         {
             ThrowIfWhiteSpace(url);
+
+            if (url is not null)
+            {
+                ThrowIfNotValidUrl(url);
+            }
+
             ThrowIfWhiteSpace(userName);
             ThrowIfWhiteSpace(password);
 
@@ -90,5 +98,14 @@ namespace NServiceBus
                 throw new ArgumentException("The value cannot be an empty string or composed entirely of whitespace.", paramName);
             }
         }
+
+        static void ThrowIfNotValidUrl(string? argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
+        {
+            if (!Uri.IsWellFormedUriString(argument, UriKind.RelativeOrAbsolute))
+            {
+                throw new ArgumentException("The value is not a valid URL.", paramName);
+            }
+        }
+
     }
 }


### PR DESCRIPTION
This PR makes the following changes related to the management client and its usage in the transport:

- An internal `Create` method has been added to `ManagementApiConfiguration` so that we can bypass having to choose the various constructors based on the combination of inputs. This drastically simplifies internal creation (for example in the command line binders) without sacrificing the validation in the public API surface.
- The `delays verify` command in the CommandLine project has been updated to use the `BrokerVerifier` instead of having its own separate copy of a management API implementation.
- The `ManagementClient` now just returns the deserialized object or bubbles up the `HttpRequestException` from the `HttpClient`. This makes it easier to be consistent in how callers handle errors.
- `BrokerVerifier` has been updated to take advantage of the new error handling surface of `ManagementClient`. All client calls are wrapped in exception handlers that provide user context for the exception.
- `ManagementApiConfiguration` now validates that the `url` arguments are valid URIs, instead of them getting to the `ManagementClient` constructor and having `UriBuilder` throw a rather cryptic format exception.


Also, the `launchSettings.json` file in the CommandLine project was updated to add `validate-delivery-limit` command and generally clean it up a bit.
