### PR TITLE
Simplify destination queue calculation

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine/Commands/Delays/DelaysMigrateCommand.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine/Commands/Delays/DelaysMigrateCommand.cs
@@ -143,25 +143,10 @@
         {
             var originalDeliveryDate = timeSent.AddSeconds(delayInSeconds);
             var newDelayInSeconds = Convert.ToInt32(originalDeliveryDate.Subtract(utcNow).TotalSeconds);
-            var destinationQueue = GetUltimateDestinationKey(currentRoutingKey);
+            var destinationQueue = currentRoutingKey[(DelayInfrastructure.MaxNumberOfBitsToUse * 2)..];
             var newRoutingKey = DelayInfrastructure.CalculateRoutingKey(newDelayInSeconds, destinationQueue, out int newDelayLevel);
 
             return (destinationQueue, newRoutingKey, newDelayLevel);
-        }
-
-        static string GetUltimateDestinationKey(string key)
-        {
-            var numberOfDotsBetweenBitFlags = DelayInfrastructure.MaxLevel;
-            var numberOfDotsAfterBitFlagsAndBeforeUltimateDestinationKey = 1;
-            var totalNumberOfDots = numberOfDotsBetweenBitFlags + numberOfDotsAfterBitFlagsAndBeforeUltimateDestinationKey;
-
-            int positionAfterLastDot = 0;
-            for (var level = 0; level < totalNumberOfDots; ++level)
-            {
-                positionAfterLastDot = key.IndexOf('.', positionAfterLastDot) + 1;
-            }
-
-            return key.Substring(positionAfterLastDot);
         }
 
         static DateTimeOffset GetTimeSent(BasicGetResult message)

--- a/src/NServiceBus.Transport.RabbitMQ/DelayedDelivery/DelayInfrastructure.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/DelayedDelivery/DelayInfrastructure.cs
@@ -12,7 +12,7 @@ namespace NServiceBus.Transport.RabbitMQ
 
     static class DelayInfrastructure
     {
-        const int MaxNumberOfBitsToUse = 28;
+        public const int MaxNumberOfBitsToUse = 28;
 
         public const int MaxLevel = MaxNumberOfBitsToUse - 1;
         public const int MaxDelayInSeconds = (1 << MaxNumberOfBitsToUse) - 1;


### PR DESCRIPTION
Here's a way to simplify the destination queue calculation but still keep the correct behavior of accounting for a destination that has dots in the name.