### PR TITLE
Cannot migrate v1 delay queues to v2 when the exchange contains dots in the name

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine.Tests/MigrateDelayedMessages/When_migrating_a_delayed_message.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine.Tests/MigrateDelayedMessages/When_migrating_a_delayed_message.cs
@@ -13,6 +13,7 @@
         [TestCase(128, new int[] { 2022, 5, 6, 12, 0, 0 }, "0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1.0.0.0.0.0.0.0.destination", new int[] { 2022, 5, 6, 12, 0, 30 }, "destination", "0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1.1.0.0.0.1.0.destination", 6)]
         [TestCase(86400, new int[] { 2022, 5, 6, 12, 0, 0 }, "0.0.0.0.0.0.0.0.0.0.0.1.0.1.0.1.0.0.0.1.1.0.0.0.0.0.0.0.destination", new int[] { 2022, 5, 7, 0, 0, 0 }, "destination", "0.0.0.0.0.0.0.0.0.0.0.0.1.0.1.0.1.0.0.0.1.1.0.0.0.0.0.0.destination", 15)]
         [TestCase(604800, new int[] { 2022, 5, 6, 12, 0, 0 }, "0.0.0.0.0.0.0.0.1.0.0.1.0.0.1.1.1.0.1.0.1.0.0.0.0.0.0.0.destination", new int[] { 2022, 5, 9, 12, 0, 0 }, "destination", "0.0.0.0.0.0.0.0.0.1.0.1.0.1.0.0.0.1.1.0.0.0.0.0.0.0.0.0.destination", 18)]
+        [TestCase(604800, new int[] { 2022, 5, 6, 12, 0, 0 }, "0.0.0.0.0.0.0.0.1.0.0.1.0.0.1.1.1.0.1.0.1.0.0.0.0.0.0.0.destination.with.dots.in.name", new int[] { 2022, 5, 9, 12, 0, 0 }, "destination.with.dots.in.name", "0.0.0.0.0.0.0.0.0.1.0.1.0.1.0.0.0.1.1.0.0.0.0.0.0.0.0.0.destination.with.dots.in.name", 18)]
         public void Should_generate_the_correct_routing_key(int originalDelayInSeconds, int[] originalTimeSentValues, string originalRoutingKey, int[] utcNowValues, string expectedDestination, string expectedRoutingKey, int expectedDelayLevel)
         {
             var originalTimeSent = GetDateTimeOffsetFromValues(originalTimeSentValues);

--- a/src/NServiceBus.Transport.RabbitMQ.CommandLine/Commands/Delays/DelaysMigrateCommand.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.CommandLine/Commands/Delays/DelaysMigrateCommand.cs
@@ -12,6 +12,7 @@
         const string poisonMessageQueue = "delays-migrate-poison-messages";
         const string timeSentHeader = "NServiceBus.TimeSent";
         const string dateTimeOffsetWireFormat = "yyyy-MM-dd HH:mm:ss:ffffff Z";
+        const int indexStartOfDestinationQueue = DelayInfrastructure.MaxNumberOfBitsToUse * 2;
 
         public static Command CreateCommand()
         {
@@ -143,7 +144,7 @@
         {
             var originalDeliveryDate = timeSent.AddSeconds(delayInSeconds);
             var newDelayInSeconds = Convert.ToInt32(originalDeliveryDate.Subtract(utcNow).TotalSeconds);
-            var destinationQueue = currentRoutingKey.Substring(currentRoutingKey.LastIndexOf('.') + 1);
+            var destinationQueue = currentRoutingKey[indexStartOfDestinationQueue..];
             var newRoutingKey = DelayInfrastructure.CalculateRoutingKey(newDelayInSeconds, destinationQueue, out int newDelayLevel);
 
             return (destinationQueue, newRoutingKey, newDelayLevel);

--- a/src/NServiceBus.Transport.RabbitMQ/DelayedDelivery/DelayInfrastructure.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/DelayedDelivery/DelayInfrastructure.cs
@@ -12,7 +12,7 @@ namespace NServiceBus.Transport.RabbitMQ
 
     static class DelayInfrastructure
     {
-        const int MaxNumberOfBitsToUse = 28;
+        public const int MaxNumberOfBitsToUse = 28;
 
         public const int MaxLevel = MaxNumberOfBitsToUse - 1;
         public const int MaxDelayInSeconds = (1 << MaxNumberOfBitsToUse) - 1;


### PR DESCRIPTION
Backport of:
-  https://github.com/Particular/NServiceBus.RabbitMQ/pull/1609

Which fixes for the `release-10.1` branch:
- https://github.com/Particular/PlatformBugs/issues/1452