### PR TITLE
Only create a single publish channel

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ/Connection/ChannelProvider.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Connection/ChannelProvider.cs
@@ -103,7 +103,7 @@ namespace NServiceBus.Transport.RabbitMQ
                     await oldChannel.DisposeAsync().ConfigureAwait(false);
                 }
 
-                var newChannel = new ConfirmsAwareChannel(connection!, routingTopology);
+                var newChannel = new ConfirmsAwareChannel(connection, routingTopology);
                 await newChannel.Initialize(cancellationToken).ConfigureAwait(false);
                 publishChannel = newChannel;
                 return newChannel;

--- a/src/NServiceBus.Transport.RabbitMQ/Connection/ChannelProvider.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Connection/ChannelProvider.cs
@@ -9,16 +9,9 @@ namespace NServiceBus.Transport.RabbitMQ
     using global::RabbitMQ.Client.Events;
     using Logging;
 
-    class ChannelProvider : IAsyncDisposable
+    class ChannelProvider(ConnectionFactory connectionFactory, TimeSpan retryDelay, IRoutingTopology routingTopology)
+        : IAsyncDisposable
     {
-        public ChannelProvider(ConnectionFactory connectionFactory, TimeSpan retryDelay, IRoutingTopology routingTopology)
-        {
-            this.connectionFactory = connectionFactory;
-            this.retryDelay = retryDelay;
-
-            this.routingTopology = routingTopology;
-        }
-
         public async Task Initialize(CancellationToken cancellationToken = default) => connection = await CreateConnectionWithShutdownListener(cancellationToken).ConfigureAwait(false);
 
         async Task<IConnection> CreateConnectionWithShutdownListener(CancellationToken cancellationToken)
@@ -154,9 +147,6 @@ namespace NServiceBus.Transport.RabbitMQ
             disposed = true;
         }
 
-        readonly ConnectionFactory connectionFactory;
-        readonly TimeSpan retryDelay;
-        readonly IRoutingTopology routingTopology;
         readonly CancellationTokenSource stoppingTokenSource = new();
         volatile IConnection? connection;
         ConfirmsAwareChannel? publishChannel;

--- a/src/NServiceBus.Transport.RabbitMQ/Connection/ChannelProvider.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Connection/ChannelProvider.cs
@@ -87,7 +87,7 @@ namespace NServiceBus.Transport.RabbitMQ
             while (true)
             {
                 var existing = Interlocked.CompareExchange(ref publishChannel, null, null);
-                if (existing is not null && !existing.IsClosed)
+                if (existing is { IsOpen: true })
                 {
                     return existing;
                 }
@@ -114,7 +114,7 @@ namespace NServiceBus.Transport.RabbitMQ
 
         public ValueTask ReturnPublishChannel(ConfirmsAwareChannel channel, CancellationToken cancellationToken = default)
         {
-            if (!channel.IsClosed)
+            if (channel.IsOpen)
             {
                 return ValueTask.CompletedTask;
             }


### PR DESCRIPTION
Fixes #1621 

Historically the underlying SDK used was dispatching synchronously the network requests and our code added some additional asynchronous parts using a custom scheduler that waited for the publisher confirms to return. The previous guidance of the RabbitMQ client suggested channels should not be re-used across concurrent operations. That's why the channel provider code was added to make sure during concurrent operations clients are never concurrently accessed. Given the synchronous nature of the SDK calls it was rarely ever possible for more than one or two channels being managed by the channel provider. 

With the new async nature of the SDK that also contains an implementation to manage publisher confirms asynchronously (contributed by us) the SDK calls are now completely asynchronous. During the migration to the new client, this detail was overlooked. This leads to massive concurrent access to the channel provider and the channel provider trying to create N number of channels which leads to slow down of publish operations and channels lingering around until the endpoint is restarted or in the worst case the client operations reaching the maximum number of channels allowed.

This PR changes the channel provider to lazy create a single publish channel (since channels are now thread safe as long as they are not used for publishing and consumptions at the same time). The channel provider still applies a rent and return pattern to make sure a faulty channel is closed when returned and new publish operations acquire a fresh channel when needed. 

I have played around with multiple internal implementations using `AsyncManualResetEvent` or CompareExchange/ Spin but ultimately concluded the semaphore version is best given channels are expensive to create. 

## Benchmark

```csharp
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Configs;
using BenchmarkDotNet.Diagnosers;
using BenchmarkDotNet.Jobs;
using NServiceBus.Routing;
using NServiceBus.Transport;

namespace RabbitMQPublishBenchmark;

[Config(typeof(Config))]
public class MessageSessionPublish
{
    private TransportInfrastructure infrastructure;
    private IMessageDispatcher messageDispatcher;

    class Config : ManualConfig
    {
        public Config()
        {
            var baseJob = Job.ShortRun;

            AddDiagnoser(MemoryDiagnoser.Default);

            AddJob(baseJob.WithNuGet("NServiceBus.RabbitMQ", "11.0.0-alpha.1.4").WithId("SemaphoreSlim"));
            AddJob(baseJob.WithNuGet("NServiceBus.RabbitMQ", "10.1.2").WithId("10.1.2"));
            AddJob(baseJob.WithNuGet("NServiceBus.RabbitMQ", "9.2.1").WithId("9.2.1"));
        }
    }

    [IterationSetup]
    public void Setup() // does not support async setup
    {
        var transport = new RabbitMQTransport(RoutingTopology.Conventional(QueueType.Quorum, useDurableEntities: true), "host=localhost;username=guest;password=guest");
        infrastructure = transport.Initialize(new HostSettings("RabbitMQPublishBenchmark", "Benchmark", new StartupDiagnosticEntries(),
            (s, exception, arg3) => { }, true), [], [ "destination"]).GetAwaiter().GetResult();
        messageDispatcher = infrastructure.Dispatcher;
    }

    [IterationCleanup]
    public void Cleanup() // does not support async cleanup
    {
        infrastructure.Shutdown().GetAwaiter().GetResult();
    }

    [Params(1000, 1500, 2000)]
    public int Concurrency { get; set; }

    [Benchmark]
    public Task Concurrent_Publish()
    {
        return Task.WhenAll(Enumerable.Range(0, Concurrency).Select(_ =>
        {
            var message = new OutgoingMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>(), Array.Empty<byte>());
            var transportOperation = new TransportOperations(new TransportOperation(message, new UnicastAddressTag("destination")));

            return messageDispatcher.Dispatch(transportOperation, new TransportTransaction());
        }));
    }

    [Benchmark]
    public async Task Sequential_Publish()
    {
        for (var i = 0; i < Concurrency; i++)
        {
            var message = new OutgoingMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>(), Array.Empty<byte>());
            var transportOperation = new TransportOperations(new TransportOperation(message, new UnicastAddressTag("destination")));

            await messageDispatcher.Dispatch(transportOperation, new TransportTransaction());
        }
    }
}
```

### Results

![image](https://github.com/user-attachments/assets/5112279c-34a7-4f7b-906b-4de4bc2be519)
