### PR TITLE
Fix condition to allow https management API connections

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ.Tests/ManagementClientTests.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/ManagementClientTests.cs
@@ -19,6 +19,22 @@ namespace NServiceBus.Transport.RabbitMQ.Tests
         static readonly ConnectionFactory connectionFactory = new(typeof(ManagementClientTests).FullName, connectionConfiguration, null, false, false, TimeSpan.FromSeconds(60), TimeSpan.FromSeconds(10), []);
 
         [Test]
+        public void Should_Pass_With_http_Scheme()
+        {
+            var managementApiConfiguration = new ManagementApiConfiguration("http://localhost:15672");
+
+            Assert.DoesNotThrow(() => new ManagementClient(connectionConfiguration, managementApiConfiguration));
+        }
+
+        [Test]
+        public void Should_Pass_With_https_Scheme()
+        {
+            var managementApiConfiguration = new ManagementApiConfiguration("https://localhost:15671");
+
+            Assert.DoesNotThrow(() => new ManagementClient(connectionConfiguration, managementApiConfiguration));
+        }
+
+        [Test]
         public void Should_Throw_With_Invalid_Scheme()
         {
             var managementApiConfiguration = new ManagementApiConfiguration("amqp://localhost:15672");

--- a/src/NServiceBus.Transport.RabbitMQ/Administration/ManagementApi/ManagementClient.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Administration/ManagementApi/ManagementClient.cs
@@ -34,7 +34,7 @@ class ManagementClient : IDisposable
                 Password = managementApiConfiguration.Password ?? connectionConfiguration.Password
             };
 
-            if (uriBuilder.Scheme is not "http" or "https")
+            if (uriBuilder.Scheme is not ("http" or "https"))
             {
                 throw new NotSupportedException($"URL scheme '{uriBuilder.Scheme}' is not supported for the RabbitMQ management API URL. Valid schemes are 'http' and 'https'.");
             }


### PR DESCRIPTION
The `ManagementClient` constructor verifies that scheme of any supplied URL is `http` or `https`.

This PR fixes the condition to actually allow `https` like it is supposed to.

Fixes #1586 