### PR TITLE
Remote certificate validation can't be disabled when accessing the management API 

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine/BrokerConnectionBinder.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine/BrokerConnectionBinder.cs
@@ -25,7 +25,7 @@
             var connectionConfiguration = ConnectionConfiguration.Create(connectionString);
             var managementApiConfiguration = ManagementApiConfiguration.Create(managementApiUrl, managementApiUserName, managementApiPassword);
 
-            var managementClient = new ManagementClient(connectionConfiguration, managementApiConfiguration);
+            var managementClient = new ManagementClient(connectionConfiguration, managementApiConfiguration, disableCertificateValidation);
             var brokerVerifier = new BrokerVerifier(managementClient, true);
 
             var certificateCollection = new X509Certificate2Collection();

--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine/BrokerVerifierBinder.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine/BrokerVerifierBinder.cs
@@ -4,7 +4,7 @@
     using System.CommandLine.Binding;
     using NServiceBus.Transport.RabbitMQ.ManagementApi;
 
-    class BrokerVerifierBinder(Option<string> connectionStringOption, Option<string> connectionStringEnvOption, Option<string> managementApiUrlOption, Option<string> managementApiUserNameOption, Option<string> managementApiPasswordOption) : BinderBase<BrokerVerifier>
+    class BrokerVerifierBinder(Option<string> connectionStringOption, Option<string> connectionStringEnvOption, Option<string> managementApiUrlOption, Option<string> managementApiUserNameOption, Option<string> managementApiPasswordOption, Option<bool> disableCertificateValidationOption) : BinderBase<BrokerVerifier>
     {
         protected override BrokerVerifier GetBoundValue(BindingContext bindingContext)
         {
@@ -13,13 +13,14 @@
             var managementApiUrl = bindingContext.ParseResult.GetValueForOption(managementApiUrlOption);
             var managementApiUserName = bindingContext.ParseResult.GetValueForOption(managementApiUserNameOption);
             var managementApiPassword = bindingContext.ParseResult.GetValueForOption(managementApiPasswordOption);
+            var disableCertificateValidation = bindingContext.ParseResult.GetValueForOption(disableCertificateValidationOption);
 
             var connectionString = GetConnectionString(connectionStringOptionValue, connectionStringEnvOptionValue);
 
             var connectionConfiguration = ConnectionConfiguration.Create(connectionString);
             var managementApiConfiguration = ManagementApiConfiguration.Create(managementApiUrl, managementApiUserName, managementApiPassword);
 
-            var managementClient = new ManagementClient(connectionConfiguration, managementApiConfiguration);
+            var managementClient = new ManagementClient(connectionConfiguration, managementApiConfiguration, disableCertificateValidation);
             var brokerVerifier = new BrokerVerifier(managementClient, true);
 
             return brokerVerifier;

--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine/SharedOptions.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine/SharedOptions.cs
@@ -160,14 +160,16 @@
             var managementApiUrlOption = CreateManagementApiUrlOption();
             var managementApiUserNameOption = CreateManagementApiUserNameOption();
             var managementApiPasswordOption = CreateManagementApiPasswordOption();
+            var disableCertValidationOption = CreateDisableCertValidationOption();
 
             command.AddOption(connectionStringOption);
             command.AddOption(connectionStringEnvOption);
             command.AddOption(managementApiUrlOption);
             command.AddOption(managementApiUserNameOption);
             command.AddOption(managementApiPasswordOption);
+            command.AddOption(disableCertValidationOption);
 
-            return new BrokerVerifierBinder(connectionStringOption, connectionStringEnvOption, managementApiUrlOption, managementApiUserNameOption, managementApiPasswordOption);
+            return new BrokerVerifierBinder(connectionStringOption, connectionStringEnvOption, managementApiUrlOption, managementApiUserNameOption, managementApiPasswordOption, disableCertValidationOption);
         }
 
         public static RoutingTopologyBinder CreateRoutingTopologyBinderWithOptions(Command command)

--- a/src/NServiceBus.Transport.RabbitMQ.Tests/BrokerVerifierTests.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/BrokerVerifierTests.cs
@@ -124,7 +124,8 @@ class BrokerVerifierTests
 
         await managementClient.CreatePolicy(policyName, policy).ConfigureAwait(false);
 
-        // If this test appears flaky, a delay should be added here to give the broker some time to apply the policy before calling ValidateDeliveryLimit
+        // If this test appears flaky, the delay should be increased to give the broker more time to apply the policy before calling ValidateDeliveryLimit
+        await Task.Delay(TimeSpan.FromSeconds(30));
 
         var exception = Assert.ThrowsAsync<InvalidOperationException>(async () => await brokerVerifier.ValidateDeliveryLimit(queueName));
         Assert.That(exception.Message, Does.Contain($"The delivery limit for '{queueName}' is set to the non-default value of '{deliveryLimit}'. Remove any delivery limit settings from queue arguments, user policies or operator policies to correct this."));

--- a/src/NServiceBus.Transport.RabbitMQ/Administration/ManagementApi/ManagementClient.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Administration/ManagementApi/ManagementClient.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
+using System.Net.Security;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -20,7 +21,7 @@ class ManagementClient : IDisposable
 
     bool disposed;
 
-    public ManagementClient(ConnectionConfiguration connectionConfiguration, ManagementApiConfiguration? managementApiConfiguration = null)
+    public ManagementClient(ConnectionConfiguration connectionConfiguration, ManagementApiConfiguration? managementApiConfiguration = null, bool disableRemoteCertificateValidation = false)
     {
         ArgumentNullException.ThrowIfNull(connectionConfiguration);
 
@@ -59,6 +60,14 @@ class ManagementClient : IDisposable
             PooledConnectionLifetime = TimeSpan.FromMinutes(2),
             PreAuthenticate = true
         };
+
+        if (disableRemoteCertificateValidation)
+        {
+            handler.SslOptions = new SslClientAuthenticationOptions
+            {
+                RemoteCertificateValidationCallback = (_, _, _, _) => true
+            };
+        }
 
         httpClient = new HttpClient(handler) { BaseAddress = uriBuilder.Uri };
     }

--- a/src/NServiceBus.Transport.RabbitMQ/RabbitMQTransport.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/RabbitMQTransport.cs
@@ -227,7 +227,7 @@
                 additionalClusterNodes
             );
 
-            ManagementClient = new ManagementClient(ConnectionConfiguration, ManagementApiConfiguration);
+            ManagementClient = new ManagementClient(ConnectionConfiguration, ManagementApiConfiguration, !ValidateRemoteCertificate);
 
             var brokerVerifier = new BrokerVerifier(ManagementClient, ValidateDeliveryLimits);
             await brokerVerifier.Initialize(cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Backport of #1599 which fixes #1596 for the `release-10.0` branch.