### PR TITLE
Disable delivery limit validation in tests

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/ConfigureEndpointRabbitMQTransport.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.AcceptanceTests/ConfigureEndpointRabbitMQTransport.cs
@@ -20,7 +20,11 @@ class ConfigureEndpointRabbitMQTransport : IConfigureEndpointTestExecution
 
     public Task Configure(string endpointName, EndpointConfiguration configuration, RunSettings settings, PublisherMetadata publisherMetadata)
     {
-        transport = new TestRabbitMQTransport(RoutingTopology.Conventional(queueType, type => type.FullName), ConnectionHelper.ConnectionString);
+        transport = new TestRabbitMQTransport(RoutingTopology.Conventional(queueType, type => type.FullName), ConnectionHelper.ConnectionString)
+        {
+            // The startup costs for creating a policy for every test queue add up, and the tests shouldn't be impacted by the default delivery limit.
+            ValidateDeliveryLimits = false
+        };
 
         configuration.UseTransport(transport);
 

--- a/src/NServiceBus.Transport.RabbitMQ.Tests/RabbitMqContext.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/RabbitMqContext.cs
@@ -20,7 +20,12 @@
 
             var useTls = connectionString.StartsWith("https", StringComparison.InvariantCultureIgnoreCase) || connectionString.StartsWith("amqps", StringComparison.InvariantCultureIgnoreCase);
 
-            var transport = new RabbitMQTransport(RoutingTopology.Conventional(queueType), connectionString);
+            var transport = new RabbitMQTransport(RoutingTopology.Conventional(queueType), connectionString)
+            {
+                // The startup costs for creating a policy for every test queue add up, and the tests shouldn't be impacted by the default delivery limit.
+                ValidateDeliveryLimits = false
+            };
+
             var connectionConfig = transport.ConnectionConfiguration;
 
             connectionFactory = new ConnectionFactory(ReceiverQueue, connectionConfig, null, true, false, transport.HeartbeatInterval, transport.NetworkRecoveryInterval, null);

--- a/src/NServiceBus.Transport.RabbitMQ.TransportTests/ConfigureRabbitMQTransportInfrastructure.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.TransportTests/ConfigureRabbitMQTransportInfrastructure.cs
@@ -16,7 +16,11 @@ class ConfigureRabbitMQTransportInfrastructure : IConfigureTransportInfrastructu
     {
         var connectionString = Environment.GetEnvironmentVariable("RabbitMQTransport_ConnectionString") ?? "host=localhost";
 
-        var transport = new RabbitMQTransport(RoutingTopology.Conventional(QueueType.Classic), connectionString, false);
+        var transport = new RabbitMQTransport(RoutingTopology.Conventional(QueueType.Classic), connectionString, false)
+        {
+            // The startup costs for creating a policy for every test queue add up, and the tests shouldn't be impacted by the default delivery limit.
+            ValidateDeliveryLimits = false
+        };
 
         return transport;
     }


### PR DESCRIPTION
This PR sets `ValidateDeliveryLimits` to `false` in tests to avoid paying the startup costs for the large amount of queues that are created over the course of a test run. We know for these tests that we don't need to worry about having a policy in place.

[This](https://github.com/Particular/NServiceBus.RabbitMQ/actions/runs/13734421902) recent CI run against `master` took 42m 33s.

The CI run for this PR took 15m 19s, so I think this change is worth making!

>[!NOTE]
>The BrokerVerifier tests that specifically test the validation logic are not effected by this change.

