### PR TITLE
Remove usage of BitVector32 in routing key calculation

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ/DelayedDelivery/DelayInfrastructure.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/DelayedDelivery/DelayInfrastructure.cs
@@ -4,7 +4,6 @@ namespace NServiceBus.Transport.RabbitMQ
 {
     using System;
     using System.Collections.Generic;
-    using System.Collections.Specialized;
     using System.Runtime.CompilerServices;
     using System.Threading;
     using System.Threading.Tasks;
@@ -105,20 +104,17 @@ namespace NServiceBus.Transport.RabbitMQ
                     var (delayInSeconds, address, startingDelayLevelPtr) = state;
 
                     var startingDelayLevel = 0;
-                    var mask = BitVector32.CreateMask();
-
-                    var bitVector = new BitVector32(delayInSeconds);
 
                     var index = 0;
                     for (var level = MaxLevel; level >= 0; level--)
                     {
-                        var flag = bitVector[mask << level];
-                        if (startingDelayLevel == 0 && flag)
+                        bool bitSet = ((delayInSeconds >> level) & 1) != 0;
+                        if (startingDelayLevel == 0 && bitSet)
                         {
                             startingDelayLevel = level;
                         }
 
-                        span[index++] = flag ? '1' : '0';
+                        span[index++] = bitSet ? '1' : '0';
                         span[index++] = '.';
                     }
 


### PR DESCRIPTION
The usage of BitVector is not really necessary. By removing it, we get some small but noticeable additional gains.

<img width="1403" alt="image" src="https://github.com/user-attachments/assets/2be46f66-0549-4e4a-9688-c3c14d3f96b3" />
