### PR TITLE
Move remarks into summary to make them more visible

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ/Configuration/RabbitMQTransportSettingsExtensions.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Configuration/RabbitMQTransportSettingsExtensions.cs
@@ -116,12 +116,11 @@
 
         /// <summary>
         /// Disables the specified broker requirement checks.
+        /// <br />
+        /// Using a broker that does not meet all of the requirements can result in message loss or other incorrect operation, so disabling checks is not recommended.
         /// </summary>
         /// <param name="transportExtensions"></param>
         /// <param name="brokerRequirementChecks">The broker requirement checks to disable.</param>
-        /// <remarks>
-        /// Using a broker that does not meet all of the requirements can result in message loss or other incorrect operation, so disabling checks is not recommended.
-        /// </remarks>
         [PreObsolete("https://github.com/Particular/NServiceBus/issues/6811",
             Message = "This is now part of routing topology configuration, which has been moved to the constructor of the RabbitMQTransport class.",
             Note = "Should not be converted to an ObsoleteEx until API mismatch described in issue is resolved.")]
@@ -165,10 +164,9 @@
 
         /// <summary>
         /// Specifies that the transport should not validate that queue delivery limits are configured properly to avoid interfering with message recoverability.
-        /// </summary>
-        /// <remarks>
+        /// <br />
         /// Incorrect delivery limit settings could result in message loss, so disabling validation is not recommended.
-        /// </remarks>
+        /// </summary>
         [PreObsolete("https://github.com/Particular/NServiceBus/issues/6811",
             ReplacementTypeOrMember = "RabbitMQTransport.ValidateDeliveryLimits",
             Message = "The configuration has been moved to RabbitMQTransport class.",

--- a/src/NServiceBus.Transport.RabbitMQ/RabbitMQTransport.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/RabbitMQTransport.cs
@@ -139,10 +139,9 @@
 
         /// <summary>
         /// Should the transport validate that queue delivery limits are configured properly to avoid interfering with message recoverability.
-        /// </summary>
-        /// <remarks>
+        /// <br />
         /// Incorrect delivery limit settings could result in message loss, so disabling validation is not recommended.
-        /// </remarks>
+        /// </summary>
         public bool ValidateDeliveryLimits { get; set; } = true;
 
         /// <summary>
@@ -152,10 +151,9 @@
 
         /// <summary>
         /// The broker requirement checks to disable.
-        /// </summary>
-        /// <remarks>
+        /// <br />
         /// Using a broker that does not meet all of the requirements can result in message loss or other incorrect operation, so disabling the checks is not recommended.
-        /// </remarks>
+        /// </summary>
         public BrokerRequirementChecks DisabledBrokerRequirementChecks { get; set; }
 
         /// <summary>


### PR DESCRIPTION
Remarks in XML comments aren't visible in all IntelliSense tooltips, so this moves the text directly into the summary instead.