### PR TITLE
Add a way to disable broker requirement checks

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine.Tests/MigrateQueue/QueueMigrateToQuorumTests.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine.Tests/MigrateQueue/QueueMigrateToQuorumTests.cs
@@ -287,7 +287,7 @@
             var connectionConfiguration = ConnectionConfiguration.Create(connectionString);
 
             var managementClient = new ManagementClient(connectionConfiguration);
-            var brokerVerifier = new BrokerVerifier(managementClient, true);
+            var brokerVerifier = new BrokerVerifier(managementClient, BrokerRequirementChecks.None, true);
 
             var connectionFactory = new RabbitMQ.ConnectionFactory("unit-tests", connectionConfiguration, null, true, false, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30), null);
 

--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine/BrokerConnectionBinder.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine/BrokerConnectionBinder.cs
@@ -26,7 +26,7 @@
             var managementApiConfiguration = ManagementApiConfiguration.Create(managementApiUrl, managementApiUserName, managementApiPassword);
 
             var managementClient = new ManagementClient(connectionConfiguration, managementApiConfiguration);
-            var brokerVerifier = new BrokerVerifier(managementClient, true);
+            var brokerVerifier = new BrokerVerifier(managementClient, BrokerRequirementChecks.None, true);
 
             var certificateCollection = new X509Certificate2Collection();
 

--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine/BrokerVerifierBinder.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine/BrokerVerifierBinder.cs
@@ -20,7 +20,7 @@
             var managementApiConfiguration = ManagementApiConfiguration.Create(managementApiUrl, managementApiUserName, managementApiPassword);
 
             var managementClient = new ManagementClient(connectionConfiguration, managementApiConfiguration);
-            var brokerVerifier = new BrokerVerifier(managementClient, true);
+            var brokerVerifier = new BrokerVerifier(managementClient, BrokerRequirementChecks.None, true);
 
             return brokerVerifier;
         }

--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine/NServiceBus.Transport.RabbitMQ.CommandLine.csproj
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine/NServiceBus.Transport.RabbitMQ.CommandLine.csproj
@@ -29,6 +29,7 @@
   <ItemGroup>
     <Compile Include="..\NServiceBus.Transport.RabbitMQ\Administration\BrokerVerifier.cs" Link="Transport\BrokerVerifier.cs" />
     <Compile Include="..\NServiceBus.Transport.RabbitMQ\Administration\ManagementApi\**\*.cs" Link="Transport\ManagementApi\%(RecursiveDir)\%(Filename)%(Extension)" />
+    <Compile Include="..\NServiceBus.Transport.RabbitMQ\Configuration\BrokerRequirementChecks.cs" Link="Transport\ManagementApi\BrokerRequirementChecks.cs" />
     <Compile Include="..\NServiceBus.Transport.RabbitMQ\Configuration\ConnectionConfiguration.cs" Link="Transport\ConnectionConfiguration.cs" />
     <Compile Include="..\NServiceBus.Transport.RabbitMQ\Configuration\ManagementApiConfiguration.cs" Link="Transport\ManagementApi\ManagementApiConfiguration.cs" />
     <Compile Include="..\NServiceBus.Transport.RabbitMQ\Configuration\QueueType.cs" Link="Transport\QueueType.cs" />

