### PR TITLE
RabbitMQ may not respect the unlimited retry policy created by the transport

### DIFF
--- a/src/NServiceBus.Transport.RabbitMQ.Tests/BrokerVerifierTests.cs
+++ b/src/NServiceBus.Transport.RabbitMQ.Tests/BrokerVerifierTests.cs
@@ -49,8 +49,79 @@ class BrokerVerifierTests
         for (int i = 0; i < attempts; i++)
         {
             var queue = await managementClient.GetQueue(queueName);
+            var deliveryLimit = queue.GetDeliveryLimit();
 
-            if (queue.DeliveryLimit == -1 && queue.AppliedPolicyName == policyName)
+            if (deliveryLimit == Queue.BigValueInsteadOfActuallyUnlimited && queue.AppliedPolicyName == policyName)
+            {
+                // Policy applied successfully
+                return;
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(3));
+        }
+
+        Assert.Fail($"Policy '{policyName}' was not applied to queue '{queueName}'.");
+    }
+
+    [Test]
+    public async Task ValidateDeliveryLimit_Should_Update_Old_Unlimited_Policy_Created_By_Transport()
+    {
+        var managementClient = new ManagementClient(connectionConfiguration);
+        using var brokerVerifier = new BrokerVerifier(managementClient, BrokerRequirementChecks.None, true);
+        await brokerVerifier.Initialize();
+
+        if (brokerVerifier.BrokerVersion < BrokerVerifier.BrokerVersion4)
+        {
+            Assert.Ignore("Test not valid for broker versions before 4.0.0");
+        }
+
+        var queueName = nameof(ValidateDeliveryLimit_Should_Set_Delivery_Limit_Policy);
+        var policyName = $"nsb.{queueName}.delivery-limit";
+
+        var oldUnlimitedPolicy = new Policy
+        {
+            ApplyTo = PolicyTarget.QuorumQueues,
+            Definition = new PolicyDefinition { DeliveryLimit = -1 },
+            Pattern = queueName,
+            Priority = 0
+        };
+
+        await CreateQueue(queueName);
+        await managementClient.CreatePolicy(policyName, oldUnlimitedPolicy);
+
+        // It can take some time for updated policies to be applied, so we need to wait.
+        // If this test is randomly failing, consider increasing the attempts
+        var attempts = 20;
+
+        int deliveryLimit = 0;
+
+        for (int i = 0; i < attempts; i++)
+        {
+            var queue = await managementClient.GetQueue(queueName);
+            deliveryLimit = queue.GetDeliveryLimit();
+
+            if (deliveryLimit == -1 && queue.AppliedPolicyName == policyName)
+            {
+                // Policy applied successfully
+                break;
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(3));
+        }
+
+        if (deliveryLimit != -1)
+        {
+            Assert.Fail($"Old unlimited Policy '{policyName}' was not applied to queue '{queueName}'.");
+        }
+
+        await brokerVerifier.ValidateDeliveryLimit(queueName);
+
+        for (int i = 0; i < attempts; i++)
+        {
+            var queue = await managementClient.GetQueue(queueName);
+            deliveryLimit = queue.GetDeliveryLimit();
+
+            if (deliveryLimit == Queue.BigValueInsteadOfActuallyUnlimited && queue.AppliedPolicyName == policyName)
             {
                 // Policy applied successfully
                 return;
@@ -124,7 +195,7 @@ class BrokerVerifierTests
 
         await managementClient.CreatePolicy(policyName, policy).ConfigureAwait(false);
 
-        // If this test appears flaky, the delay should be increased to give the broker more time to apply the policy before calling ValidateDeliveryLimit
+        // If this test appears flaky, the delay should be increased to give the broker more time to apply the oldUnlimitedPolicy before calling ValidateDeliveryLimit
         await Task.Delay(TimeSpan.FromSeconds(30));
 
         var exception = Assert.ThrowsAsync<InvalidOperationException>(async () => await brokerVerifier.ValidateDeliveryLimit(queueName));

--- a/src/NServiceBus.Transport.RabbitMQ/Administration/ManagementApi/Models/Queue.cs
+++ b/src/NServiceBus.Transport.RabbitMQ/Administration/ManagementApi/Models/Queue.cs
@@ -43,8 +43,8 @@ class Queue
         }
 
         // RabbitMQ 3.x
-        // The broker doesn't tell us what the actual delivery limit is, so we have to figure it out
-        // We have to find the lowest value from the possible places in can be configured
+        // The broker doesn't tell us what the actual delivery limit is, so we have to figure it out.
+        // We have to find the lowest value from the possible places it can be configured.
 
         int? limit = null;
 
@@ -67,6 +67,8 @@ class Queue
             limit = 0;
         }
 
-        return limit ?? -1;
+        return limit ?? BigValueInsteadOfActuallyUnlimited;
     }
+
+    public const int BigValueInsteadOfActuallyUnlimited = 100_000;
 }


### PR DESCRIPTION
Backport of #1689 which fixes #1688 for the `release-10.1` branch