### PR TITLE
Handling routing keys with dots in delay delivery

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine.Tests/MigrateDelayedMessages/When_migrating_a_delayed_message.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine.Tests/MigrateDelayedMessages/When_migrating_a_delayed_message.cs
@@ -13,6 +13,7 @@
         [TestCase(128, new int[] { 2022, 5, 6, 12, 0, 0 }, "0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1.0.0.0.0.0.0.0.destination", new int[] { 2022, 5, 6, 12, 0, 30 }, "destination", "0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1.1.0.0.0.1.0.destination", 6)]
         [TestCase(86400, new int[] { 2022, 5, 6, 12, 0, 0 }, "0.0.0.0.0.0.0.0.0.0.0.1.0.1.0.1.0.0.0.1.1.0.0.0.0.0.0.0.destination", new int[] { 2022, 5, 7, 0, 0, 0 }, "destination", "0.0.0.0.0.0.0.0.0.0.0.0.1.0.1.0.1.0.0.0.1.1.0.0.0.0.0.0.destination", 15)]
         [TestCase(604800, new int[] { 2022, 5, 6, 12, 0, 0 }, "0.0.0.0.0.0.0.0.1.0.0.1.0.0.1.1.1.0.1.0.1.0.0.0.0.0.0.0.destination", new int[] { 2022, 5, 9, 12, 0, 0 }, "destination", "0.0.0.0.0.0.0.0.0.1.0.1.0.1.0.0.0.1.1.0.0.0.0.0.0.0.0.0.destination", 18)]
