### PR TITLE
The ContentType (and other properties) from BasicProperties is lost/incorrect when messages are retried by ServiceControl because the transport doesn't propagate it to the NServiceBus ContentType header

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ.Tests/MessageConverterTests.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/MessageConverterTests.cs
@@ -33,130 +33,61 @@
 
             public string ProtocolClassName => throw new NotSupportedException();
 
-            public void ClearAppId()
-            {
-                throw new NotSupportedException();
-            }
+            public void ClearAppId() => throw new NotSupportedException();
 
-            public void ClearClusterId()
-            {
-                throw new NotSupportedException();
-            }
+            public void ClearClusterId() => throw new NotSupportedException();
 
-            public void ClearContentEncoding()
-            {
-                throw new NotSupportedException();
-            }
+            public void ClearContentEncoding() => throw new NotSupportedException();
 
-            public void ClearContentType()
-            {
-                throw new NotSupportedException();
-            }
+            public void ClearContentType() => throw new NotSupportedException();
 
-            public void ClearCorrelationId()
-            {
-                throw new NotSupportedException();
-            }
+            public void ClearCorrelationId() => throw new NotSupportedException();
 
-            public void ClearDeliveryMode()
-            {
-                throw new NotSupportedException();
-            }
+            public void ClearDeliveryMode() => throw new NotSupportedException();
 
-            public void ClearExpiration()
-            {
-                throw new NotSupportedException();
-            }
+            public void ClearExpiration() => throw new NotSupportedException();
 
-            public void ClearHeaders()
-            {
-                throw new NotSupportedException();
-            }
+            public void ClearHeaders() => throw new NotSupportedException();
 
-            public void ClearMessageId()
-            {
-                throw new NotSupportedException();
-            }
+            public void ClearMessageId() => throw new NotSupportedException();
 
-            public void ClearPriority()
-            {
-                throw new NotSupportedException();
-            }
+            public void ClearPriority() => throw new NotSupportedException();
 
-            public void ClearReplyTo()
-            {
-                throw new NotSupportedException();
-            }
+            public void ClearReplyTo() => throw new NotSupportedException();
 
-            public void ClearTimestamp()
-            {
-                throw new NotSupportedException();
-            }
+            public void ClearTimestamp() => throw new NotSupportedException();
 
-            public void ClearType()
-            {
-                throw new NotSupportedException();
-            }
+            public void ClearType() => throw new NotSupportedException();
 
-            public void ClearUserId()
-            {
-                throw new NotSupportedException();
-            }
+            public void ClearUserId() => throw new NotSupportedException();
 
-            public bool IsAppIdPresent()
-            {
-                throw new NotSupportedException();
-            }
+            public bool IsAppIdPresent() => throw new NotSupportedException();
 
-            public bool IsClusterIdPresent()
-            {
-                throw new NotSupportedException();
-            }
+            public bool IsClusterIdPresent() => throw new NotSupportedException();
 
-            public bool IsContentEncodingPresent()
-            {
-                throw new NotSupportedException();
-            }
+            public bool IsContentEncodingPresent() => throw new NotSupportedException();
 
-            public bool IsContentTypePresent()
-            {
-                throw new NotSupportedException();
-            }
+            public bool IsContentTypePresent() => ContentType != null;
 
             public bool IsCorrelationIdPresent() => !string.IsNullOrEmpty(CorrelationId);
 
             public bool IsDeliveryModePresent() => DeliveryMode != 0;
 
-            public bool IsExpirationPresent()
-            {
-                throw new NotSupportedException();
-            }
+            public bool IsExpirationPresent() => throw new NotSupportedException();
 
-            public bool IsHeadersPresent()
-            {
-                throw new NotSupportedException();
-            }
+            public bool IsHeadersPresent() => throw new NotSupportedException();
 
             public bool IsMessageIdPresent() => !string.IsNullOrEmpty(MessageId);
 
-            public bool IsPriorityPresent()
-            {
-                throw new NotSupportedException();
-            }
+            public bool IsPriorityPresent() => throw new NotSupportedException();
 
             public bool IsReplyToPresent() => !string.IsNullOrEmpty(ReplyTo);
 
-            public bool IsTimestampPresent()
-            {
-                throw new NotSupportedException();
-            }
+            public bool IsTimestampPresent() => throw new NotSupportedException();
 
             public bool IsTypePresent() => !string.IsNullOrEmpty(Type);
 
-            public bool IsUserIdPresent()
-            {
-                throw new NotSupportedException();
-            }
+            public bool IsUserIdPresent() => throw new NotSupportedException();
         }
 
         MessageConverter converter = new MessageConverter(MessageConverter.DefaultMessageIdStrategy);
@@ -402,6 +333,35 @@
 
             Assert.NotNull(headers);
             Assert.AreEqual("key1=value1,key2=value2", Convert.ToString(headers["Foo"]));
+        }
+
+        [Test]
+        public void Should_handle_content_type()
+        {
+            var basicProperties = new TestingBasicProperties
+            {
+                MessageId = "Blah",
+                ContentType = "content_type"
+            };
+
+            var message = new BasicDeliverEventArgs
+            {
+                BasicProperties = new TestingBasicProperties
+                {
+                    MessageId = "Blah",
+                    ContentType = "content_type"
+                }
+            };
+
+            var headers = converter.RetrieveHeaders(message);
+            var messageId = converter.RetrieveMessageId(message, headers);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(messageId, Is.Not.Null);
+                Assert.That(headers, Is.Not.Null);
+                Assert.That(headers[NServiceBus.Headers.ContentType], Is.EqualTo(basicProperties.ContentType));
+            });
         }
     }
 }

--- a/src/NServiceBus.Transport.RabbitMQ/Receiving/MessageConverter.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Receiving/MessageConverter.cs
@@ -39,11 +39,11 @@
                 messageHeaders.Remove(BasicPropertiesExtensions.ConfirmationIdHeader);
             }
 
-            // Leaving space for ReplyTo, CorrelationId, DeliveryMode, EnclosedMessageTypes conditionally
+            // Leaving space for ReplyTo, CorrelationId, DeliveryMode, EnclosedMessageTypes, ContentType conditionally
             // added below. This is a bit cumbersome and need to be changed when things are conditionally added below
             // but it prevents the header dictionary from growing and relocating which creates quite a bit of
             // memory allocations and eats up CPU cycles.
-            const int extraCapacity = 4;
+            const int extraCapacity = 5;
             var deserializedHeaders = DeserializeHeaders(messageHeaders, extraCapacity);
 
             if (properties.IsReplyToPresent())
@@ -70,6 +70,11 @@
             if (!deserializedHeaders.ContainsKey(Headers.EnclosedMessageTypes) && properties.IsTypePresent())
             {
                 deserializedHeaders[Headers.EnclosedMessageTypes] = properties.Type;
+            }
+
+            if (properties.IsContentTypePresent())
+            {
+                deserializedHeaders[Headers.ContentType] = properties.ContentType;
             }
 
             //These headers need to be removed so that they won't be copied to an outgoing message if this message gets forwarded


### PR DESCRIPTION
Backport of:
-  Backport of https://github.com/Particular/NServiceBus.RabbitMQ/pull/1666

Which fixes for the `release-9.2` branch:
- https://github.com/Particular/NServiceBus.RabbitMQ/issues/1664