### PR TITLE
Handle more queue types in QueueTypeConverter

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ/Administration/ManagementApi/Converters/QueueTypeConverter.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Administration/ManagementApi/Converters/QueueTypeConverter.cs
@@ -18,7 +18,7 @@ class QueueTypeConverter : JsonConverter<QueueType>
             "classic" => QueueType.Classic,
             "stream" => QueueType.Stream,
             "rabbit_mqtt_qos0_queue" => QueueType.MqttQos0,
-            _ => throw new JsonException($"Unknown queue type: {value}")
+            _ => QueueType.Unknown
         };
     }
 
@@ -30,6 +30,7 @@ class QueueTypeConverter : JsonConverter<QueueType>
             QueueType.Classic => "classic",
             QueueType.Stream => "stream",
             QueueType.MqttQos0 => "rabbit_mqtt_qos0_queue",
+            QueueType.Unknown => throw new ArgumentOutOfRangeException(nameof(queueType), "Cannot write unknown queue type"),
             _ => throw new ArgumentOutOfRangeException(nameof(queueType), $"QueueType value out of range: {queueType}")
         };
 

--- a/src/NServiceBus.Transport.RabbitMQ/Administration/ManagementApi/Models/QueueType.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Administration/ManagementApi/Models/QueueType.cs
@@ -4,6 +4,7 @@
 // by the NServiceBus transport, which doesn't include the `Stream` value
 enum QueueType
 {
+    Unknown,
     Classic,
     Quorum,
     Stream,


### PR DESCRIPTION
This PR adds support in `QueueTypeConverter` used by `ManagementClient` for the [MQTT QoS 0 queue type](https://www.rabbitmq.com/docs/mqtt#qos0-queue-type) when getting the details of a queue.

It also ensures that any new queue type introduced in the future will not cause a similar failure.