--- a/src/NServiceBus.Transport.RabbitMQ.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -3,6 +3,13 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"ServiceControl.Transports.RabbitMQ, PublicKey=0024000004800000940000000602000000240000525341310004000001000100dde965e6172e019ac82c2639ffe494dd2e7dd16347c34762a05732b492e110f2e4e2e1b5ef2d85c848ccfb671ee20a47c8d1376276708dc30a90ff1121b647ba3b7259a6bc383b2034938ef0e275b58b920375ac605076178123693c6c4f1331661a62eba28c249386855637780e3ff5f23a6d854700eaa6803ef48907513b92")]
 namespace NServiceBus
 {
+    [System.Flags]
+    public enum BrokerRequirementChecks
+    {
+        None = 0,
+        Version310OrNewer = 1,
+        StreamsEnabled = 2,
+    }
     public class ManagementApiConfiguration
     {
         public ManagementApiConfiguration(string url) { }
@@ -29,6 +36,7 @@ namespace NServiceBus
         public RabbitMQTransport(NServiceBus.RoutingTopology routingTopology, string connectionString) { }
         public RabbitMQTransport(NServiceBus.RoutingTopology routingTopology, string connectionString, bool enableDelayedDelivery) { }
         public System.Security.Cryptography.X509Certificates.X509Certificate2 ClientCertificate { get; set; }
+        public NServiceBus.BrokerRequirementChecks DisabledBrokerRequirementChecks { get; set; }
         public System.TimeSpan HeartbeatInterval { get; set; }
         public NServiceBus.ManagementApiConfiguration ManagementApiConfiguration { get; set; }
         public System.Func<RabbitMQ.Client.Events.BasicDeliverEventArgs, string> MessageIdStrategy { get; set; }
@@ -51,6 +59,7 @@ namespace NServiceBus
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> ConnectionString(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions, System.Func<string> getConnectionString) { }
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> ConnectionString(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions, string connectionString) { }
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> CustomMessageIdStrategy(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions, System.Func<RabbitMQ.Client.Events.BasicDeliverEventArgs, string> customIdStrategy) { }
+        public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> DisableBrokerRequirementChecks(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions, NServiceBus.BrokerRequirementChecks brokerRequirementChecks) { }
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> DisableDurableExchangesAndQueues(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions) { }
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> DisableRemoteCertificateValidation(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions) { }
         public static NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> DoNotValidateDeliveryLimits(this NServiceBus.TransportExtensions<NServiceBus.RabbitMQTransport> transportExtensions) { }

--- a/src/NServiceBus.Transport.RabbitMQ.Tests/BrokerVerifierTests.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/BrokerVerifierTests.cs
@@ -19,7 +19,7 @@ class BrokerVerifierTests
     public void Initialize_Should_Get_Response_When_Management_Client_Is_Available_And_Valid()
     {
         var managementClient = new ManagementClient(connectionConfiguration);
-        using var brokerVerifier = new BrokerVerifier(managementClient, true);
+        using var brokerVerifier = new BrokerVerifier(managementClient, BrokerRequirementChecks.None, true);
 
         Assert.DoesNotThrowAsync(async () => await brokerVerifier.Initialize());
     }
@@ -28,7 +28,7 @@ class BrokerVerifierTests
     public async Task ValidateDeliveryLimit_Should_Set_Delivery_Limit_Policy()
     {
         var managementClient = new ManagementClient(connectionConfiguration);
-        using var brokerVerifier = new BrokerVerifier(managementClient, true);
+        using var brokerVerifier = new BrokerVerifier(managementClient, BrokerRequirementChecks.None, true);
         await brokerVerifier.Initialize();
 
         if (brokerVerifier.BrokerVersion < BrokerVerifier.BrokerVersion4)
@@ -67,7 +67,7 @@ class BrokerVerifierTests
     {
         var queueName = "WrongQueue";
         var managementClient = new ManagementClient(connectionConfiguration);
-        using var brokerVerifier = new BrokerVerifier(managementClient, true);
+        using var brokerVerifier = new BrokerVerifier(managementClient, BrokerRequirementChecks.None, true);
         await brokerVerifier.Initialize();
 
         var exception = Assert.ThrowsAsync<InvalidOperationException>(async () => await brokerVerifier.ValidateDeliveryLimit(queueName));
@@ -81,7 +81,7 @@ class BrokerVerifierTests
         await CreateQueue(queueName, queueType: "classic");
 
         var managementClient = new ManagementClient(connectionConfiguration);
-        using var brokerVerifier = new BrokerVerifier(managementClient, true);
+        using var brokerVerifier = new BrokerVerifier(managementClient, BrokerRequirementChecks.None, true);
         await brokerVerifier.Initialize();
 
         await brokerVerifier.ValidateDeliveryLimit(queueName);
@@ -95,7 +95,7 @@ class BrokerVerifierTests
         await CreateQueue(queueName, deliveryLimit: deliveryLimit);
 
         var managementClient = new ManagementClient(connectionConfiguration);
-        using var brokerVerifier = new BrokerVerifier(managementClient, true);
+        using var brokerVerifier = new BrokerVerifier(managementClient, BrokerRequirementChecks.None, true);
         await brokerVerifier.Initialize();
 
         var exception = Assert.ThrowsAsync<InvalidOperationException>(async () => await brokerVerifier.ValidateDeliveryLimit(queueName));
@@ -109,7 +109,7 @@ class BrokerVerifierTests
         await CreateQueue(queueName);
 
         var managementClient = new ManagementClient(connectionConfiguration);
-        using var brokerVerifier = new BrokerVerifier(managementClient, true);
+        using var brokerVerifier = new BrokerVerifier(managementClient, BrokerRequirementChecks.None, true);
         await brokerVerifier.Initialize();
 
         var deliveryLimit = 15;

--- a/src/NServiceBus.Transport.RabbitMQ/Administration/BrokerVerifier.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Administration/BrokerVerifier.cs
@@ -32,6 +32,7 @@ class BrokerVerifier(ManagementClient managementClient, BrokerRequirementChecks 
 
     public async Task Initialize(CancellationToken cancellationToken = default)
     {
+        //This needs to stay in sync with changes to BrokerRequirementChecks
         var all = BrokerRequirementChecks.Version310OrNewer | BrokerRequirementChecks.StreamsEnabled;
 
         if (disabledBrokerRequirementChecks == all && !validateDeliveryLimits)

--- a/src/NServiceBus.Transport.RabbitMQ/Administration/BrokerVerifier.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Administration/BrokerVerifier.cs
@@ -7,17 +7,10 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-#if !COMMANDLINE
-using NServiceBus.Logging;
-#endif
 using NServiceBus.Transport.RabbitMQ.ManagementApi;
 
-class BrokerVerifier(ManagementClient managementClient, bool validateDeliveryLimits) : IDisposable
+class BrokerVerifier(ManagementClient managementClient, BrokerRequirementChecks disabledBrokerRequirementChecks, bool validateDeliveryLimits) : IDisposable
 {
-#if !COMMANDLINE
-    static readonly ILog Logger = LogManager.GetLogger(typeof(BrokerVerifier));
-#endif
-
     static readonly Version MinimumSupportedBrokerVersion = Version.Parse("3.10.0");
     public static readonly Version BrokerVersion4 = Version.Parse("4.0.0");
 
@@ -39,6 +32,13 @@ class BrokerVerifier(ManagementClient managementClient, bool validateDeliveryLim
 
     public async Task Initialize(CancellationToken cancellationToken = default)
     {
+        var all = BrokerRequirementChecks.Version310OrNewer | BrokerRequirementChecks.StreamsEnabled;
+
+        if (disabledBrokerRequirementChecks == all && !validateDeliveryLimits)
+        {
+            return;
+        }
+
         try
         {
             var overview = await managementClient.GetOverview(cancellationToken).ConfigureAwait(false);
@@ -67,26 +67,50 @@ class BrokerVerifier(ManagementClient managementClient, bool validateDeliveryLim
 
     public async Task VerifyRequirements(CancellationToken cancellationToken = default)
     {
-        if (BrokerVersion < MinimumSupportedBrokerVersion)
+        if ((disabledBrokerRequirementChecks & BrokerRequirementChecks.Version310OrNewer) == BrokerRequirementChecks.Version310OrNewer)
         {
-            throw new InvalidOperationException($"An unsupported broker version was detected: {BrokerVersion}. The broker must be at least version {MinimumSupportedBrokerVersion}.");
+            LogWarning("Verification of the minimum supported broker version has been disabled. The transport will not be able to ensure the delayed delivery infrastructure works properly.");
+        }
+        else
+        {
+            VerifyBrokerMinimumVersion();
         }
 
-        bool streamsEnabled;
-
-        try
+        if ((disabledBrokerRequirementChecks & BrokerRequirementChecks.StreamsEnabled) == BrokerRequirementChecks.StreamsEnabled)
         {
-            var featureFlags = await managementClient.GetFeatureFlags(cancellationToken).ConfigureAwait(false);
-            streamsEnabled = featureFlags.HasEnabledFeature(FeatureFlag.StreamQueue);
+            LogWarning("Verification of the 'stream_queue' feature flag has been disabled. The transport will not be able to ensure the delayed delivery infrastructure works properly.");
         }
-        catch (HttpRequestException ex)
+        else
         {
-            throw new InvalidOperationException("There was a problem accessing the RabbitMQ management API to verify broker requirements. See the inner exception for details.", ex);
+            await VerifyStreamEnabled(cancellationToken).ConfigureAwait(false);
         }
 
-        if (!streamsEnabled)
+        void VerifyBrokerMinimumVersion()
         {
-            throw new InvalidOperationException("An unsupported broker configuration was detected. The 'stream_queue' feature flag needs to be enabled.");
+            if (BrokerVersion < MinimumSupportedBrokerVersion)
+            {
+                throw new InvalidOperationException($"An unsupported broker version was detected: {BrokerVersion}. The broker must be at least version {MinimumSupportedBrokerVersion}.");
+            }
+        }
+
+        async Task VerifyStreamEnabled(CancellationToken cancellationToken)
+        {
+            bool streamsEnabled;
+
+            try
+            {
+                var featureFlags = await managementClient.GetFeatureFlags(cancellationToken).ConfigureAwait(false);
+                streamsEnabled = featureFlags.HasEnabledFeature(FeatureFlag.StreamQueue);
+            }
+            catch (HttpRequestException ex)
+            {
+                throw new InvalidOperationException("There was a problem accessing the RabbitMQ management API to verify broker requirements. See the inner exception for details.", ex);
+            }
+
+            if (!streamsEnabled)
+            {
+                throw new InvalidOperationException("An unsupported broker configuration was detected. The 'stream_queue' feature flag needs to be enabled.");
+            }
         }
     }
 
@@ -94,9 +118,7 @@ class BrokerVerifier(ManagementClient managementClient, bool validateDeliveryLim
     {
         if (!validateDeliveryLimits)
         {
-#if !COMMANDLINE
-            Logger.Warn("Validation of delivery limits has been disabled. The transport will not be able to ensure that messages are not lost after repeated retries.");
-#endif
+            LogWarning("Validation of delivery limits has been disabled. The transport will not be able to ensure that messages are not lost after repeated retries.");
             return;
         }
 
@@ -191,6 +213,14 @@ class BrokerVerifier(ManagementClient managementClient, bool validateDeliveryLim
         {
             throw new InvalidOperationException($"There was a problem accessing the RabbitMQ management API to create an unlimited delivery limit policy for the '{queue.Name}' queue. See the inner exception for details.", ex);
         }
+    }
+
+    static void LogWarning(string message)
+    {
+#if !COMMANDLINE
+        var logger = Logging.LogManager.GetLogger(typeof(BrokerVerifier));
+        logger.Warn(message);
+#endif
     }
 
     protected virtual void Dispose(bool disposing)

--- a/src/NServiceBus.Transport.RabbitMQ/Configuration/BrokerRequirementChecks.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Configuration/BrokerRequirementChecks.cs
@@ -1,0 +1,26 @@
+﻿namespace NServiceBus;
+
+using System;
+
+/// <summary>
+///
+/// </summary>
+[Flags]
+public enum BrokerRequirementChecks
+{
+    /// <summary>
+    ///
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    ///
+    /// </summary>
+    Version310OrNewer = 1,
+
+    /// <summary>
+    ///
+    /// </summary>
+    StreamsEnabled = 2,
+}
+

--- a/src/NServiceBus.Transport.RabbitMQ/Configuration/BrokerRequirementChecks.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Configuration/BrokerRequirementChecks.cs
@@ -2,24 +2,26 @@
 
 using System;
 
+//Any changes to BrokerRequirementChecks need to be synchronzied with the `all` value in BrokerVerifier.Initialize.
+
 /// <summary>
-///
+/// The broker requirements that the transport will verify.
 /// </summary>
 [Flags]
 public enum BrokerRequirementChecks
 {
     /// <summary>
-    ///
+    ///  None
     /// </summary>
     None = 0,
 
     /// <summary>
-    ///
+    /// The transport requires broker version 3.10 or newer.
     /// </summary>
     Version310OrNewer = 1,
 
     /// <summary>
-    ///
+    /// The 'stream-queue' feature flag needs to be enabled.
     /// </summary>
     StreamsEnabled = 2,
 }

--- a/src/NServiceBus.Transport.RabbitMQ/Configuration/RabbitMQTransportSettingsExtensions.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Configuration/RabbitMQTransportSettingsExtensions.cs
@@ -115,6 +115,25 @@
         }
 
         /// <summary>
+        /// Disables the specified broker requirement checks.
+        /// </summary>
+        /// <param name="transportExtensions"></param>
+        /// <param name="brokerRequirementChecks">The broker requirement checks to disable.</param>
+        /// <remarks>
+        /// Using a broker that does not meet these requirements can result in message loss or other incorrect operation, so disabling the checks is not recommended.
+        /// </remarks>
+        [PreObsolete("https://github.com/Particular/NServiceBus/issues/6811",
+            Message = "This is now part of routing topology configuration, which has been moved to the constructor of the RabbitMQTransport class.",
+            Note = "Should not be converted to an ObsoleteEx until API mismatch described in issue is resolved.")]
+        public static TransportExtensions<RabbitMQTransport> DisableBrokerRequirementChecks(this TransportExtensions<RabbitMQTransport> transportExtensions, BrokerRequirementChecks brokerRequirementChecks)
+        {
+            ArgumentNullException.ThrowIfNull(transportExtensions);
+
+            transportExtensions.Transport.DisabledBrokerRequirementChecks = brokerRequirementChecks;
+            return transportExtensions;
+        }
+
+        /// <summary>
         /// Specifies that exchanges and queues should be declared as non-durable.
         /// </summary>
         /// <param name="transportExtensions"></param>

--- a/src/NServiceBus.Transport.RabbitMQ/Configuration/RabbitMQTransportSettingsExtensions.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Configuration/RabbitMQTransportSettingsExtensions.cs
@@ -120,7 +120,7 @@
         /// <param name="transportExtensions"></param>
         /// <param name="brokerRequirementChecks">The broker requirement checks to disable.</param>
         /// <remarks>
-        /// Using a broker that does not meet these requirements can result in message loss or other incorrect operation, so disabling the checks is not recommended.
+        /// Using a broker that does not meet all of the requirements can result in message loss or other incorrect operation, so disabling checks is not recommended.
         /// </remarks>
         [PreObsolete("https://github.com/Particular/NServiceBus/issues/6811",
             Message = "This is now part of routing topology configuration, which has been moved to the constructor of the RabbitMQTransport class.",

--- a/src/NServiceBus.Transport.RabbitMQ/RabbitMQTransport.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/RabbitMQTransport.cs
@@ -154,7 +154,7 @@
         /// The broker requirement checks to disable.
         /// </summary>
         /// <remarks>
-        /// Using a broker that does not meet these requirements can result in message loss or other incorrect operation, so disabling the checks is not recommended.
+        /// Using a broker that does not meet all of the requirements can result in message loss or other incorrect operation, so disabling the checks is not recommended.
         /// </remarks>
         public BrokerRequirementChecks DisabledBrokerRequirementChecks { get; set; }
 

--- a/src/NServiceBus.Transport.RabbitMQ/RabbitMQTransport.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/RabbitMQTransport.cs
@@ -151,6 +151,14 @@
         public ManagementApiConfiguration ManagementApiConfiguration { get; set; }
 
         /// <summary>
+        /// The broker requirement checks to disable.
+        /// </summary>
+        /// <remarks>
+        /// Using a broker that does not meet these requirements can result in message loss or other incorrect operation, so disabling the checks is not recommended.
+        /// </remarks>
+        public BrokerRequirementChecks DisabledBrokerRequirementChecks { get; set; }
+
+        /// <summary>
         /// The interval for heartbeats between the endpoint and the broker.
         /// </summary>
         public TimeSpan HeartbeatInterval
@@ -229,7 +237,7 @@
 
             ManagementClient = new ManagementClient(ConnectionConfiguration, ManagementApiConfiguration);
 
-            var brokerVerifier = new BrokerVerifier(ManagementClient, ValidateDeliveryLimits);
+            var brokerVerifier = new BrokerVerifier(ManagementClient, DisabledBrokerRequirementChecks, ValidateDeliveryLimits);
             await brokerVerifier.Initialize(cancellationToken).ConfigureAwait(false);
             await brokerVerifier.VerifyRequirements(cancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION
While it's not recommended to ever disable the checks the transport makes to ensure the broker meets the minimum requirements required for correct operation, in some very restricted environments it's not possible to let the transport have access to the management API.

In order to unblock using the transport in those sort of environments, this PR adds a new API to tell the transport to disable the checks it makes.

