### PR TITLE
Fix typo in queueName description

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine/Commands/Queue/QueueValidateDeliveryLimitCommand.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine/Commands/Queue/QueueValidateDeliveryLimitCommand.cs
@@ -11,7 +11,7 @@
             var queueNameArgument = new Argument<string>()
             {
                 Name = "queueName",
-                Description = "The name of the queue to migrate to validate"
+                Description = "The name of the queue to validate"
             };
 
             var brokerVerifierBinder = SharedOptions.CreateBrokerVerifierBinderWithOptions(command);


### PR DESCRIPTION
This PR fixes a typo in the description of the `queueName` argument of the new `queue validate-delivery-limit` command.