+        [TestCase(604800, new int[] { 2022, 5, 6, 12, 0, 0 }, "0.0.0.0.0.0.0.0.1.0.0.1.0.0.1.1.1.0.1.0.1.0.0.0.0.0.0.0.destination.with.dots.in.name", new int[] { 2022, 5, 9, 12, 0, 0 }, "destination.with.dots.in.name", "0.0.0.0.0.0.0.0.0.1.0.1.0.1.0.0.0.1.1.0.0.0.0.0.0.0.0.0.destination.with.dots.in.name", 18)]
         public void Should_generate_the_correct_routing_key(int originalDelayInSeconds, int[] originalTimeSentValues, string originalRoutingKey, int[] utcNowValues, string expectedDestination, string expectedRoutingKey, int expectedDelayLevel)
         {
             var originalTimeSent = GetDateTimeOffsetFromValues(originalTimeSentValues);

--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine/Commands/Delays/DelaysMigrateCommand.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine/Commands/Delays/DelaysMigrateCommand.cs
@@ -12,6 +12,7 @@
         const string poisonMessageQueue = "delays-migrate-poison-messages";
         const string timeSentHeader = "NServiceBus.TimeSent";
         const string dateTimeOffsetWireFormat = "yyyy-MM-dd HH:mm:ss:ffffff Z";
+        const int indexStartOfDestinationQueue = DelayInfrastructure.MaxNumberOfBitsToUse * 2;
 
         public static Command CreateCommand()
         {
@@ -143,8 +144,7 @@
         {
             var originalDeliveryDate = timeSent.AddSeconds(delayInSeconds);
             var newDelayInSeconds = Convert.ToInt32(originalDeliveryDate.Subtract(utcNow).TotalSeconds);
-            var indexStartOfDestinationQueue = DelayInfrastructure.MaxNumberOfBitsToUse * 2;
-            var destinationQueue = currentRoutingKey[indexStartOfDestinationQueue..];
+            var destinationQueue = currentRoutingKey[IndexStartOfDestinationQueue..];
             var newRoutingKey = DelayInfrastructure.CalculateRoutingKey(newDelayInSeconds, destinationQueue, out int newDelayLevel);
 
             return (destinationQueue, newRoutingKey, newDelayLevel);

--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine/Commands/Delays/DelaysMigrateCommand.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine/Commands/Delays/DelaysMigrateCommand.cs
@@ -143,25 +143,10 @@
         {
             var originalDeliveryDate = timeSent.AddSeconds(delayInSeconds);
             var newDelayInSeconds = Convert.ToInt32(originalDeliveryDate.Subtract(utcNow).TotalSeconds);
-            var destinationQueue = GetUltimateDestinationKey(currentRoutingKey);
+            var destinationQueue = currentRoutingKey[(DelayInfrastructure.MaxNumberOfBitsToUse * 2)..];
             var newRoutingKey = DelayInfrastructure.CalculateRoutingKey(newDelayInSeconds, destinationQueue, out int newDelayLevel);
 
             return (destinationQueue, newRoutingKey, newDelayLevel);
-        }
-
-        static string GetUltimateDestinationKey(string key)
-        {
-            var numberOfDotsBetweenBitFlags = DelayInfrastructure.MaxLevel;
-            var numberOfDotsAfterBitFlagsAndBeforeUltimateDestinationKey = 1;
-            var totalNumberOfDots = numberOfDotsBetweenBitFlags + numberOfDotsAfterBitFlagsAndBeforeUltimateDestinationKey;
-
-            int positionAfterLastDot = 0;
-            for (var level = 0; level < totalNumberOfDots; ++level)
-            {
-                positionAfterLastDot = key.IndexOf('.', positionAfterLastDot) + 1;
-            }
-
-            return key.Substring(positionAfterLastDot);
         }
 
         static DateTimeOffset GetTimeSent(BasicGetResult message)

--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine/Commands/Delays/DelaysMigrateCommand.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine/Commands/Delays/DelaysMigrateCommand.cs
@@ -143,10 +143,25 @@
         {
             var originalDeliveryDate = timeSent.AddSeconds(delayInSeconds);
             var newDelayInSeconds = Convert.ToInt32(originalDeliveryDate.Subtract(utcNow).TotalSeconds);
-            var destinationQueue = currentRoutingKey.Substring(currentRoutingKey.LastIndexOf('.') + 1);
+            var destinationQueue = GetUltimateDestinationKey(currentRoutingKey);
             var newRoutingKey = DelayInfrastructure.CalculateRoutingKey(newDelayInSeconds, destinationQueue, out int newDelayLevel);
 
             return (destinationQueue, newRoutingKey, newDelayLevel);
+        }
+
+        static string GetUltimateDestinationKey(string key)
+        {
+            var numberOfDotsBetweenBitFlags = DelayInfrastructure.MaxLevel;
+            var numberOfDotsAfterBitFlagsAndBeforeUltimateDestinationKey = 1;
+            var totalNumberOfDots = numberOfDotsBetweenBitFlags + numberOfDotsAfterBitFlagsAndBeforeUltimateDestinationKey;
+
+            int positionAfterLastDot = 0;
+            for (var level = 0; level < totalNumberOfDots; ++level)
+            {
+                positionAfterLastDot = key.IndexOf('.', positionAfterLastDot) + 1;
+            }
+
+            return key.Substring(positionAfterLastDot);
         }
 
         static DateTimeOffset GetTimeSent(BasicGetResult message)

--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine/Commands/Delays/DelaysMigrateCommand.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine/Commands/Delays/DelaysMigrateCommand.cs
@@ -143,7 +143,8 @@
         {
             var originalDeliveryDate = timeSent.AddSeconds(delayInSeconds);
             var newDelayInSeconds = Convert.ToInt32(originalDeliveryDate.Subtract(utcNow).TotalSeconds);
-            var destinationQueue = currentRoutingKey[(DelayInfrastructure.MaxNumberOfBitsToUse * 2)..];
+            var indexStartOfDestinationQueue = DelayInfrastructure.MaxNumberOfBitsToUse * 2;
+            var destinationQueue = currentRoutingKey[indexStartOfDestinationQueue..];
             var newRoutingKey = DelayInfrastructure.CalculateRoutingKey(newDelayInSeconds, destinationQueue, out int newDelayLevel);
 
             return (destinationQueue, newRoutingKey, newDelayLevel);

--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine/Commands/Delays/DelaysMigrateCommand.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine/Commands/Delays/DelaysMigrateCommand.cs
@@ -144,7 +144,7 @@
         {
             var originalDeliveryDate = timeSent.AddSeconds(delayInSeconds);
             var newDelayInSeconds = Convert.ToInt32(originalDeliveryDate.Subtract(utcNow).TotalSeconds);
-            var destinationQueue = currentRoutingKey[IndexStartOfDestinationQueue..];
+            var destinationQueue = currentRoutingKey[indexStartOfDestinationQueue..];
             var newRoutingKey = DelayInfrastructure.CalculateRoutingKey(newDelayInSeconds, destinationQueue, out int newDelayLevel);
 
             return (destinationQueue, newRoutingKey, newDelayLevel);

--- a/src/NServiceBus.Transport.RabbitMQ/DelayedDelivery/DelayInfrastructure.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/DelayedDelivery/DelayInfrastructure.cs
@@ -12,7 +12,7 @@ namespace NServiceBus.Transport.RabbitMQ
 
     static class DelayInfrastructure
     {
-        const int MaxNumberOfBitsToUse = 28;
+        public const int MaxNumberOfBitsToUse = 28;
 
         public const int MaxLevel = MaxNumberOfBitsToUse - 1;
         public const int MaxDelayInSeconds = (1 << MaxNumberOfBitsToUse) - 1;


### PR DESCRIPTION
Fix for:

- https://github.com/Particular/NServiceBus.RabbitMQ/issues/1608

Previously used `LastIndexOf` but that doesn't work if destinations have dots in their names. The routing bits are always a fixed length so new implementation calculates the length of the routing bits (bits *2) as each bit is a `1.` or `0.` in the routing key.