### PR TITLE
Management API configuration does not allow HTTPS URLs

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine/NServiceBus.Transport.RabbitMQ.CommandLine.csproj
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine/NServiceBus.Transport.RabbitMQ.CommandLine.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.2.6" />
-    <PackageReference Include="RabbitMQ.Client" Version="7.1.1" />
+    <PackageReference Include="RabbitMQ.Client" Version="7.1.2" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
 

--- a/src/NServiceBus.Transport.RabbitMQ.Tests/ManagementClientTests.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/ManagementClientTests.cs
@@ -19,6 +19,22 @@ namespace NServiceBus.Transport.RabbitMQ.Tests
         static readonly ConnectionFactory connectionFactory = new(typeof(ManagementClientTests).FullName, connectionConfiguration, null, false, false, TimeSpan.FromSeconds(60), TimeSpan.FromSeconds(10), []);
 
         [Test]
+        public void Should_Pass_With_http_Scheme()
+        {
+            var managementApiConfiguration = new ManagementApiConfiguration("http://localhost:15672");
+
+            Assert.DoesNotThrow(() => new ManagementClient(connectionConfiguration, managementApiConfiguration));
+        }
+
+        [Test]
+        public void Should_Pass_With_https_Scheme()
+        {
+            var managementApiConfiguration = new ManagementApiConfiguration("https://localhost:15671");
+
+            Assert.DoesNotThrow(() => new ManagementClient(connectionConfiguration, managementApiConfiguration));
+        }
+
+        [Test]
         public void Should_Throw_With_Invalid_Scheme()
         {
             var managementApiConfiguration = new ManagementApiConfiguration("amqp://localhost:15672");

--- a/src/NServiceBus.Transport.RabbitMQ/Administration/ManagementApi/ManagementClient.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Administration/ManagementApi/ManagementClient.cs
@@ -34,7 +34,7 @@ class ManagementClient : IDisposable
                 Password = managementApiConfiguration.Password ?? connectionConfiguration.Password
             };
 
-            if (uriBuilder.Scheme is not "http" or "https")
+            if (uriBuilder.Scheme is not ("http" or "https"))
             {
                 throw new NotSupportedException($"URL scheme '{uriBuilder.Scheme}' is not supported for the RabbitMQ management API URL. Valid schemes are 'http' and 'https'.");
             }

--- a/src/NServiceBus.Transport.RabbitMQ/NServiceBus.Transport.RabbitMQ.csproj
+++ b/src/NServiceBus.Transport.RabbitMQ/NServiceBus.Transport.RabbitMQ.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="BitFaster.Caching" Version="2.5.3" />
     <PackageReference Include="NServiceBus" Version="9.2.6" />
-    <PackageReference Include="RabbitMQ.Client" Version="7.1.1" />
+    <PackageReference Include="RabbitMQ.Client" Version="7.1.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Backport of #1585 which fixes #1586 for the `release-10.0` branch.

>[!NOTE]
>The RabbitMQ.Client package has also been updated from 7.1.1 to 7.1.2 as part of this PR.